### PR TITLE
Fixes range limit not plugin not working.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -225,16 +225,7 @@ class CatalogController < ApplicationController
     config.add_facet_field "availability_facet", label: "Availability"
     config.add_facet_field "library_facet", label: "Library"
     config.add_facet_field "format", label: "Resource Type"
-    config.add_facet_field "pub_date", label: "Date",
-                           range: {
-                             num_segments: 6,
-                             assumed_boundaries: [1100, Time.now.year + 2],
-                             segments: true,
-                             slider_js: true,
-                             chart_js: true,
-                             maxlength: 4
-                           }
-
+    config.add_facet_field "pub_date_sort", label: "Date", range: true
     config.add_facet_field "creator_facet", label: "Author/creator", limit: true, show: true
     config.add_facet_field "subject_facet", label: "Subject", limit: true, show: false
     config.add_facet_field "subject_topic_facet", label: "Topic"     # limit: 20, index_range: 'A'..'Z'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,42 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-
   root to: "catalog#index"
 
+  # concerns
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
+  concern :searchable, Blacklight::Routes::Searchable.new
+  concern :exportable, Blacklight::Routes::Exportable.new
+
+  # mounts
+  mount Blacklight::Engine => "/"
+  mount BlacklightAdvancedSearch::Engine => "/"
+  mount BentoSearch::Engine => "/bento"
+
+
+  # resource and resources
+  resource :catalog, only: [:index], as: "catalog", path: "/catalog", controller: "catalog" do
+    concerns :searchable
+    concerns :range_searchable
+  end
+
+  resources :solr_documents, only: [:show], path: "/catalog", controller: "catalog" do
+    concerns :exportable
+  end
+
+  resources :bookmarks do
+    concerns :exportable
+
+    collection do
+      delete "clear"
+    end
+  end
+
+  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
 
+  # auth
   authenticate do
     post "users/renew"
 
@@ -24,7 +54,7 @@ Rails.application.routes.draw do
 
   end
 
-  mount BentoSearch::Engine => "/bento"
+  # gets
   get "bento" => "search#index"
   get "bento" => "search#index", :as => "multi_search"
 
@@ -43,52 +73,13 @@ Rails.application.routes.draw do
     get "alma/availability" => "alma#availability"
   end
 
-
-  concern :exportable, Blacklight::Routes::Exportable.new
-
-  resources :solr_documents, only: [:show], path: "/catalog", controller: "catalog" do
-    concerns :exportable
-  end
-
-  resources :bookmarks do
-    concerns :exportable
-
-    collection do
-      delete "clear"
-    end
-  end
-
-  Blacklight::Marc.add_routes(self)
-  mount Blacklight::Engine => "/"
-  mount BlacklightAdvancedSearch::Engine => "/"
-
-  root to: "catalog#index"
-  concern :searchable, Blacklight::Routes::Searchable.new
-
-  resource :catalog, only: [:index], as: "catalog", path: "/catalog", controller: "catalog" do
-    concerns :searchable
-    concerns :range_searchable
-
-  end
-
   get "catalog/:id/staff_view", to: "catalog#librarian_view", as: "staff_view"
 
-  concern :exportable, Blacklight::Routes::Exportable.new
-
-  resources :solr_documents, only: [:show], path: "/catalog", controller: "catalog" do
-    concerns :exportable
-  end
-
-  resources :bookmarks do
-    concerns :exportable
-
-    collection do
-      delete "clear"
-    end
-  end
-
+  # matches
   match "/404", to: "errors#not_found", via: :all
   match "/500", to: "errors#internal_server_error", via: :all
+
+  Blacklight::Marc.add_routes(self)
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
REF BL-205 BL-112 BL-27

When a user opens the "Date" facet, the range limit should work as
expected.  However, do to a controller mis-configuration an ajax call to
the catalog/range_limit route was throwing 500.

This commit updates the config/routes.rb removing duplications and
organizing it so that it's easier to read.

It also changes the solr range limit field to be pub_date_sort because
that field is indexed as a trint which is the desired format for the
range limit.

QA Steps
==
- [x] Go to the root of the site.  Click on the "Date" facet, you should
see a graph with years under it. not a box with -1 and 1 on each side.
- [ ] Go to
http://localhost:3000/catalog/range_limit?range_end=2080&range_field=pub_date_sort&range_start=1100
you should see a list of dates and counts for each date.