### PR TITLE
Shrink the fl params to send less data on search results

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -38,29 +38,12 @@ class CatalogController < ApplicationController
         creator_display
         format
         imprint_display
-        isbn_t
-        language_facet
-        lc_callnum_display
-        material_type_display
-        published_display
-        published_vern_display
         pub_date
         title_series_vern_display
         title_display
         title_vern_display
-        subject_topic_facet
-        subject_geo_facet
-        subject_era_facet
-        subtitle_display
-        subtitle_vern_display
-        url_fulltext_display
-        url_suppl_display
         title_statement_display
         title_uniform_display
-        imprint
-        summary
-        contents
-        issn
       ].join(" "),
       wt: "json",
       rows: 10,


### PR DESCRIPTION
We were asking solr to send fields for search results that we didn't end up using in the display. This reduces that, hopefully providing a performance gain.