### PR TITLE
Update ruby-marc version for bugfix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,7 +199,7 @@ GEM
     lumberjack (1.0.12)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
-    marc (1.0.0)
+    marc (1.0.2)
       scrub_rb (>= 1.0.1, < 2)
       unf
     marc-fastxmlwriter (1.0.0)


### PR DESCRIPTION
Fixes an issue where traject would bomb out on certain records, leaving any subsequent records 
in the same file unindexed.

Fixes #BL-33