### PR TITLE
Remove duplicate fields from traject indexer and catalog controller

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -137,12 +137,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_region_facet', label: 'Region'
     config.add_facet_field 'genre_facet', label: 'Genre'
     config.add_facet_field 'language_facet', label: 'Language'     # limit: true
-
-    # config.add_facet_field 'location_facet', label: 'Location', helper_method: :render_location
     config.add_facet_field 'format', label: 'Resource Type'
-    # config.add_facet_field 'lc_1letter_facet', label: 'Call Number'
-    # config.add_facet_field 'subject_geo_facet', label: 'Region'
-
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -155,15 +150,6 @@ class CatalogController < ApplicationController
     config.add_index_field 'imprint_display', label: 'Published'
     config.add_index_field 'creator_display', label: 'Author/creator'
     config.add_index_field 'format', label: 'Resource Type'
-
-    # config.add_index_field 'title_display', label: 'Title'
-    # config.add_index_field 'title_vern_display', label: 'Title Vern'
-    # config.add_index_field 'author_display', label: 'Author'
-    # config.add_index_field 'author_vern_display', label: 'Author Vern'
-    # config.add_index_field 'published_display', label: 'Published'
-    # config.add_index_field 'published_vern_display', label: 'Published Vern'
-    # config.add_index_field 'location_display', label: 'Location', helper_method: :render_location
-    #new
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -238,22 +224,6 @@ class CatalogController < ApplicationController
     config.add_show_field 'language_display', label: 'Language', :helper_method => :list
     config.add_show_field 'library', label: 'Library', helper_method: :render_location_show
 
-    # config.add_show_field 'title_display', label: 'Title'
-    # config.add_show_field 'title_vern_display', label: 'Title'
-    # config.add_show_field 'subtitle_display', label: 'Subtitle'
-    # config.add_show_field 'subtitle_vern_display', label: 'Subtitle'
-    # config.add_show_field 'author_display', label: 'Author'
-    # config.add_show_field 'author_vern_display', label: 'Author'
-    # config.add_show_field 'url_fulltext_display', label: 'URL'
-    # config.add_show_field 'url_suppl_display', label: 'More Information'
-    # config.add_show_field 'published_display', label: 'Published'
-    # config.add_show_field 'published_vern_display', label: 'Published'
-    # config.add_show_field 'lc_callnum_display', label: 'Call number'
-    # config.add_show_field 'isbn_t', label: 'ISBN'
-    # config.add_show_field 'control_number_display', label: 'Control Number'
-    # config.add_show_field 'location_display', label: 'Location', helper_method: :render_location
-    #config.add_show_field 'title_statement_display', label: 'Title Statement'
-
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
     #
@@ -316,7 +286,7 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
-    
+
     config.add_sort_field 'score desc, pub_date_sort desc, title_sort asc', label: 'relevance'
     config.add_sort_field 'pub_date_sort desc, title_sort asc', label: 'year'
     config.add_sort_field 'author_sort asc, title_sort asc', label: 'author'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -25,41 +25,41 @@ class CatalogController < ApplicationController
 
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
-  fl: %w[
-    id
-    score
-    author_display
-    author_vern_display
-    creator_display
-    format
-    imprint_display
-    isbn_t
-    language_facet
-    lc_callnum_display
-    material_type_display
-    published_display
-    published_vern_display
-    pub_date
-    title_series_vern_display
-    title_display
-    title_vern_display
-    subject_topic_facet
-    subject_geo_facet
-    subject_era_facet
-    subtitle_display
-    subtitle_vern_display
-    url_fulltext_display
-    url_suppl_display
-    title_statement_display
-    title_uniform_display
-    imprint
-    summary
-    contents
-    issn
-  ].join(" "),
-  wt: "json",
-  rows: 10,
-}
+      fl: %w[
+        id
+        score
+        author_display
+        author_vern_display
+        creator_display
+        format
+        imprint_display
+        isbn_t
+        language_facet
+        lc_callnum_display
+        material_type_display
+        published_display
+        published_vern_display
+        pub_date
+        title_series_vern_display
+        title_display
+        title_vern_display
+        subject_topic_facet
+        subject_geo_facet
+        subject_era_facet
+        subtitle_display
+        subtitle_vern_display
+        url_fulltext_display
+        url_suppl_display
+        title_statement_display
+        title_uniform_display
+        imprint
+        summary
+        contents
+        issn
+      ].join(" "),
+      wt: "json",
+      rows: 10,
+    }
 
     # solr path which will be added to solr base url before the other solr params.
     #config.solr_path = 'select'
