### PR TITLE
Move search params defaults to catalog_controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ git clone git@github.com:tulibraries/tul_cob
 cd tul_cob
 bundle install
 cp config/secrets.yml.example config/secrets.yml
-bundle exec rails db:migrate
 ```
 
 We also need to configure the application with our Alma and Primo apikey for development work on the Bento box or User account. Start by copying the example alma and bento config files.
@@ -24,6 +23,10 @@ cp config/bento.yml.example config/bento.yml
 ```
 
 Then edit them adding in the apikeys for our application specified in our Ex Libris Developer Network.
+
+```bash
+bundle exec rails db:migrate
+```
 
 
 ### Start the Application

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -30,6 +30,7 @@ class CatalogController < ApplicationController
 
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
+      wt: "json",
       fl: %w[
         id
         score
@@ -47,8 +48,13 @@ class CatalogController < ApplicationController
         title_statement_display
         title_uniform_display
       ].join(" "),
-      wt: "json",
-      rows: 10,
+      defType: "dismax",
+      echoParams: "explicit",
+      rows: "10",
+      q.alt: "*:*",
+      mm: "2&lt;-1 5&lt;-2 6&lt;90%",
+      ps: "3",
+      tie: "0.01",
       qf: %w[
         title_unstem_search^100000
         subtitle_unstem_search^50000
@@ -70,8 +76,101 @@ class CatalogController < ApplicationController
         subject_addl_t^50
         title_series_unstem_search^25
         title_series_t^10
+        isbn_t
         text
-      ].join(" ")
+      ].join(" "),
+      pf: %w[
+        title_unstem_search^1000000
+        subtitle_unstem_search^500000
+        title_t^250000
+        subtitle_t^100000
+        title_addl_unstem_search^50000
+        title_addl_t^25000
+        title_added_entry_unstem_search^15000
+        title_added_entry_t^12500
+        subject_topic_unstem_search^10000
+        subject_unstem_search^7500
+        subject_topic_facet^6250
+        subject_t^5000
+        author_unstem_search^2500
+        author_addl_unstem_search^2500
+        author_t^1000
+        author_addl_t^500
+        subject_addl_unstem_search^2500
+        subject_addl_t^500
+        title_series_unstem_search^250
+        title_series_t^100
+        text^10
+      ].join(" "),
+      author_qf: %w[
+        author_unstem_search^200
+        author_addl_unstem_search^50
+        author_t^20
+        author_addl_t
+      ].join(" "),
+      author_pf: %w[
+        author_unstem_search^2000
+        author_addl_unstem_search^500
+        author_t^200
+        author_addl_t^10
+      ].join(" "),
+      title_qf: %w[
+        title_unstem_search^50000
+        subtitle_unstem_search^25000
+        title_addl_unstem_search^10000
+        title_t^5000
+        subtitle_t^2500
+        title_addl_t^100
+        title_added_entry_unstem_search^50
+        title_added_entry_t^10
+        title_series_unstem_search^5
+        title_series_t
+      ].join(" "),
+      title_pf: %w[
+        title_unstem_search^500000
+        subtitle_unstem_search^250000
+        title_addl_unstem_search^100000
+        title_t^50000
+        subtitle_t^25000
+        title_addl_t^1000
+        title_added_entry_unstem_search^500
+        title_added_entry_t^100
+        title_series_t^50
+        title_series_unstem_search^10
+      ].join(" "),
+      subject_qf: %w[
+        subject_topic_unstem_search^200
+        subject_unstem_search^125
+        subject_topic_facet^100
+        subject_t^50
+        subject_addl_unstem_search^10
+        subject_addl_t
+      ].join(" "),
+      subject_pf: %w[
+        subject_topic_unstem_search^2000
+        subject_unstem_search^1250
+        subject_t^1000
+        subject_topic_facet^500
+        subject_addl_unstem_search^100
+        subject_addl_t^10
+      ].join(" "),
+      facet: "true",
+      facet.mincount: "1",
+      facet.field: "format",
+      facet.field: "lc_1letter_facet",
+      facet.field: "lc_alpha_facet",
+      facet.field: "lc_b4cutter_facet",
+      facet.field: "language_facet",
+      facet.field: "pub_date",
+      facet.field: "subject_era_facet",
+      facet.field: "subject_geo_facet",
+      facet.field: "subject_topic_facet",
+      spellcheck: "true",
+      spellcheck.dictionary: "default",
+      spellcheck.onlyMorePopular: "true",
+      spellcheck.extendedResults: "true",
+      spellcheck.collate: "false",
+      spellcheck.count: "5"
     }
 
     # solr path which will be added to solr base url before the other solr params.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -51,7 +51,6 @@ class CatalogController < ApplicationController
       defType: "dismax",
       echoParams: "explicit",
       rows: "10",
