### PR TITLE
Ignore empty string years

### DIFF
--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -31,7 +31,8 @@ def get_xml options={}
 end
 
 def four_digit_year(field)
-  field.gsub(/[^0-9,.]/, '').gsub(/[[:punct:]]/, '')[0..3].strip unless field.nil?
+  year = field.gsub(/[^0-9,.]/, '').gsub(/[[:punct:]]/, '')[0..3].strip unless field.nil?
+  year unless year.empty?
 end
 
 settings do


### PR DESCRIPTION
Issue #BL-100

Empty string for years was causing range limits to ignore defaults due to a known bug in blacklight_range_limits. This change works around that problem.

See: https://github.com/projectblacklight/blacklight_range_limit/issues/25