### PR TITLE
Rethink solr schema. Move qf into conroller

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -64,6 +64,29 @@ class CatalogController < ApplicationController
       ].join(" "),
       wt: "json",
       rows: 10,
+      qf: %w[
+        title_unstem_search^100000
+        subtitle_unstem_search^50000
+        title_t^25000
+        subtitle_t^10000
+        title_addl_unstem_search^5000
+        title_addl_t^2500
+        title_added_entry_unstem_search^1500
+        title_added_entry_t^1250
+        subject_topic_unstem_search^1000
+        subject_unstem_search^750
+        subject_topic_facet^625
+        subject_t^500
+        author_unstem_search^250
+        author_addl_unstem_search^250
+        author_t^100
+        author_addl_t^50
+        subject_addl_unstem_search^250
+        subject_addl_t^50
+        title_series_unstem_search^25
+        title_series_t^10
+        text
+      ].join(" ")
     }
 
     # solr path which will be added to solr base url before the other solr params.
@@ -125,7 +148,7 @@ class CatalogController < ApplicationController
     # }
 
     config.add_facet_field 'availability_facet', label: 'Availability'
-    config.add_facet_field 'library', label: 'Library'
+    config.add_facet_field 'library_facet', label: 'Library'
     config.add_facet_field 'format', label: 'Resource Type'
     config.add_facet_field 'pub_date', label: 'Date',
                            range: {
@@ -138,7 +161,7 @@ class CatalogController < ApplicationController
                            }
 
     config.add_facet_field 'creator_facet', label: 'Author/creator', limit: true, show: true
-    config.add_facet_field 'subject', label: 'Subject', limit: true, show: false
+    config.add_facet_field 'subject_facet', label: 'Subject', limit: true, show: false
     config.add_facet_field 'subject_topic_facet', label: 'Topic'     # limit: 20, index_range: 'A'..'Z'
     config.add_facet_field 'subject_era_facet', label: 'Era'
     config.add_facet_field 'subject_region_facet', label: 'Region'

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -46,7 +46,7 @@ settings do
 end
 
 to_field "id", extract_marc("001", :first => true)
-to_field 'marc_display', get_xml
+to_field 'marc_display_raw', get_xml
 to_field "text", extract_all_marc_values do |r, acc|
   acc.replace [acc.join(' ')] # turn it into a single string
 end
@@ -70,13 +70,6 @@ to_field "format", marc_formats do |rec, acc|
   acc.map! { |x| x == "Conference" ? "Conference Proceedings" : x }.flatten! # replace Conference with Conference Proceedings
 end
 
-to_field "isbn_t",  extract_marc('020a', :separator=>nil) do |rec, acc|
-     orig = acc.dup
-     acc.map!{|x| StdNum::ISBN.allNormalizedValues(x)}
-     acc << orig
-     acc.flatten!
-     acc.uniq!
-end
 
 # Title fields
 # primary title
@@ -329,7 +322,7 @@ end
     #subject fields
     #[TODO] need to improve the subjects
 
-    to_field 'subject', extract_marc('600abcdefghklmnopqrstuxyz:610abcdefghklmnoprstuvxy:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz', :separator => " — ", :trim_punctuation => true)
+    to_field 'subject_facet', extract_marc('600abcdefghklmnopqrstuxyz:610abcdefghklmnoprstuvxy:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz', :separator => " — ", :trim_punctuation => true)
     to_field 'subject_display', extract_marc('600abcdefghklmnopqrstuvxyz:610abcdefghklmnoprstuvxy:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz', :separator => " — ", :trim_punctuation => true)
     to_field 'subject_topic_facet', extract_marc('600abcdq:610ab:611a:630a:650a:653a:654ab:655ab')
     to_field 'subject_era_facet', extract_marc('648a:650y:651y:654y:655y:690y', :trim_punctuation => true)
@@ -341,17 +334,37 @@ end
     to_field 'call_number_display', extract_marc('HLDhi')
     to_field 'call_number_alt_display', extract_marc('ITMjk')
 
-    to_field 'library', extract_marc('HLDb', :translation_map=>'locations_map')
+    to_field 'library_facet', extract_marc('HLDb', :translation_map=>'locations_map')
 
     #Identifier fields
 