@@ -110,17 +110,9 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    # config.add_facet_field 'location_facet', label: 'Location', helper_method: :render_location
-    config.add_facet_field 'format', label: 'Resource Type'
-    # config.add_facet_field 'pub_date', label: 'Publication Year', single: true
-    # config.add_facet_field 'subject_topic_facet', label: 'Topic', limit: 20, index_range: 'A'..'Z'
-    # config.add_facet_field 'language_facet', label: 'Language', limit: true
-    # config.add_facet_field 'lc_1letter_facet', label: 'Call Number'
-    # config.add_facet_field 'subject_geo_facet', label: 'Region'
-    # config.add_facet_field 'subject_era_facet', label: 'Era'
-    #
+    # Facet Fields
+
     # config.add_facet_field 'example_pivot_field', label: 'Pivot Field', :pivot => ['format', 'language_facet']
-    #
     # config.add_facet_field 'example_query_facet_field', label: 'Publish Date', :query => {
     #    :years_5 => { label: 'within 5 Years', fq: "pub_date:[#{Time.zone.now.year - 5 } TO *]" },
     #    :years_10 => { label: 'within 10 Years', fq: "pub_date:[#{Time.zone.now.year - 10 } TO *]" },
@@ -140,11 +132,17 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'subject', label: 'Subject', limit: true, show: false
     config.add_facet_field 'creator', label: 'Author/creator', limit: true, show: false
-    config.add_facet_field 'subject_topic_facet', label: 'Topic'
+    config.add_facet_field 'subject_topic_facet', label: 'Topic'     # limit: 20, index_range: 'A'..'Z'
     config.add_facet_field 'subject_era_facet', label: 'Era'
     config.add_facet_field 'subject_region_facet', label: 'Region'
     config.add_facet_field 'genre_facet', label: 'Genre'
-    config.add_facet_field 'language_facet', label: 'Language'
+    config.add_facet_field 'language_facet', label: 'Language'     # limit: true
+
+    # config.add_facet_field 'location_facet', label: 'Location', helper_method: :render_location
+    config.add_facet_field 'format', label: 'Resource Type'
+    # config.add_facet_field 'lc_1letter_facet', label: 'Call Number'
+    # config.add_facet_field 'subject_geo_facet', label: 'Region'
+
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
@@ -153,48 +151,23 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    # config.add_index_field 'title_display', label: 'Title'
-    # config.add_index_field 'title_vern_display', label: 'Title Vern'
-    # config.add_index_field 'title_uniform_vern_display', label: 'Title Uniform Vern'
-    # config.add_index_field 'title_series_vern_display', label: 'Title Series Vern'
-    # config.add_index_field 'title_addl_vern_display', label: 'Additional Title Vern'
-    # config.add_index_field 'author_display', label: 'Author'
-    # config.add_index_field 'author_vern_display', label: 'Author Vern'
-    # config.add_index_field 'format', label: 'Format'
-    # config.add_index_field 'language_facet', label: 'Language'
-    # config.add_index_field 'published_display', label: 'Published'
-    # config.add_index_field 'published_vern_display', label: 'Published Vern'
-    # config.add_index_field 'lc_callnum_display', label: 'Call number'
-    # config.add_index_field 'location_display', label: 'Location', helper_method: :render_location
-    #new
-    #config.add_index_field 'title_statement_display', label: 'Title Statement'
+
     config.add_index_field 'imprint_display', label: 'Published'
     config.add_index_field 'creator_display', label: 'Author/creator'
     config.add_index_field 'format', label: 'Resource Type'
