### PR TITLE
Update electronic links

### DIFF
--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -76,11 +76,6 @@ input[type="radio"] + label {
   margin-top: 25px;
 }
 
-button.avail-button {
-  display: inline-block;
-  margin: 5px 5px 10px 10px;
-}
-
 .availability button {
   display: none;
 }
@@ -91,12 +86,9 @@ dd.blacklight-availability {
   vertical-align: middle;
 }
 
-.availability_iframe {
-  margin: 30px;
-}
-
 .panel-heading {
   margin: 0;
+  padding: 5px;
 }
 
 .bl_alma_iframe {
@@ -116,6 +108,11 @@ div.online_resources {
 
 .button-break {
   padding: 3px;
+}
+
+.online-panel {
+  border-bottom: 1px solid #ececec;
+  padding-bottom: 20px;
 }
 
 /* === MEDIA QUERIES === */

--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -114,6 +114,10 @@ div.online_resources {
   padding-left: 5px;
 }
 
+.button-break {
+  padding: 3px;
+}
+
 /* === MEDIA QUERIES === */
 
 @media (min-width: 768px) {

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -7,7 +7,7 @@
           <% if document[field_name].length == 1 %>
             <%= button_to "Online", single_link_builder(document[field_name][i]), class:"collapse-button btn btn-sm btn-info" %>
           <% else %>
-            <button class="btn btn-sm btn-info collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document_counter %>">Online</button>
+            <button class="btn-block btn btn-sm btn-info collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document_counter %>">Online</button>
             <div id="online-document-<%= document_counter %>" class="collapse online_resources">
               <ul>
                 <p class="online_resources col-md-9"><%= doc_presenter.field_value field_name %></p>
@@ -17,6 +17,8 @@
         <% end -%>
       <% end -%>
     <% end -%>
+    
+  <div class="row button-break"></div>
 
   <% elsif document.fetch("availability_facet", [])[i] == "At the Library" %>
     <button class="btn btn-sm btn-default availability-toggle-details collapse-button" data-toggle="collapse" data-target="#physical-document-<%=  document_counter %>">Loading...</button>

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -1,34 +1,34 @@
 <% doc_presenter = show_presenter(document) %>
 <%# partial to display availability details in catalog show view -%>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h4 class="panel-heading">Availability</h4>
+  </div>
 
-<% @response["response"][:docs].each_with_index do |field, i| %>
-  <% if document["availability_facet"][i] == "Online" %>
+  <% if document["availability_facet"].include?("Online") %>
     <% document_show_fields(document).each do |field_name, field| %>
     <% if field_name == 'electronic_resource_display' %>
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4 class="panel-heading">Availability</h4>
-        </div>
-        <div class="panel-body">
-          <h5>Online</h5>
-          <dd class="blacklight-<%= field_name.parameterize %>">
-            <ul>
+
+      <div class="panel-body online-panel">
+        <h5>Online</h5>
+        <dd class="blacklight-<%= field_name.parameterize %>">
+          <ul>
             <% doc_presenter.configuration.show_fields.fetch(field_name)[:helper_method] %>
-              <% values = Array.wrap(doc_presenter.field_value field_name) %>
-              <% values.each do |value| %>
+            <% values = Array.wrap(doc_presenter.field_value field_name) %>
+            <% values.each do |value| %>
               <li class="list_items"> <%= safe_join(Array.wrap(value)) %> </li>
-            </ul>
             <% end %>
-          </dd>
-        </div>
+          </ul>
+        </dd>
       </div>
       <% end %>
     <% end %>
   <% end %>
-  <% if document["availability_facet"][i] == "At the Library" %>
-    <div class="availability_iframe panel panel-default">
-      <h4 class="panel-heading">Availability</h4>
+
+  <% if document["availability_facet"].include?("At the Library") %>
+    <div class="availability_iframe panel-body">
+      <h5>In Library</h5>
       <iframe class="bl_alma_iframe" src="<%= alma_app_fulfillment_url(document) %>"></iframe>
     </div>
   <% end %>
-<% end %>
+</div>


### PR DESCRIPTION
Cleans up some of the issues regarding availability display
- BL-194 Ensure availability buttons in index view are on new lines with space in between when there are both online and physical holdings
<img width="806" alt="screen shot 2017-11-16 at 2 25 51 pm" src="https://user-images.githubusercontent.com/15167238/32911408-1a9874ae-cada-11e7-8585-7413281e2f30.png">
- BL-195 Refactor record views so that both online and physical availability are displayed when both are present
- see http://localhost:3004/catalog/991012599009703811 for example
<img width="606" alt="screen shot 2017-11-16 at 2 26 57 pm" src="https://user-images.githubusercontent.com/15167238/32911486-526cd168-cada-11e7-8d47-ddb2c3a0ed9b.png">

