### PR TITLE
Only add separator if has date statement in e resource link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,6 +65,10 @@ module ApplicationHelper
       query: query_defaults.merge(query).to_query).to_s
   end
 
+  def render_alma_eresource_link(portfolio_pid, db_name)
+    link_to(db_name, alma_electronic_resource_direct_link(portfolio_pid))
+  end
+
   def alma_electronic_resource_direct_link(portfolio_pid)
     query = {
         'u.ignore_date_coverage': "true",
@@ -74,12 +78,17 @@ module ApplicationHelper
     alma_build_openurl(query)
   end
 
+  def electronic_resource_list_item(portfolio_pid, db_name, addl_info)
+    item_parts = [render_alma_eresource_link(portfolio_pid, db_name), addl_info]
+    item_html = item_parts.compact.join(" - ").html_safe
+    content_tag(:li, item_html , class: "list_items")
+  end
+
   def electronic_resource_link_builder(field)
-    electronic_resource_from_traject = field.split("|")
-    portfolio_pid = electronic_resource_from_traject.first
-    database_name = electronic_resource_from_traject.second || "Find it online"
-    additional_info = electronic_resource_from_traject.third || ""
-    new_link = content_tag(:li, link_to(database_name, alma_electronic_resource_direct_link(portfolio_pid)) + " - " + additional_info , class: "list_items")
+    return if field.empty?
+    portfolio_pid, db_name, addl_info = field.split("|")
+    db_name ||= "Find it online"
+    electronic_resource_list_item(portfolio_pid, db_name, addl_info)
   end
 
   def single_link_builder(field)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "has correct link to resource" do
         expect(electronic_resource_link_builder(field)).to have_link(text: "Find it online", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=12345&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
       end
+
+      it "does not have a separator" do
+        expect(electronic_resource_link_builder(field)).to_not have_text(" - ")
+      end
     end
 
     context "two subfields present" do
@@ -30,6 +34,10 @@ RSpec.describe ApplicationHelper, type: :helper do
 
       it "displays database name if available" do
         expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+      end
+
+      it "does not contain a separator" do
+        expect(electronic_resource_link_builder(field)).to_not have_text(" - ")
       end
     end
 


### PR DESCRIPTION
The separator between e resource links and their data statements was appearing even if the date statement was missing.  Something like:
![screenshot-2017-11-8 availability online - blacklight search results](https://user-images.githubusercontent.com/1128631/32566392-c4555d50-c485-11e7-92de-23a74e496b89.png)

This pull request makes that go away!!!

### To Verify
* Fetch and checkout his branch
* Run your fave variation on `bundle exec rake server`
* Go to the show page for record with id `991013867929703811`

- [ ] Inside the availability section at the bottom of the page, there should be a link to EbscoHost Academic Ebook Collection that does not have a trailing  "-" (dash).