+
+    # config.add_index_field 'title_display', label: 'Title'
+    # config.add_index_field 'title_vern_display', label: 'Title Vern'
+    # config.add_index_field 'author_display', label: 'Author'
+    # config.add_index_field 'author_vern_display', label: 'Author Vern'
+    # config.add_index_field 'published_display', label: 'Published'
+    # config.add_index_field 'published_vern_display', label: 'Published Vern'
+    # config.add_index_field 'location_display', label: 'Location', helper_method: :render_location
+    #new
+
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    # config.add_show_field 'title_display', label: 'Title'
-    # config.add_show_field 'title_vern_display', label: 'Title'
-    # config.add_show_field 'subtitle_display', label: 'Subtitle'
-    # config.add_show_field 'subtitle_vern_display', label: 'Subtitle'
-    # config.add_show_field 'author_display', label: 'Author'
-    # config.add_show_field 'author_vern_display', label: 'Author'
-    # config.add_show_field 'format', label: 'Format'
-    # config.add_show_field 'url_fulltext_display', label: 'URL'
-    # config.add_show_field 'url_suppl_display', label: 'More Information'
-    # config.add_show_field 'language_facet', label: 'Language Facet'
-    # config.add_show_field 'language', label: 'Language'
-    # config.add_show_field 'published_display', label: 'Published'
-    # config.add_show_field 'published_vern_display', label: 'Published'
-    # config.add_show_field 'lc_callnum_display', label: 'Call number'
-    # config.add_show_field 'isbn_t', label: 'ISBN'
-    # config.add_show_field 'control_number_display', label: 'Control Number'
-    # config.add_show_field 'location_display', label: 'Location', helper_method: :render_location
 
-    #new
-    #config.add_show_field 'title_statement_display', label: 'Title Statement'
-    #config.add_show_field 'title', label: 'Title'
-    #config.add_show_field 'subtitle', label: 'Subtitle'
     config.add_show_field 'title_statement_vern_display', label: 'Title Statement'
     config.add_show_field 'title_uniform_display', label: 'Uniform title'
     config.add_show_field 'title_uniform_vern_display', label: 'Uniform title'
@@ -265,6 +238,22 @@ class CatalogController < ApplicationController
     config.add_show_field 'language_display', label: 'Language', :helper_method => :list
     config.add_show_field 'library', label: 'Library', helper_method: :render_location_show
 
+    # config.add_show_field 'title_display', label: 'Title'
+    # config.add_show_field 'title_vern_display', label: 'Title'
+    # config.add_show_field 'subtitle_display', label: 'Subtitle'
+    # config.add_show_field 'subtitle_vern_display', label: 'Subtitle'
+    # config.add_show_field 'author_display', label: 'Author'
+    # config.add_show_field 'author_vern_display', label: 'Author'
+    # config.add_show_field 'url_fulltext_display', label: 'URL'
+    # config.add_show_field 'url_suppl_display', label: 'More Information'
+    # config.add_show_field 'published_display', label: 'Published'
+    # config.add_show_field 'published_vern_display', label: 'Published'
+    # config.add_show_field 'lc_callnum_display', label: 'Call number'
+    # config.add_show_field 'isbn_t', label: 'ISBN'
+    # config.add_show_field 'control_number_display', label: 'Control Number'
+    # config.add_show_field 'location_display', label: 'Location', helper_method: :render_location
+    #config.add_show_field 'title_statement_display', label: 'Title Statement'
+
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
     #
@@ -284,7 +273,6 @@ class CatalogController < ApplicationController
     # since we aren't specifying it otherwise.
 
     config.add_search_field 'all_fields', label: 'All Fields'
-
 
     # Now we see how to over-ride Solr request handler defaults, in this
     # case for a BL "search field", which is really a dismax aggregate
@@ -328,6 +316,7 @@ class CatalogController < ApplicationController
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
+    
     config.add_sort_field 'score desc, pub_date_sort desc, title_sort asc', label: 'relevance'
     config.add_sort_field 'pub_date_sort desc, title_sort asc', label: 'year'
     config.add_sort_field 'author_sort asc, title_sort asc', label: 'author'

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -133,9 +133,6 @@ to_field 'subject_t', extract_marc(%W(
   653a:654abcde:655abc
 ).join(':'))
 to_field 'subject_addl_t', extract_marc("600vwxyz:610vwxyz:611vwxyz:630vwxyz:650vwxyz:651vwxyz:654vwxyz:655vwxyz")
