### PR TITLE
Fix error undefined [] for nil class.

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -134,7 +134,8 @@ module BlacklightAdvancedSearch
         position = q.to_s.scan(/\d+$/)[0]
         f = "f#{position}".to_sym
         op = "op#{position}".to_sym
-        label = search_field_def_for_key(my_params[f])[:label]
+        field = search_field_def_for_key(my_params[f]).to_h
+        label = field[:label].to_s
         query = my_params[op].to_s + " " + my_params[q]
         [label, query, [f, q, op]]
       }

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 module BlacklightAdvancedSearch
   module RenderConstraintsOverride
     def search_field_def_for_key(key)
-      { label: "All fields" }
+      nil
     end
   end
 end


### PR DESCRIPTION
REF BL-95

Description
===

The current implementation of the #guided_search method incorrectly
assumes that #search_field_def_for_key returns a hash even when a field
is not found for a specific key.  This change corrects that assumption
by coercing nil into a hash before attempting to use it, and also by
coercing nil into an empty string ("") in the case where :label is not
defined in the field definition.