### PR TITLE
BL-68 Add heading and padding to iframe on show page

### DIFF
--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -29,5 +29,18 @@ ul {
 
   .show_page_records dd {
     margin-bottom: 20px;
+  }
 }
+
+.availability_iframe {
+  margin: 30px;
+}
+
+.panel-heading {
+  margin: 0;
+}
+
+.bl_alma_iframe {
+  border: 0;
+  width: 99.9%;
 }

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -38,4 +38,8 @@
     <% end -%>
   </dl>
 </div>
-<iframe src="<%= alma_app_fulfillment_url(document) %>" style="width: 100%"></iframe>
+
+<div class="availability_iframe panel panel-default">
+  <h4 class="panel-heading">Availability</h4>
+  <iframe class="bl_alma_iframe" src="<%= alma_app_fulfillment_url(document) %>"></iframe>
+</div>


### PR DESCRIPTION
This addresses the heading and padding.  I couldn't figure out how to override the css for the iframe from blacklight_alma, it seems like the text needs to be indented a little to the left at some point.