### PR TITLE
Use relative path for Back to Main View link.

### DIFF
--- a/app/views/catalog/librarian_view.html.erb
+++ b/app/views/catalog/librarian_view.html.erb
@@ -1,5 +1,5 @@
 <div class="modal-header">
-  <%= link_to t("blacklight.search.back"), "/catalog/#{@document.id}", :class =>"pull-right" %>
+  <%= link_to t("blacklight.search.back"), "../#{@document.id}", :class =>"pull-right" %>
   <h3 class="modal-title"><%= t('blacklight.search.librarian_view.title') %></h3>
 </div>
 <%- if @document.respond_to?(:to_marc) -%>


### PR DESCRIPTION
REF BL-176

The "Back to Main View" link does not work in
http://libqa.library.temple.edu/catalog/catalog/991024675119703811/staff_view
where the path to the catalog is double labeled.

This commit fixes this issue by making the path back to the main view
relative to the current path.

QA Steps
==
* Do a catalog search
* Follow a result link to main view
* Follow the staff view link
- [ ] Verify that the url for "Back to Main View" is a relative format link, `../:id`
- [ ] Verify that clicking on the link takes you back to the document main view.