### PR TITLE
Add configuration that allows for pry dubugging.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   app:
     build: .
     command: "bundle exec rails s -p 3000 -b '0.0.0.0'"
+    tty: true
+    stdin_open: true
     volumes:
       - .:/tul_cob
     ports:


### PR DESCRIPTION
You cannot use the pry debugger from a container without adding this
configuration.

See:
http://www.chris-kelly.net/2016/07/25/debugging-rails-with-pry-within-a-docker-container/