### PR TITLE
Let solr handle when to commit.

### DIFF
--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -42,7 +42,7 @@ settings do
   # extend commit timeout
   provide 'solr_writer.commit_timeout', 300
   provide 'solr.url', solr_url
-  provide "solr_writer.commit_on_close", "true"
+  provide "solr_writer.commit_on_close", "false"
 end
 
 to_field "id", extract_marc("001", :first => true)

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -54,12 +54,16 @@
   <admin>
     <defaultQuery>*:*</defaultQuery>
   </admin>
- 
-  <autoCommit>
-    <maxDocs>50000</maxDocs>
-    <maxTime>100000</maxTime>
-    <openSearcher>false</openSearcher>
-  </autoCommit>
+
+  <updateHandler class="solr.DirectUpdateHandler2">
+    <autoCommit>
+      <maxDocs>1000000</maxDocs>
+      <maxTime>900000</maxTime>
+      <openSearcher>true</openSearcher>
+    </autoCommit>
+  </updateHandler>
+
+
 
 
   <!-- SearchHandler


### PR DESCRIPTION
Solr will auto commit after 1M documents, or 15 minutes, since the last commit.

We might be able to bump these even further depending on how much memory
we throw at the server running solr.