### PR TITLE
Remove import of nonexistent scss file.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,12 +10,11 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
  *= require_self
+ *= require_tree .
  */
 @import "partials/_vars.scss";
 @import "partials/_colors.scss";
 @import "partials/_facets.scss";
 @import "partials/_header.scss";
-@import "partials/_main.scss";
 @import "partials/_pagination.scss";


### PR DESCRIPTION
Make application stylesheet scss.

@cdoyle-temple Was working fine in development, but when we switched to `RAILS_ENV=production` for deployments, the `@import` of a file that was not preent caused issues. 