### PR TITLE
Refactors fix for advanced search not clearing.

### DIFF
--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+module BlacklightAdvancedSearch
+  module RenderConstraintsOverride
+    def search_field_def_for_key(key)
+      { label: "All fields" }
+    end
+  end
+end
+
+RSpec.describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helper do
+  describe "#guided_search" do
+
+    example "empty search fields" do
+      expect(helper.guided_search.empty?).to be(true)
+    end
+
+    example "one search field" do
+      params = ActionController::Parameters.new(
+        f1: "all_fields",
+        search_field: "advanced",
+        q1: "james"
+      )
+      expect(helper.guided_search(params).count).to eq(1)
+    end
+
+    example "two search fields" do
+      params = ActionController::Parameters.new(
+        f1: "all_fields",
+        search_field: "advanced",
+        q1: "james",
+        f2: "all_fields",
+        q2: "james",
+        op2: "OR"
+      )
+      expect(helper.guided_search(params).count).to eq(2)
+    end
+
+    it "can handle more than the number of fields defined (current is 3)" do
+      params = ActionController::Parameters.new(
+        f1: "all_fields",
+        search_field: "advanced",
+        q1: "james",
+        f2: "all_fields",
+        q2: "john",
+        op2: "OR",
+        f3: "all_fields",
+        q3: "david",
+        op3: "OR",
+        f4: "all_fields",
+        q4: "summer",
+        op4: "OR"
+      )
+      expect(helper.guided_search(params).count).to eq(4)
+    end
+  end
+end


### PR DESCRIPTION
REF BL-141

Description
===
The current solution to BL-141 has some duplication and will need to be
modified if ever we add or remove fields in the advanced search section.
This PR makes the following changes:

* It refactors the code to make it more resistant to change and
also remove some of the duplication.

* It adds back labels for OR, and AND ops that are missing from
the buttons after a search is done.

* It adds some new tests to this area of the code.

QA Steps
==
- [ ] After running an advanced search, clearing specific sections of
the search should continue to have the expected behavior.