### PR TITLE
Online and physical holdings

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -84,9 +84,13 @@ module ApplicationHelper
   end
 
   def single_link_builder(field)
-    electronic_resource_from_traject = field.split("|")
-    portfolio_pid = electronic_resource_from_traject.first
-    alma_electronic_resource_direct_link(portfolio_pid)
+    if field.include?("http")
+      field.split("|").last
+    else
+      electronic_resource_from_traject = field.split("|")
+      portfolio_pid = electronic_resource_from_traject.first
+      alma_electronic_resource_direct_link(portfolio_pid)
+    end
   end
 
   def bento_engine_nice_name(engine_id)

--- a/app/helpers/blacklight_alma_helper.rb
+++ b/app/helpers/blacklight_alma_helper.rb
@@ -9,10 +9,10 @@ module BlacklightAlmaHelper
   # that we always "viewit" in the case of an "Online" record.
   def alma_service_type_for_fulfillment_url(document = {})
     document ||= {}
-    if document.fetch("availability_facet", []).include?("Online")
-      "viewit"
-    else
+    if document.fetch("availability_facet", []).include?("At the Library")
       "getit"
+    else
+      "viewit"
     end
   end
 end

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -17,13 +17,14 @@
               <% values.each do |value| %>
               <li class="list_items"> <%= safe_join(Array.wrap(value)) %> </li>
             </ul>
+            <% end %>
           </dd>
         </div>
       </div>
       <% end %>
     <% end %>
   <% end %>
-  <% elsif document["availability_facet"][i] == "At the Library" %>
+  <% if document["availability_facet"][i] == "At the Library" %>
     <div class="availability_iframe panel panel-default">
       <h4 class="panel-heading">Availability</h4>
       <iframe class="bl_alma_iframe" src="<%= alma_app_fulfillment_url(document) %>"></iframe>

--- a/spec/helpers/blacklight_alma_helper_spec.rb
+++ b/spec/helpers/blacklight_alma_helper_spec.rb
@@ -14,22 +14,22 @@ require "rails_helper"
 # end
 RSpec.describe BlacklightAlmaHelper, type: :helper do
   describe "#alma_service_type_for_fulfillment_url" do
-    example "An online file is available" do
-      doc = { "availability_facet" => ["Online"] }
-      actual = helper.alma_service_type_for_fulfillment_url doc
-      expect(actual).to be("viewit")
-    end
-
-    example "An online file is not available" do
-      doc = { "availability_facet" => [] }
+    example "A physical holding is available" do
+      doc = { "availability_facet" => ["At the Library"] }
       actual = helper.alma_service_type_for_fulfillment_url doc
       expect(actual).to be("getit")
+    end
+
+    example "A physical holding is not available" do
+      doc = { "availability_facet" => [] }
+      actual = helper.alma_service_type_for_fulfillment_url doc
+      expect(actual).to be("viewit")
     end
 
     example "Something has gone terribly wrong" do
       doc = nil
       actual = helper.alma_service_type_for_fulfillment_url doc
-      expect(actual).to be("getit")
+      expect(actual).to be("viewit")
     end
   end
 end


### PR DESCRIPTION
BL-169 Adjust availability settings
- Refactor single_link_builder method to work with both alma api links and 856 fields
- Refactor alma_service_type_for_fulfillment method to display physical holdings first
- There is a change in the blacklight_alma gem that also goes along with this 