-    #to_field 'isbn_display', extract_marc('020aq')
-    to_field 'isbn_display', extract_marc('020a')
-    to_field 'issn_display', extract_marc('022a')
+    to_field "isbn_display",  extract_marc('020a', :separator=>nil) do |rec, acc|
+         orig = acc.dup
+         acc.map!{|x| StdNum::ISBN.allNormalizedValues(x)}
+         acc << orig
+         acc.flatten!
+         acc.uniq!
+    end
+
+    to_field 'issn_display', extract_marc('022a', :separator=>nil) do |rec, acc|
+         orig = acc.dup
+         acc.map!{|x| StdNum::ISSN.normalize(x)}
+         acc << orig
+         acc.flatten!
+         acc.uniq!
+    end
+
+    to_field 'lccn_display', extract_marc('010ab', :separator=>nil) do |rec, acc|
+         orig = acc.dup
+         acc.map!{|x| StdNum::LCCN.normalize(x)}
+         acc << orig
+         acc.flatten!
+         acc.uniq!
+    end
+
     to_field 'pub_no_display', extract_marc('028ab')
     to_field 'sudoc_display', extract_marc('086|0*|a')
     to_field 'diamond_id_display', extract_marc('907a')
-    to_field 'lccn_display', extract_marc('010ab')
     to_field 'gpo_display', extract_marc('074a')
     to_field 'alma_mms_display', extract_marc('001')
 

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -16,10 +16,10 @@
  limitations under the License.
 -->
 
-<!--  
+<!--
  This is the Solr schema file. This file should be named "schema.xml" and
  should be in the conf directory under the solr home
- (i.e. ./solr/conf/schema.xml by default) 
+ (i.e. ./solr/conf/schema.xml by default)
  or located where the classloader for the Solr webapp can find it.
 
  This example schema is the recommended starting point for users.
@@ -51,7 +51,7 @@
        version="1.4" is Solr's version number for the schema syntax and semantics.  It should
        not normally be changed by applications.
        1.0: multiValued attribute did not exist, all fields are multiValued by nature
-       1.1: multiValued attribute introduced, false by default 
+       1.1: multiValued attribute introduced, false by default
        1.2: omitTermFreqAndPositions attribute introduced, true by default except for text fields.
        1.3: removed optional field compress feature
        1.4: default auto-phrase (QueryParser feature) to off
@@ -88,7 +88,7 @@
        - If sortMissingLast="false" and sortMissingFirst="false" (the default),
          then default lucene sorting will be used which places docs without the
          field first in an ascending sort and last in a descending sort.
-    -->    
+    -->
 
     <!--
       Default numeric field types. For faster range queries, consider the tint/tfloat/tlong/tdouble types.
@@ -115,7 +115,7 @@
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
-         http://www.w3.org/TR/xmlschema-2/#dateTime    
+         http://www.w3.org/TR/xmlschema-2/#dateTime
          The trailing "Z" designates UTC time and is mandatory.
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
          All other components are mandatory.
@@ -130,7 +130,7 @@
                NOW/DAY+6MONTHS+3DAYS
                   ... 6 months and 3 days in the future from the start of
                       the current day
-                      
+
          Consult the DateField javadocs for more information.
 
          Note: For faster range queries, consider the tdate type
@@ -142,11 +142,11 @@
 
     <!-- The "RandomSortField" is not used to store or search any
          data.  You can declare fields of this type it in your schema
-         to generate pseudo-random orderings of your docs for sorting 
-         purposes.  The ordering is generated based on the field name 
+         to generate pseudo-random orderings of your docs for sorting
+         purposes.  The ordering is generated based on the field name
          and the version of the index, As long as the index version
          remains unchanged, and the same field name is reused,
-         the ordering of the docs will be consistent.  
+         the ordering of the docs will be consistent.
          If you want different psuedo-random orderings of documents,
          for the same version of the index, use a dynamicField and
          change the name
@@ -351,13 +351,13 @@
         <filter class="solr.TrimFilterFactory" />
         <!-- The PatternReplaceFilter gives you the flexibility to use
              Java Regular expression to replace any sequence of characters
-             matching a pattern with an arbitrary replacement string, 
+             matching a pattern with an arbitrary replacement string,
              which may include back references to portions of the original
              string matched by the pattern.
-             
+
              See the Java Regular Expression documentation for more
              information on pattern and replacement string syntax.
