### PR TITLE
Make the bento search view displayed by default.

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -7,7 +7,7 @@
 
         <p></p>
 
-        <%= form_tag({}, :method=> "get", :class => "well form-search", :style => 'display: none') do %>
+        <%= form_tag({}, :method=> "get", :class => "well form-search") do %>
 
             Search: <%= search_field_tag 'q', params[:q], :class => "search-query" %>
 


### PR DESCRIPTION
We will eventually integrate the bento search into the regular search,
but for now it would be nice to be able to go to `/bento` and be able to
search or QA the bento search without having to do any additional steps.