### PR TITLE
BL-180 Add new skin for alma iframe

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,8 +56,6 @@ module ApplicationHelper
 
   def alma_build_openurl(query)
     query_defaults = {
-      'is_new_ui': true,
-      "req.skin": "temple_01",
       rfr_id: "info:sid/primo.exlibrisgroup.com",
     }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,6 +57,7 @@ module ApplicationHelper
   def alma_build_openurl(query)
     query_defaults = {
       'is_new_ui': true,
+      "req.skin": "temple_01",
       rfr_id: "info:sid/primo.exlibrisgroup.com",
     }
 

--- a/app/helpers/blacklight_alma_helper.rb
+++ b/app/helpers/blacklight_alma_helper.rb
@@ -15,4 +15,30 @@ module BlacklightAlmaHelper
       "viewit"
     end
   end
+
+  def alma_app_fulfillment_url(document, service_type: nil, language: nil, view: nil)
+      mms_id = document.respond_to?(:alma_mms_id) ? document.alma_mms_id : document.id
+      service_type ||= alma_service_type_for_fulfillment_url(document)
+
+      query = {
+          'is_new_ui': true,
+          "req.skin": "temple_01",
+          svc_dat: service_type,
+          'rft.mms_id': mms_id,
+      }
+      rft_dat_value = [language.present? ? "language=#{language}" : nil,
+                       view.present? ? "view=#{view}" : nil].compact.join(',')
+      query['rft_dat'] = rft_dat_value if rft_dat_value.present?
+      query['u.ignore_date_coverage'] = 'true' if service_type == 'viewit'
+
+      if session[:alma_auth_type] == 'sso' && session[:alma_sso_token].present?
+        query['sso'] = 'true'
+        query['token'] = session[:alma_sso_token]
+      elsif session[:alma_social_login_provider].present?
+        query['oauth'] = 'true'
+        query['provider'] = session[:alma_social_login_provider]
+      end
+
+      alma_build_openurl(query)
+  end
 end

--- a/config/alma.yml.example
+++ b/config/alma.yml.example
@@ -1,7 +1,7 @@
 default: &default
   apikey: "EX_LIBRIS_DEVELOPERS_NETWORK_APIKEY"
   institution_code: 01TULI_INST
-  delivery_domain: alma.delivery.exlibrisgroup.com
+  delivery_domain: "sandbox01-na.alma.exlibrisgroup.com"
 
 development:
     <<: *default

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:field) { "12345" }
 
       it "has correct link to resource" do
-        expect(electronic_resource_link_builder(field)).to have_link(text: "Find it online", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=12345&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(electronic_resource_link_builder(field)).to have_link(text: "Find it online", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=12345&req.skin=temple_01&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
       end
 
       it "does not have a separator" do
@@ -33,7 +33,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:field) { "77777|Sample Name" }
 
       it "displays database name if available" do
-        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=77777&req.skin=temple_01&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
       end
 
       it "does not contain a separator" do
@@ -45,7 +45,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:field) { "77777|Sample Name|Sample Text" }
 
       it "displays additional information as plain text" do
-        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=77777&req.skin=temple_01&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
         expect(electronic_resource_link_builder(field)).to have_text("Sample Text")
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context "alma api links go through electronic_resource_display method" do
       it "directs an http link through the electronic_access_links method" do
-        expect(check_for_full_http_link(args)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(check_for_full_http_link(args)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=77777&req.skin=temple_01&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:field) { "12345" }
 
       it "has correct link to resource" do
-        expect(electronic_resource_link_builder(field)).to have_link(text: "Find it online", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=12345&req.skin=temple_01&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(electronic_resource_link_builder(field)).to have_link(text: "Find it online", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=12345&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
       end
 
       it "does not have a separator" do
@@ -33,7 +33,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:field) { "77777|Sample Name" }
 
       it "displays database name if available" do
-        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=77777&req.skin=temple_01&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
       end
 
       it "does not contain a separator" do
@@ -45,7 +45,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:field) { "77777|Sample Name|Sample Text" }
 
       it "displays additional information as plain text" do
-        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=77777&req.skin=temple_01&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
         expect(electronic_resource_link_builder(field)).to have_text("Sample Text")
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context "alma api links go through electronic_resource_display method" do
       it "directs an http link through the electronic_access_links method" do
-        expect(check_for_full_http_link(args)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&is_new_ui=true&portfolio_pid=77777&req.skin=temple_01&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(check_for_full_http_link(args)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
       end
     end
   end


### PR DESCRIPTION
BL-180 Allows us to create our own custom css for the alma availability iframe.  The delivery_domain in the alma.yml.example file was also out of date, so that updated to use the sandbox.