-             
+
              http://java.sun.com/j2se/1.5.0/docs/api/java/util/regex/package-summary.html
           -->
         <filter class="solr.PatternReplaceFilterFactory"
@@ -365,7 +365,7 @@
         />
       </analyzer>
     </fieldType>
-    
+
     <fieldtype name="phonetic" stored="false" indexed="true" class="solr.TextField" >
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -379,7 +379,7 @@
         <!--
         The DelimitedPayloadTokenFilter can put payloads on tokens... for example,
         a token of "foo|1.4"  would be indexed as "foo" with a payload of 1.4f
-        Attributes of the DelimitedPayloadTokenFilterFactory : 
+        Attributes of the DelimitedPayloadTokenFilterFactory :
          "delimiter" - a one character delimiter. Default is | (pipe)
 	 "encoder" - how to encode the following value into a playload
 	    float -> org.apache.lucene.analysis.payloads.FloatEncoder,
@@ -406,12 +406,12 @@
     </fieldType>
 
     <!-- since fields of this type are by default not stored or indexed,
-         any data added to them will be ignored outright.  --> 
+         any data added to them will be ignored outright.  -->
     <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
 
     <!-- This point type indexes the coordinates as separate fields (subFields)
       If subFieldType is defined, it references a type, and a dynamic field
-      definition is created matching *___<typename>.  Alternately, if 
+      definition is created matching *___<typename>.  Alternately, if
       subFieldSuffix is defined, that is used to create the subFields.
       Example: if subFieldType="double", then the coordinates would be
         indexed in fields myloc_0___double,myloc_1___double.
@@ -436,7 +436,7 @@
  <fields>
    <!-- Valid attributes for fields:
      name: mandatory - the name for the field
-     type: mandatory - the name of a previously defined type from the 
+     type: mandatory - the name of a previously defined type from the
        <types> section
      indexed: true if this field should be indexed (searchable or sortable)
      stored: true if this field should be retrievable
@@ -449,9 +449,9 @@
        given field.
        When using MoreLikeThis, fields used for similarity should be
        stored for best performance.
-     termPositions: Store position information with the term vector.  
+     termPositions: Store position information with the term vector.
        This will increase storage costs.
-     termOffsets: Store offset information with the term vector. This 
+     termOffsets: Store offset information with the term vector. This
        will increase storage costs.
      default: a value that should be used if no value is specified
        when adding a document.
@@ -463,18 +463,11 @@
    <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
    <!-- default, catch all search field -->
    <field name="text" type="text" indexed="true" stored="false" multiValued="true"/>
-   
    <!-- these display fields are NOT multi-valued -->
-   <field name="marc_display" type="string" indexed="false" stored="true" multiValued="false"/>
-   <field name="title_display" type="string" indexed="false" stored="true" multiValued="false"/>
-   <field name="title_vern_display" type="string" indexed="false" stored="true" multiValued="false"/>
-   <field name="subtitle_display" type="string" indexed="false" stored="true" multiValued="false"/>
-   <field name="subtitle_vern_display" type="string" indexed="false" stored="true" multiValued="false"/>
-   <field name="author_display" type="string" indexed="false" stored="true" multiValued="true"/>       <!-- fix ingest error on multivalue author -->
-   <field name="author_vern_display" type="string" indexed="false" stored="true" multiValued="false"/>
-   
-   <!-- these fields are also used for display, so they must be stored -->
-   <field name="isbn_t" type="text" indexed="true" stored="true" multiValued="true"/>
+
+   <field name="marc_display_raw" type="string" indexed="false" stored="true" multiValued="false"/>
+
+
    <field name="language_facet" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="subject_topic_facet" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="subject_era_facet" type="string" indexed="true" stored="true" multiValued="true" />
@@ -484,64 +477,11 @@
    <!-- pub_date sort uses new trie-based int fields, which are recommended for any int and are displayable, sortable, and range-quer
    we use 'tint' for faster range-queries. -->
    <field name="pub_date_sort" type="tint" indexed="true" stored="true" multiValued="false"/>
-     
+
    <!-- format is used for facet, display, and choosing which partial to use for the show view, so it must be stored and indexed -->
    <field name="format" type="string" indexed="true" stored="true" multiValued="true"/>
