### PR TITLE
Bl 193 update creator fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -260,8 +260,10 @@ class CatalogController < ApplicationController
     config.add_show_field "title_uniform_vern_display", label: "Uniform title"
     config.add_show_field "title_addl_display", label: "Additional titles"
     config.add_show_field "title_addl_vern_display", label: "Additional titles"
-    config.add_show_field "creator_display", label: "Author/creator/contributor", helper_method: :browse_creator, multi: true
-    config.add_show_field "creator_vern_display", label: "Author/creator/contributor", helper_method: :list_with_links
+    config.add_show_field "creator_display", label: "Author/Creator", helper_method: :browse_creator, multi: true
+    config.add_show_field "creator_vern_display", label: "Author/Creator", helper_method: :browse_creator
+    config.add_show_field "contributor_vern_display", label: "Contributor", helper_method: :browse_creator
+    config.add_show_field "contributor_display", label: "Contributor", helper_method: :browse_creator, multi: true
     config.add_show_field "format", label: "Resource Type"
     config.add_show_field "imprint_display", label: "Published"
     config.add_show_field "edition_display", label: "Edition"

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -124,8 +124,10 @@ to_field "location_display", extract_marc("HLDc")
 # Creator/contributor fields
 to_field "creator_t", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true)
 to_field "creator_facet", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true)
-to_field "creator_display", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true, alternate_script: false)
-to_field "creator_vern_display", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true, alternate_script: :only)
+to_field "creator_display", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt", trim_punctuation: true, alternate_script: false)
+to_field "contributor_display", extract_marc("700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true, alternate_script: false)
+to_field "creator_vern_display", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt", trim_punctuation: true, alternate_script: :only)
+to_field "contributor_vern_display", extract_marc("700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true, alternate_script: :only)
 
 # Publication fields
 # For the imprint, make sure to take RDA-style 264, second indicator = 1

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -132,28 +132,38 @@ RSpec.feature "RecordPageFields", type: :feature do
         expect(page).to have_text(item_111["creator"])
       end
     end
+  end
 
-    let (:item_700) { fixtures.fetch("creator_700") }
-    scenario "User visits a document with creator" do
+  feature "MARC Contributor Fields" do
+    let (:item_700) { fixtures.fetch("contributor_700") }
+    scenario "User visits a document with contributor" do
       visit "catalog/#{item_700['doc_id']}"
-      within "dd.blacklight-creator_display" do
-        expect(page).to have_text(item_700["creator"])
+      within "dd.blacklight-contributor_display" do
+        expect(page).to have_text(item_700["contributor"])
       end
     end
 
-    let (:item_710) { fixtures.fetch("creator_710") }
-    scenario "User visits a document with creator" do
+    let (:item_710) { fixtures.fetch("contributor_710") }
+    scenario "User visits a document with contributor" do
       visit "catalog/#{item_710['doc_id']}"
-      within "dd.blacklight-creator_display" do
-        expect(page).to have_text(item_710["creator"])
+      within "dd.blacklight-contributor_display" do
+        expect(page).to have_text(item_710["contributor"])
       end
     end
 
-    let (:item_711) { fixtures.fetch("creator_711") }
-    scenario "User visits a document with creator" do
+    let (:item_711) { fixtures.fetch("contributor_711") }
+    scenario "User visits a document with contributor" do
       visit "catalog/#{item_711['doc_id']}"
-      within "dd.blacklight-creator_display" do
-        expect(page).to have_text(item_711["creator"])
+      within "dd.blacklight-contributor_display" do
+        expect(page).to have_text(item_711["contributor"])
+      end
+    end
+
+    let (:item_700_v) { fixtures.fetch("contributor_700_v") }
+    scenario "User visits a document with contributor vernacular" do
+      visit "catalog/#{item_700_v['doc_id']}"
+      within "dd.blacklight-contributor_vern_display" do
+        expect(page).to have_text(item_700_v["contributor_vern"])
       end
     end
   end

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -42,22 +42,25 @@ creator_100:
   creator: "Giovanni, Nikki. Subfield B. Subfield C. Subfield D. Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield T. Subfield U."
 creator_100_v:
   doc_id: "991012172649703811"
-  creator_vern: "מעקלער, ד.ל.  לאועב, מיטשעל"
+  creator_vern: "מעקלער, ד.ל."
 creator_110:
   doc_id: "991012132499760618"
   creator: "Dictionary of American history: 110. Subfield B. Subfield C. Subfield D. Subfield E. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield T."
 creator_111:
   doc_id: "991012132499760619"
   creator: "Dictionary of American history: 111. Subfield C. Subfield D. Subfield E. Subfield J. Subfield L. Subfield N. Subfield O. Subfield P. Subfield T."
-creator_700:
+contributor_700:
   doc_id: "991012132499760620"
   creator: "Dictionary of American history: 700. Subfield B. Subfield C. Subfield D. Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield T. Subfield U."
-creator_710:
+contributor_710:
   doc_id: "991012132499760621"
   creator: "Dictionary of American history: 710. Subfield B. Subfield C. Subfield D. Subfield E. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield T."
-creator_711:
+contributor_711:
   doc_id: "991012132499760622"
   creator: "Dictionary of American history: 711. Subfield C. Subfield D. Subfield E. Subfield J. Subfield L. Subfield N. Subfield O. Subfield P. Subfield T."
+contributor_700_v:
+  doc_id: "991012172649703811"
+  contributor_vern: "לאועב, מיטשעל"
 imprint_260:
   doc_id: "991012132499760623"
   imprint: "Dictionary of American history: 260. Subfield B. Subfield C. Subfield E. Subfield F. Subfield G. Subfield 3."


### PR DESCRIPTION
BL-193 The decision was made to refine the creator field Marc data.
- Creator fields are now labeled "Author/Creator" and only pull from the 100 fields
- Added a new contributor field, labeled "Contributor" that accessing the 700 fields
- The same changes were made for the creator vernacular fields
- Check http://localhost:3004/catalog/991030852609703811 to see that the 700 info is displayed with the Contributor label
<img width="404" alt="screen shot 2017-11-16 at 9 15 03 am" src="https://user-images.githubusercontent.com/15167238/32895722-fd7e46d0-caae-11e7-82a1-80b84cbba606.png">