### PR TITLE
Add the institutional code to alma.yml.example

### DIFF
--- a/config/alma.yml.example
+++ b/config/alma.yml.example
@@ -1,6 +1,6 @@
 default: &default
   apikey: "EX_LIBRIS_DEVELOPERS_NETWORK_APIKEY"
-  institution_code: INST_CODE
+  institution_code: 01TULI_INST
   delivery_domain: alma.delivery.exlibrisgroup.com
 
 development:


### PR DESCRIPTION
Since this code is not a secret, it makes sense to add it to the example
configuration file to avoid needing to enter it manually and potentially
make a mistake in the entry.