-
-
-
-
-
-
-
-
-
-
-
-   <!--  new fields for testing  -->
-   <field name="title_statement" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="title" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="subtitle" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="title_uniform" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="title_addl" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="creator" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="imprint" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="edition" type="string" indexed="true" stored="true" multiValued="true"/>
-   <!--<field name="pub_date" type="string" indexed="true" stored="true" multiValued="true"/>-->
-   <field name="pub_location" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="publisher" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="phys_desc" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="title_series" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="volume" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_with" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_biblio" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_toc" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_restrictions" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_references" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_summary" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_cite" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_terms" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_bio" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_finding_aid" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_custodial" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_binding" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_related" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_accruals" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="note_local" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="subject" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="subject_topic" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="subject_era" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="subject_region" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="genre" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="call_number" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="library" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="url" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="isbn" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="issn" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="govdoc" type="string" indexed="true" stored="true" multiValued="true"/>
-   <field name="language" type="string" indexed="true" stored="true" multiValued="true"/>
-
+   <!--field name="library_facet" type="string" indexed="true" stored="true" multiValued="true"/>
+   <field name="subject" type="string" indexed="true" stored="true" multiValued="true"/ -->
 
    <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
         will be used if the name matches any of the patterns.
@@ -550,8 +490,12 @@
         EXAMPLE:  name="*_i" will match any field ending in _i (like myid_i, z_i)
         Longer patterns will be matched first.  if equal size patterns
         both match, the first appearing in the schema will be used.  -->
+
+   <dynamicField name="*_display" type="string" indexed="false" stored="true" multiValued="true" />
+
    <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"/>
    <dynamicField name="*_s"  type="string"  indexed="true"  stored="true"/>
+   <dynamicField name="*_ms"  type="string"  indexed="true"  stored="true" multiValued="true"/>
    <dynamicField name="*_l"  type="long"   indexed="true"  stored="true"/>
    <dynamicField name="*_t"  type="text"    indexed="true"  stored="true" multiValued="true"/>
    <dynamicField name="*_txt" type="text_general"    indexed="true"  stored="true" multiValued="true"/>
@@ -577,22 +521,22 @@
 
    <dynamicField name="random_*" type="random" />
 
-   <dynamicField name="*_display" type="string" indexed="false" stored="true" multiValued="true" />
+
    <dynamicField name="*_facet" type="string" indexed="true" stored="false" multiValued="true" />
    <dynamicField name="*_sort" type="alphaOnlySort" indexed="true" stored="false" multiValued="false" />
    <dynamicField name="*_unstem_search" type="text_general" indexed="true" stored="false" multiValued="true" />
    <dynamicField name="*spell" type="textSpell" indexed="true" stored="false" multiValued="true" />
    <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
 
-   <!-- uncomment the following to ignore any fields that don't already match an existing 
-        field name or dynamic field, rather than reporting them as an error. 
-        alternately, change the type="ignored" to some other type e.g. "text" if you want 
-        unknown fields indexed and/or stored by default --> 
+   <!-- uncomment the following to ignore any fields that don't already match an existing
+        field name or dynamic field, rather than reporting them as an error.
+        alternately, change the type="ignored" to some other type e.g. "text" if you want
+        unknown fields indexed and/or stored by default -->
    <!--dynamicField name="*" type="ignored" multiValued="true" /-->
-   
+
  </fields>
 
- <!-- Field to use to determine and enforce document uniqueness. 
+ <!-- Field to use to determine and enforce document uniqueness.
       Unless this field is marked with required="false", it will be a required field
    -->
  <uniqueKey>id</uniqueKey>
@@ -607,7 +551,7 @@
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->
    <!-- Copy Fields -->
-        
+
    <!-- unstemmed fields -->
    <copyField source="title_t" dest="title_unstem_search"/>
    <copyField source="subtitle_t" dest="subtitle_unstem_search"/>
@@ -619,10 +563,11 @@
    <copyField source="subject_t" dest="subject_unstem_search"/>
    <copyField source="subject_addl_t" dest="subject_addl_unstem_search"/>
    <copyField source="subject_topic_facet" dest="subject_topic_unstem_search"/>
-   
+
    <!-- sort fields  NOTE: no longer feasible with multiple dates -->
   <!--  <copyField source="pub_date" dest="pub_date_sort"/>  -->
 