-      q.alt: "*:*",
       mm: "2&lt;-1 5&lt;-2 6&lt;90%",
       ps: "3",
       tie: "0.01",
@@ -155,22 +154,7 @@ class CatalogController < ApplicationController
         subject_addl_t^10
       ].join(" "),
       facet: "true",
-      facet.mincount: "1",
-      facet.field: "format",
-      facet.field: "lc_1letter_facet",
-      facet.field: "lc_alpha_facet",
-      facet.field: "lc_b4cutter_facet",
-      facet.field: "language_facet",
-      facet.field: "pub_date",
-      facet.field: "subject_era_facet",
-      facet.field: "subject_geo_facet",
-      facet.field: "subject_topic_facet",
       spellcheck: "true",
-      spellcheck.dictionary: "default",
-      spellcheck.onlyMorePopular: "true",
-      spellcheck.extendedResults: "true",
-      spellcheck.collate: "false",
-      spellcheck.count: "5"
     }
 
     # solr path which will be added to solr base url before the other solr params.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -51,7 +51,11 @@ class CatalogController < ApplicationController
       defType: "dismax",
       echoParams: "explicit",
       rows: "10",
-      mm: "2&lt;-1 5&lt;-2 6&lt;90%",
+      mm:[ 
+        "2<-1", 
+        "5<-2", 
+        URI.escape("6<90%")
+          ],
       ps: "3",
       tie: "0.01",
       qf: %w[

--- a/spec/features/searches_spec.rb
+++ b/spec/features/searches_spec.rb
@@ -176,4 +176,29 @@ RSpec.feature "Searches", type: :feature do
       end
     end
   end
+
+  feature "Test queries" do
+    let (:test_queries) { fixtures.fetch("results_queries") }
+    scenario "Test queries" do
+      test_queries.each do |test_item|
+        search_string = ''
+        test_item['query_type'].each do |query_field|
+          test_item[query_field].each do |search_term|
+            search_string += search_term + " "
+          end
+        end
+        visit '/'
+        fill_in 'q', with: search_string
+        click_button 'Search'
+        #save_and_open_page
+        within(".document-position-0 h3") do
+          test_item['query_type'].each do |query_field|
+            test_item[query_field].each do |search_term|
+              expect(page).to have_text search_term
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/fixtures/search_features.yml
+++ b/spec/fixtures/search_features.yml
@@ -26,3 +26,31 @@ journal_search:
   issn: 0163-7525
   lccn: 80644745
   availability_facet: "Online"
+results_queries:
+  - doc_id:
+      - "991001254809703811"
+      - "991022272009703811"
+    PCI_recordid:
+      - "TN_crossref10.1080/07268602.2017.1295798"
+    title:
+      - "test"
+    query_type:
+      - "title"
+  - doc_id:
+      - "991024587289703811"
+    title:
+      - "Crisis management in American higher education"
+    query_type:
+      - "title"
+  - doc_id:
+      - "991036742233003811"
+      - "991017814679703811"
+      - "991001513649703811"
+      - "991002431869703811"
+    title:
+      - "States of political discourse"
+    subtitle:
+      - "words, regimes, seditions"
+    query_type:
+      - "title"
+      - "subtitle"


### PR DESCRIPTION
REF: BL-124

Description
===
Move the solr query parameter configs like ps, pf, author_qf, etc, out of the solrconfig searchHandler and into the catalogContoller
Temporarily move this configuration into the catalog controller for ease of use and update. Once our work on relvancy and schema settles down, we can move it back into solrconfig.