### PR TITLE
Fix Uncaught ReferenceError: select is not defined.

### DIFF
--- a/app/assets/javascripts/tulcob.js.coffee
+++ b/app/assets/javascripts/tulcob.js.coffee
@@ -6,4 +6,4 @@ $(document).on "turbolinks:load", ->
     width: '250px'
 
 
-  $(select).trigger 'chosen:updated'
+  $('select').trigger 'chosen:updated'


### PR DESCRIPTION
When you go to any page on the site you will see this error displayed in the console:

```
Uncaught ReferenceError: select is not defined
```

* Fixes a bug in the Javascript browser console 
* Also fixes clear button "x" does not work on advanced search results by adding rails helper methods REF BL-141