+   <copyField source="*_display" dest="text" />
 
  <!-- spellcheck fields -->
    <!-- default spell check;  should match fields for default request handler -->
@@ -641,8 +586,8 @@
    <!-- subject spell check; should match fields for subject request handler -->
    <copyField source="subject_topic_facet" dest="subject_spell"/>
    <copyField source="subject_t" dest="subject_spell"/>
-   <copyField source="subject_addl_t" dest="subject_spell"/>  
-   
+   <copyField source="subject_addl_t" dest="subject_spell"/>
+
    <!-- OpenSearch query field should match request handler search fields -->
    <copyField source="title_t" dest="opensearch_display"/>
    <copyField source="subtitle_t" dest="opensearch_display"/>
@@ -653,22 +598,22 @@
    <copyField source="author_addl_t" dest="opensearch_display"/>
    <copyField source="subject_topic_facet" dest="opensearch_display"/>
    <copyField source="subject_t" dest="opensearch_display"/>
-   <copyField source="subject_addl_t" dest="opensearch_display"/>  
+   <copyField source="subject_addl_t" dest="opensearch_display"/>
 
    <!-- for suggestions -->
    <copyField source="*_t" dest="suggest"/>
    <copyField source="*_facet" dest="suggest"/>
-   
-   <!-- Above, multiple source fields are copied to the [text] field. 
-	  Another way to map multiple source fields to the same 
-	  destination field is to use the dynamic field syntax. 
+
+   <!-- Above, multiple source fields are copied to the [text] field.
+	  Another way to map multiple source fields to the same
+	  destination field is to use the dynamic field syntax.
 	  copyField also supports a maxChars to copy setting.  -->
-	   
+
    <!-- <copyField source="*_t" dest="text" maxChars="3000"/> -->
 
    <!-- copy name to alphaNameSort, a field designed for sorting by name -->
    <!-- <copyField source="name" dest="alphaNameSort"/> -->
- 
+
 
  <!-- Similarity is the scoring routine for each document vs. a query.
       A custom similarity may be specified here, but the default is fine

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -24242,4 +24242,123 @@
       <subfield code='a'>Dictionary of American history: 008.</subfield>
     </datafield>
   </record>
