### PR TITLE
Don't require pry

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,5 @@
 module ApplicationHelper
 
-  require 'pry'
-
   def render_location(value)
     Rails.configuration.locations[value]
   end


### PR DESCRIPTION
Requiring pry in production environment when it is limited to dev and test does bad things, man. BAD THINGS!

No Stacktrace, no pry.
