### PR TITLE
Add autocommit, and have traject not commit 

### DIFF
--- a/app/models/marc_indexer.rb
+++ b/app/models/marc_indexer.rb
@@ -15,6 +15,7 @@ class MarcIndexer < Blacklight::Marc::Indexer
       # set this to be non-negative if threshold should be enforced
       provide 'solr_writer.max_skipped', -1
       #provide 'solr.update_url', 'http://localhost:8983/solr/blacklight-core/update'
+      provide "solr_writer.commit_on_close", "false"
     end
 
     #to_field 'id', trim(extract_marc("001"), :first => true)

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -54,6 +54,13 @@
   <admin>
     <defaultQuery>*:*</defaultQuery>
   </admin>
+ 
+  <autoCommit>
+    <maxDocs>50000</maxDocs>
+    <maxTime>100000</maxTime>
+    <openSearcher>false</openSearcher>
+  </autoCommit>
+
 
   <!-- SearchHandler
 


### PR DESCRIPTION
When running multiple traject indexers, the commit requests overlap, causing pain. Let solr autocommit handle that.