-#to_field 'subject_topic_facet', extract_marc("600abcdq:610ab:611ab:630aa:650aa:653aa:654ab:655ab", :trim_punctuation => true)
-#to_field 'subject_era_facet',  extract_marc("650y:651y:654y:655y", :trim_punctuation => true)
-#to_field 'subject_geo_facet',  extract_marc("651a:650z",:trim_punctuation => true )
 
 # Publication fields
 #to_field 'published_display', extract_marc('260a', :trim_punctuation => true, :alternate_script=>false)
@@ -202,7 +199,6 @@ to_field 'url_suppl_display' do |rec, acc|
   end
 end
 
-
     to_field 'location_facet' do |rec, acc|
       rec.fields('945').each do |field|
         #Strip the values, as many come in with space padding
@@ -217,8 +213,6 @@ end
       end
       acc.replace [acc.join(",")]
     end
-
-
 
     #new solr fields for TUL search
 
@@ -235,11 +229,9 @@ end
     to_field "creator", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", :trim_punctuation => true)
     to_field 'creator_display', extract_marc('100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt', :trim_punctuation => true, :alternate_script=>false)
     to_field 'creator_vern_display', extract_marc('100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt', :trim_punctuation => true, :alternate_script=>:only)
-    #creator_facet?
 
     #publication fields
-    # For the imprint, make sure to take RDA-style 264, second
-    # indicator = 1
+    # For the imprint, make sure to take RDA-style 264, second indicator = 1
     to_field 'imprint_display', extract_marc('260abcefg3:264|*0|abc3:264|*1|abc3:264|*2|abc3:264|*3|abc3', :alternate_script=>false)
     to_field 'imprint_vern_display', extract_marc('260abcefg3:264|*1|abc3', :alternate_script=>:only)
     to_field 'edition_display', extract_marc('250a:254a', :trim_punctuation => true, :alternate_script=>false)
@@ -282,7 +274,6 @@ end
     # to_field 'date_series', extract_marc('362a')
     to_field 'volume_series_display', extract_marc('830v:490v:440v')
 
-
     #note fields
 
     to_field 'note_display', extract_marc('500a:508a:511a:515a:518a:521ab:530abcd:533abcdefmn:534pabcefklmnt:538aiu:546ab:550a:586a:588a')
@@ -306,8 +297,8 @@ end
 
     #subject fields
     #Note need to improve the subjects
-    to_field 'subject', extract_marc('600abcdefghklmnopqrstuxyz:610abcdefghklmnoprstuvxy:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz', :separator => " — ", :trim_punctuation => true)
 
+    to_field 'subject', extract_marc('600abcdefghklmnopqrstuxyz:610abcdefghklmnoprstuvxy:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz', :separator => " — ", :trim_punctuation => true)
     to_field 'subject_display', extract_marc('600abcdefghklmnopqrstuxyz:610abcdefghklmnoprstuvxy:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz', :separator => " — ", :trim_punctuation => true)
     to_field 'subject_topic_facet', extract_marc('600abcdq:610ab:611a:630a:650a:653a:654ab:655ab')
     to_field 'subject_era_facet', extract_marc('648a:650y:651y:654y:655y:690y', :trim_punctuation => true)
@@ -341,6 +332,7 @@ end
 
 
     #Preceding Entry fields
+
     to_field 'continues_display', extract_marc('780|00|iabdghkmnopqrstuxyz3:780|02|iabdghkmnopqrstuxyz3', trim_punctuation: true)
     to_field 'continues_in_part_display', extract_marc('780|01|iabdghkmnopqrstuxyz3:780|03|iabdghkmnopqrstuxyz3', trim_punctuation: true)
     to_field 'formed_from_display', extract_marc('780|04|iabdghkmnopqrstuxyz3', trim_punctuation: true)