+<record>
+  <leader>01753nas a2200481 a 4500</leader>
+  <controlfield tag="005">20020418062816.0</controlfield>
+  <controlfield tag="008">020418c19959999nyuqr p b g   0  |a0eng d</controlfield>
+  <controlfield tag="001">991027045839703811</controlfield>
+  <datafield tag="022" ind1="0" ind2="">
+    <subfield code="a">1521-6497</subfield>
+    <subfield code="y">0164-9345</subfield>
+  </datafield>
+  <datafield tag="035" ind1="" ind2="">
+    <subfield code="a">(PPT)b24728196-01tuli_inst</subfield>
+  </datafield>
+  <datafield tag="035" ind1="" ind2="">
+    <subfield code="a">PATL02-S26</subfield>
+  </datafield>
+  <datafield tag="040" ind1="" ind2="">
+    <subfield code="a">TxU-L</subfield>
+    <subfield code="c">TxU-L</subfield>
+    <subfield code="d">MnU-L</subfield>
+  </datafield>
+  <datafield tag="043" ind1="" ind2="">
+    <subfield code="a">n-us-ky</subfield>
+  </datafield>
+  <datafield tag="130" ind1="0" ind2="">
+    <subfield code="a">Bench &amp; bar (Frankfort, Ky.)</subfield>
+  </datafield>
+  <datafield tag="210" ind1="0" ind2="">
+    <subfield code="a">Bench bar</subfield>
+    <subfield code="b">(Frankfort, Ky.)</subfield>
+  </datafield>
+  <datafield tag="222" ind1="" ind2="0">
+    <subfield code="a">Bench &amp; bar</subfield>
+    <subfield code="b">(Frankfort, Ky.)</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Bench &amp; bar</subfield>
+    <subfield code="h">[microform] /</subfield>
+    <subfield code="c">Kentucky Bar Association.</subfield>
+  </datafield>
+  <datafield tag="246" ind1="1" ind2="3">
+    <subfield code="a">Kentucky bench &amp; bar</subfield>
+    <subfield code="f">1995-2001</subfield>
+  </datafield>
+  <datafield tag="246" ind1="1" ind2="3">
+    <subfield code="a">Kentucky Bar Association bench &amp; bar</subfield>
+  </datafield>
+  <datafield tag="246" ind1="1" ind2="">
+    <subfield code="a">Bench and bar</subfield>
+  </datafield>
+  <datafield tag="260" ind1="" ind2="">
+    <subfield code="a">Frankfort, Ky. :</subfield>
+    <subfield code="b">Kentucky Bar Association,</subfield>
+    <subfield code="c">1995-</subfield>
+  </datafield>
+  <datafield tag="300" ind1="" ind2="">
+    <subfield code="a">v. :</subfield>
+    <subfield code="b">ill. ;</subfield>
+    <subfield code="c">28 cm.</subfield>
+  </datafield>
+  <datafield tag="310" ind1="" ind2="">
+    <subfield code="a">Bimonthly,</subfield>
+    <subfield code="b">1998-</subfield>
+  </datafield>
+  <datafield tag="321" ind1="" ind2="">
+    <subfield code="a">Quarterly,</subfield>
+    <subfield code="b">1995-1998</subfield>
+  </datafield>
+  <datafield tag="362" ind1="0" ind2="">
+    <subfield code="a">Vol. 59, no. 3 (summer 1995)-</subfield>
+  </datafield>
+  <datafield tag="500" ind1="" ind2="">
+    <subfield code="a">Title from cover.</subfield>
+  </datafield>
+  <datafield tag="500" ind1="" ind2="">
+    <subfield code="a">Title on microfiche header: Kentucky bench &amp; bar, 1995-2001.</subfield>
+  </datafield>
+  <datafield tag="500" ind1="" ind2="">
+    <subfield code="a">Also called: Kentucky Bar Association bench &amp; bar.</subfield>
+  </datafield>
+  <datafield tag="533" ind1="" ind2="">
+    <subfield code="a">Microfiche.</subfield>
+    <subfield code="b">Buffalo, NY :</subfield>
+    <subfield code="c">W.S. Hein,</subfield>
+    <subfield code="d">1995- .</subfield>
+    <subfield code="e">microfiches : negative.</subfield>
+    <subfield code="f">(Hein's bar journal service).</subfield>
+  </datafield>
+  <datafield tag="650" ind1="" ind2="0">
+    <subfield code="a">Law</subfield>
+    <subfield code="z">Kentucky</subfield>
+    <subfield code="v">Periodicals.</subfield>
+  </datafield>
+  <datafield tag="610" ind1="2" ind2="0">
+    <subfield code="a">Kentucky Bar Association (1971- )</subfield>
+    <subfield code="v">Periodicals.</subfield>
+  </datafield>
+  <datafield tag="650" ind1="" ind2="0">
+    <subfield code="a">Bar associations</subfield>
+    <subfield code="z">Kentucky</subfield>
+    <subfield code="v">Periodicals.</subfield>
+  </datafield>
+  <datafield tag="710" ind1="2" ind2="">
+    <subfield code="a">Kentucky Bar Association (1971- )</subfield>
+  </datafield>
+  <datafield tag="776" ind1="1" ind2="">
+    <subfield code="d">(Original)</subfield>
+    <subfield code="w">(DLC)sn 96041529</subfield>
+  </datafield>
+  <datafield tag="780" ind1="0" ind2="0">
+    <subfield code="t">Kentucky bench &amp; bar</subfield>
+    <subfield code="x">0164-9345</subfield>
+  </datafield>
+  <datafield tag="HLD" ind1="" ind2="">
+    <subfield code="b">LAW</subfield>
+    <subfield code="c">micro</subfield>
+    <subfield code="8">22266041880003811</subfield>
+  </datafield>
+</record>
+
 </collection>


### PR DESCRIPTION
* Removes a lot of unused fields from the controller. 
* Standardize on using `*_display` dynamicField to catch most of our display fields.
* Standardize (mostly) facet filds to use the `*_facet` dynamicField
* All `*_display` fields should now be `copyField`ed into text, to be picked up on all_fields searches.
* Moves `qf` definition into catalog controller, with all of the attendant score boosts. Will make it more apparent how we can do boosting.
* Does a bit more Library Standard Number normalization for ISBN, ISSN and LCCNs.
