### PR TITLE
Bl 175 update iframe

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,6 +56,7 @@ module ApplicationHelper
 
   def alma_build_openurl(query)
     query_defaults = {
+      'is_new_ui': true,
       rfr_id: "info:sid/primo.exlibrisgroup.com",
     }
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:field) { "12345" }
 
       it "has correct link to resource" do
-        expect(electronic_resource_link_builder(field)).to have_link(text: "Find it online", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=12345&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(electronic_resource_link_builder(field)).to have_link(text: "Find it online", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=12345&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
       end
 
       it "does not have a separator" do
@@ -33,7 +33,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:field) { "77777|Sample Name" }
 
       it "displays database name if available" do
-        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
       end
 
       it "does not contain a separator" do
@@ -45,7 +45,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:field) { "77777|Sample Name|Sample Text" }
 
       it "displays additional information as plain text" do
-        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
         expect(electronic_resource_link_builder(field)).to have_text("Sample Text")
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context "alma api links go through electronic_resource_display method" do
       it "directs an http link through the electronic_access_links method" do
-        expect(check_for_full_http_link(args)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(check_for_full_http_link(args)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
       end
     end
   end


### PR DESCRIPTION
This adds the new_ui parameter to the openurl links so that the iframe uses the newer version.  To verify, check any physical holding iframe and it should have this updated styling.

![screen shot 2017-11-09 at 11 59 23 am](https://user-images.githubusercontent.com/15167238/32623280-99e1654a-c553-11e7-9614-f889e11e8a50.png)