@@ -349,6 +341,7 @@ end
     to_field 'separated_from_display', extract_marc('780|07|iabdghkmnopqrstuxyz3', trim_punctuation: true)
 
     #Succeeding Entry fields
+
     to_field 'continued_by_display', extract_marc('785|00|iabdghkmnopqrstuxyz3:785|02|iabdghkmnopqrstuxyz3', trim_punctuation: true)
     to_field 'continued_in_part_by_display', extract_marc('785|01|iabdghkmnopqrstuxyz3:785|03|iabdghkmnopqrstuxyz3', trim_punctuation: true)
     to_field 'absorbed_by_display', extract_marc('785|04|iabdghkmnopqrstuxyz3', trim_punctuation: true)

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -66,10 +66,8 @@ to_field "isbn_t",  extract_marc('020a', :separator=>nil) do |rec, acc|
      acc.uniq!
 end
 
-#to_field 'material_type_display', extract_marc('300a', :trim_punctuation => true)
-
 # Title fields
-#    primary title
+# primary title
 
 to_field 'title_t', extract_marc('245a')
 to_field 'title_display', extract_marc('245a', :trim_punctuation => true, :alternate_script=>false) do |r, acc|
@@ -78,7 +76,7 @@ end
 
 to_field 'title_vern_display', extract_marc('245a', :trim_punctuation => true, :alternate_script=>:only)
 
-#    subtitle
+# subtitle
 
 to_field 'subtitle_t', extract_marc('245b')
 to_field 'subtitle_display', extract_marc('245b', :trim_punctuation => true, :alternate_script=>false)do |r, acc|
@@ -86,7 +84,7 @@ to_field 'subtitle_display', extract_marc('245b', :trim_punctuation => true, :al
 end
 to_field 'subtitle_vern_display', extract_marc('245b', :trim_punctuation => true, :alternate_script=>:only)
 
-#    additional title fields
+# additional title fields
 to_field 'title_addl_t',
   extract_marc(%W{
     245abnps
@@ -133,10 +131,6 @@ to_field 'subject_t', extract_marc(%W(
   653a:654abcde:655abc
 ).join(':'))
 to_field 'subject_addl_t', extract_marc("600vwxyz:610vwxyz:611vwxyz:630vwxyz:650vwxyz:651vwxyz:654vwxyz:655vwxyz")
-
-# Publication fields
-#to_field 'published_display', extract_marc('260a', :trim_punctuation => true, :alternate_script=>false)
-#to_field 'published_vern_display', extract_marc('260a', :trim_punctuation => true, :alternate_script=>:only)
 
 #does marc_publication_date guarantee single value?
 to_field 'pub_date_sort', marc_publication_date
@@ -214,8 +208,6 @@ end
       acc.replace [acc.join(",")]
     end
 
-    #new solr fields for TUL search
-
     #Title fields
 
     to_field 'title_statement_display', extract_marc('245abcfgknps', :alternate_script=>false)
@@ -253,8 +245,6 @@ end
         acc << four_digit_year(field['c'])  if field.indicator2 == '4'
       end
     end
-
-    # to_field 'carto_data_display', extract_marc('', :trim_punctuation => true)
 
     #physical characteristics fields -3xx
 
@@ -296,7 +286,7 @@ end
     to_field 'note_local_display', extract_marc('590a')
 
     #subject fields
-    #Note need to improve the subjects
+    #[TODO] need to improve the subjects
 
     to_field 'subject', extract_marc('600abcdefghklmnopqrstuxyz:610abcdefghklmnoprstuvxy:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz', :separator => " — ", :trim_punctuation => true)
     to_field 'subject_display', extract_marc('600abcdefghklmnopqrstuxyz:610abcdefghklmnoprstuvxy:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz', :separator => " — ", :trim_punctuation => true)
@@ -329,7 +319,6 @@ end
     to_field 'lccn_display', extract_marc('010ab')
     to_field 'gpo_display', extract_marc('074a')
     to_field 'alma_mms_display', extract_marc('001')
-
 
     #Preceding Entry fields
 


### PR DESCRIPTION
I took out things that were duplicate entries.  I left commented fields that I wasn't sure whether we planned on using at some point.  