### PR TITLE
BL-169 Update panel heading for online iframe

### DIFF
--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -7,7 +7,7 @@
     <% if field_name == 'electronic_resource_display' %>
       <div class="panel panel-default">
         <div class="panel-heading">
-          <h3 class="panel-title"><dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt></h3>
+          <h4 class="panel-heading">Availability</h4>
         </div>
         <div class="panel-body">
           <h5>Online</h5>


### PR DESCRIPTION
BL-169 Removes the colon from Availability heading for online items in the record display.