### PR TITLE
Remove modal button and add back link.

### DIFF
--- a/app/views/catalog/librarian_view.html.erb
+++ b/app/views/catalog/librarian_view.html.erb
@@ -1,0 +1,9 @@
+<div class="modal-header">
+  <%= link_to t("blacklight.search.back"), "/catalog/#{@document.id}", :class =>"pull-right" %>
+  <h3 class="modal-title"><%= t('blacklight.search.librarian_view.title') %></h3>
+</div>
+<%- if @document.respond_to?(:to_marc) -%>
+  <%= render "marc_view" %>
+<%- else %>
+  <%= t('blacklight.search.librarian_view.empty') %>
+<%- end -%>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -5,5 +5,6 @@ en:
       library_account: "Library Account"
 
     search:
+      back: "Back to Main View"
       librarian_view:
         title: "Staff View"

--- a/spec/views/catalog/librian_view.html.erb_spec.rb
+++ b/spec/views/catalog/librian_view.html.erb_spec.rb
@@ -3,8 +3,14 @@
 require "rails_helper"
 
 RSpec.describe "catalog/librarian_view.html.erb", type: :view do
-  it "displays the correct title name"  do
+  before(:each) do
+    @document = SolrDocument.new(id: 1)
+  end
+
+  it "renders as expected"  do
     render
     expect(rendered).to match(/Staff View<\/h3>/)
+    expect(rendered).to match(/Back to Main View/)
+    expect(rendered).to_not match(/×<\/button>/)
   end
 end


### PR DESCRIPTION
REF BL-176

The staff view should allow users to go back to the regular document view.  This Changes adds a "Back to Main View" to the staff view.

QA Steps
===
* Make a search in the catalog.
* Follow a link to a document.
* Follow "Staff View" link to the staff view.
- [x] Verify that a "Back to Main View" is available.
- [x] Verify that the link takes you back to the original document
- [x] Verify that there is no longer a button labeled "x" on the page.