### PR TITLE
Do not force a bind to port 80 or 443.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       context: .
       dockerfile: .docker/sp/Dockerfile
     ports:
-      - "80:80"
-      - "443:443"
+      - "80"
+      - "443"
     volumes:
       - .:/var/www/html/tul_cob
       - .docker/sp/etc-apache2-sites-enabled:/etc/apache2/sites-enabled


### PR DESCRIPTION
REF ADO-1

We will need ports 80 and 443 open for our reverse proxy server on
Jenkins QA site.  Thus, we cannot force our instances to be bound to the
hosts 80 or 443 port.