### PR TITLE
Do not render Librarian view link.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -460,5 +460,9 @@ class CatalogController < ApplicationController
     config.autocomplete_path = "suggest"
 
     config.add_nav_action :library_account, partial: "/users/account_link", if: :user_signed_in?
+
+    # marc config
+    # Do not show library_view link
+    config.show.document_actions.delete(:librarian_view)
   end
 end


### PR DESCRIPTION
REF BL-209

QA Steps
==
* Do a search and click on a document
- [ ] Verify that the "Librarian View" link does not appear in the Tool box section.