### PR TITLE
Update creator facet and display

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -245,7 +245,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
 
     config.add_index_field "imprint_display", label: "Published"
-    config.add_index_field "creator_display", label: "Author/creator"
+    config.add_index_field "creator_display", label: "Author/Creator", helper_method: :creator_index_separator
     config.add_index_field "format", label: "Resource Type"
 
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -260,8 +260,8 @@ class CatalogController < ApplicationController
     config.add_show_field "title_addl_vern_display", label: "Additional titles"
     config.add_show_field "creator_display", label: "Author/Creator", helper_method: :browse_creator, multi: true
     config.add_show_field "creator_vern_display", label: "Author/Creator", helper_method: :browse_creator
-    config.add_show_field "contributor_vern_display", label: "Contributor", helper_method: :browse_creator
     config.add_show_field "contributor_display", label: "Contributor", helper_method: :browse_creator, multi: true
+    config.add_show_field "contributor_vern_display", label: "Contributor", helper_method: :browse_creator
     config.add_show_field "format", label: "Resource Type"
     config.add_show_field "imprint_display", label: "Published"
     config.add_show_field "edition_display", label: "Edition"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,6 +28,7 @@ module ApplicationHelper
   end
 
   def browse_creator(args)
+    #binding.pry
     creator = args[:document][args[:field]]
     creator.map do |name|
       linked_subfield = name.split("|").first.sub(/ *[ ,.\/;:] *\Z/, "")
@@ -42,10 +43,9 @@ module ApplicationHelper
   end
 
   def creator_index_separator(args)
-    #binding.pry
     creator = args[:document][args[:field]]
     creator.map do |name|
-      plain_text_subfields = name.delete("[]|")
+      plain_text_subfields = name.gsub("|", " ")
       creator = plain_text_subfields
     end
     creator

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,11 +28,25 @@ module ApplicationHelper
   end
 
   def browse_creator(args)
+    creator = args[:document][args[:field]]
+    creator.map do |name|
+      linked_subfield = name.split("|").first.sub(/ *[ ,.\/;:] *\Z/, "")
+      newname = link_to(linked_subfield, root_url + "/?f[creator_facet][]=#{linked_subfield}").html_safe
+      plain_text_subfields = name.split("|").second
+      creator = newname
+      if plain_text_subfields.present?
+        creator = newname + ", " + plain_text_subfields
+      end
+    end
+    creator
+  end
+
+  def creator_index_separator(args)
     #binding.pry
     creator = args[:document][args[:field]]
     creator.map do |name|
-      newname = link_to(name, root_url + "/?f[creator_facet][]=#{name}").html_safe
-      creator = newname
+      plain_text_subfields = name.delete("[]|")
+      creator = plain_text_subfields
     end
     creator
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,7 +28,6 @@ module ApplicationHelper
   end
 
   def browse_creator(args)
-    #binding.pry
     creator = args[:document][args[:field]]
     creator.map do |name|
       linked_subfield = name.split("|").first

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,14 +28,13 @@ module ApplicationHelper
   end
 
   def browse_creator(args)
+    #binding.pry
     creator = args[:document][args[:field]]
-    creator.each_with_index do |name, i|
-      content_tag :ul do
-        newname = link_to(name, root_url + "/?f[creator_facet][]=#{name}", class: "list_items")
-        creator = newname.html_safe
-      end
+    creator.map do |name|
+      newname = link_to(name, root_url + "/?f[creator_facet][]=#{name}").html_safe
+      creator = newname
     end
-    list_with_links(args)
+    creator
   end
 
   def check_for_full_http_link(args)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,7 @@ module ApplicationHelper
     #binding.pry
     creator = args[:document][args[:field]]
     creator.map do |name|
-      linked_subfield = name.split("|").first.sub(/ *[ ,.\/;:] *\Z/, "")
+      linked_subfield = name.split("|").first
       newname = link_to(linked_subfield, root_url + "/?f[creator_facet][]=#{linked_subfield}").html_safe
       plain_text_subfields = name.split("|").second
       creator = newname

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,7 +36,7 @@ module ApplicationHelper
       plain_text_subfields = name.split("|").second
       creator = newname
       if plain_text_subfields.present?
-        creator = newname + ", " + plain_text_subfields
+        creator = newname + " " + plain_text_subfields
       end
     end
     creator

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -124,7 +124,7 @@ to_field "location_display", extract_marc("HLDc")
 # Creator/contributor fields
 to_field "creator_t", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true)
 to_field "creator_facet", extract_marc("100abcdq:110abcd:111acdj:700abcdq:710abcd:711acdj", trim_punctuation: true)
-to_field "creator_display", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt", trim_punctuation: true, alternate_script: false)
+to_field "creator_display", extract_creator
 to_field "contributor_display", extract_marc("700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true, alternate_script: false)
 to_field "creator_vern_display", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt", trim_punctuation: true, alternate_script: :only)
 to_field "contributor_vern_display", extract_marc("700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true, alternate_script: :only)

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -126,7 +126,7 @@ to_field "creator_t", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejln
 to_field "creator_facet", extract_marc("100abcdq:110abcd:111acdj:700abcdq:710abcd:711acdj", trim_punctuation: true)
 to_field "creator_display", extract_creator
 to_field "contributor_display", extract_marc("700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true, alternate_script: false)
-to_field "creator_vern_display", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt", trim_punctuation: true, alternate_script: :only)
+to_field "creator_vern_display", extract_creator
 to_field "contributor_vern_display", extract_marc("700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true, alternate_script: :only)
 
 # Publication fields

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -126,8 +126,8 @@ to_field "creator_t", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejln
 to_field "creator_facet", extract_marc("100abcdq:110abcd:111acdj:700abcdq:710abcd:711acdj")
 to_field "creator_display", extract_creator
 to_field "contributor_display", extract_contributor
-to_field "creator_vern_display", extract_creator
-to_field "contributor_vern_display", extract_contributor
+to_field "creator_vern_display", extract_creator_vern
+to_field "contributor_vern_display", extract_contributor_vern
 
 # Publication fields
 # For the imprint, make sure to take RDA-style 264, second indicator = 1

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -123,11 +123,11 @@ to_field "location_display", extract_marc("HLDc")
 
 # Creator/contributor fields
 to_field "creator_t", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true)
-to_field "creator_facet", extract_marc("100abcdq:110abcd:111acdj:700abcdq:710abcd:711acdj", trim_punctuation: true)
+to_field "creator_facet", extract_marc("100abcdq:110abcd:111acdj:700abcdq:710abcd:711acdj")
 to_field "creator_display", extract_creator
-to_field "contributor_display", extract_marc("700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true, alternate_script: false)
+to_field "contributor_display", extract_contributor
 to_field "creator_vern_display", extract_creator
-to_field "contributor_vern_display", extract_marc("700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true, alternate_script: :only)
+to_field "contributor_vern_display", extract_contributor
 
 # Publication fields
 # For the imprint, make sure to take RDA-style 264, second indicator = 1

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -123,7 +123,7 @@ to_field "location_display", extract_marc("HLDc")
 
 # Creator/contributor fields
 to_field "creator_t", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true)
-to_field "creator_facet", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true)
+to_field "creator_facet", extract_marc("100abcdq:110abcd:111acdj:700abcdq:710abcd:711acdj", trim_punctuation: true)
 to_field "creator_display", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt", trim_punctuation: true, alternate_script: false)
 to_field "contributor_display", extract_marc("700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true, alternate_script: false)
 to_field "creator_vern_display", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt", trim_punctuation: true, alternate_script: :only)

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -25,13 +25,24 @@ module Traject
         end
       end
 
-      #100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt
+      # creator_facet = "100abcdq:110abcd:111acdj:700abcdq:710abcd:711acdj"
+      # creator_display = 100ejlmnoprtu:110elmnopt:111elnopt
 
       def extract_creator
         lambda do |rec, acc|
           rec.fields("100").each do |f|
             linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
+            acc << linked_subfields + "|" + plain_text_subfields
+          end
+          rec.fields("110").each do |f|
+            linked_subfields = [f["a"], f["b"], f["c"], f["d"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["l"], f["m"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
+            acc << linked_subfields + "|" + plain_text_subfields
+          end
+          rec.fields("111").each do |f|
+            linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
             acc << linked_subfields + "|" + plain_text_subfields
           end
         end

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -30,8 +30,8 @@ module Traject
       def extract_creator
         lambda do |rec, acc|
           rec.fields("100").each do |f|
-            linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(",")
-            plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(",")
+            linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
             acc << linked_subfields + "|" + plain_text_subfields
           end
         end

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -45,6 +45,26 @@ module Traject
         end
       end
 
+      def extract_creator_vern
+        lambda do |rec, acc|
+          MarcExtractor.cached("100abcdejlmnopqrtu", alternate_script: :only).collect_matching_lines(rec) do |f|
+            linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
+            acc << linked_subfields + "|" + plain_text_subfields
+          end
+          MarcExtractor.cached("110abcdelmnopt", alternate_script: :only).collect_matching_lines(rec) do |f|
+            linked_subfields = [f["a"], f["b"], f["c"], f["d"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["l"], f["m"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
+            acc << linked_subfields + "|" + plain_text_subfields
+          end
+          MarcExtractor.cached("111acdejlnopt", alternate_script: :only).collect_matching_lines(rec) do |f|
+            linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
+            acc << linked_subfields + "|" + plain_text_subfields
+          end
+        end
+      end
+
       def extract_contributor
         lambda do |rec, acc|
           rec.fields("700").each do |f|
@@ -58,6 +78,26 @@ module Traject
             acc << linked_subfields + "|" + plain_text_subfields
           end
           rec.fields("711").each do |f|
+            linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
+            acc << linked_subfields + "|" + plain_text_subfields
+          end
+        end
+      end
+
+      def extract_contributor_vern
+        lambda do |rec, acc|
+          MarcExtractor.cached("700abcdejlmnopqrtu", alternate_script: :only).collect_matching_lines(rec) do |f|
+            linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
+            acc << linked_subfields + "|" + plain_text_subfields
+          end
+          MarcExtractor.cached("710abcdelmnopt", alternate_script: :only).collect_matching_lines(rec) do |f|
+            linked_subfields = [f["a"], f["b"], f["c"], f["d"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["l"], f["m"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
+            acc << linked_subfields + "|" + plain_text_subfields
+          end
+          MarcExtractor.cached("711acdejlnopt", alternate_script: :only).collect_matching_lines(rec) do |f|
             linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
             acc << linked_subfields + "|" + plain_text_subfields

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -25,9 +25,6 @@ module Traject
         end
       end
 
-      # creator_facet = "100abcdq:110abcd:111acdj:700abcdq:710abcd:711acdj"
-      # creator_display = 100ejlmnoprtu:110elmnopt:111elnopt
-
       def extract_creator
         lambda do |rec, acc|
           rec.fields("100").each do |f|
@@ -41,6 +38,26 @@ module Traject
             acc << linked_subfields + "|" + plain_text_subfields
           end
           rec.fields("111").each do |f|
+            linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
+            acc << linked_subfields + "|" + plain_text_subfields
+          end
+        end
+      end
+
+      def extract_contributor
+        lambda do |rec, acc|
+          rec.fields("700").each do |f|
+            linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
+            acc << linked_subfields + "|" + plain_text_subfields
+          end
+          rec.fields("710").each do |f|
+            linked_subfields = [f["a"], f["b"], f["c"], f["d"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["l"], f["m"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
+            acc << linked_subfields + "|" + plain_text_subfields
+          end
+          rec.fields("711").each do |f|
             linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
             acc << linked_subfields + "|" + plain_text_subfields

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -25,6 +25,18 @@ module Traject
         end
       end
 
+      #100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt
+
+      def extract_creator
+        lambda do |rec, acc|
+          rec.fields("100").each do |f|
+            linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(",")
+            plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(",")
+            acc << linked_subfields + "|" + plain_text_subfields
+          end
+        end
+      end
+
       def extract_electronic_resource
         lambda do |rec, acc|
           rec.fields("PRT").each do |f|

--- a/spec/features/indices_spec.rb
+++ b/spec/features/indices_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature "Indices", type: :feature do
         expect(page).to have_text :title
         expect(page).to have_text "Resource Type:"
         expect(page).to have_text "Book"
-        expect(page).to have_text "Author/creator:"
+        expect(page).to have_text "Author/Creator:"
         expect(page).to have_text "Published:"
         has_css?(".avail-button", visible: true)
       end

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -1100,22 +1100,6 @@ RSpec.feature "RecordPageFields", type: :feature do
   end
 
   feature "Multiple value fields display as a list" do
-    let (:item_100) { fixtures.fetch("creator_100") }
-    scenario "Has list of creators" do
-      visit "catalog/#{item_100['doc_id']}"
-      within "dd.blacklight-creator_display" do
-        expect(page).to have_css("li.list_items")
-      end
-    end
-
-    let (:item_100_v) { fixtures.fetch("creator_100_v") }
-    scenario "Has list of creators" do
-      visit "catalog/#{item_100_v['doc_id']}"
-      within "dd.blacklight-creator_display" do
-        expect(page).to have_css("li.list_items")
-      end
-    end
-
     let (:note_500) { fixtures.fetch("note_500") }
     scenario "Has list of notes" do
       visit "catalog/#{note_500['doc_id']}"

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -39,7 +39,7 @@ title_addl_740:
   title_addl: "Dictionary of American history: 740. Subfield N. Subfield P."
 creator_100:
   doc_id: "991012132499760617"
-  creator: "Giovanni, Nikki. Subfield B. Subfield C. Subfield D. Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield T. Subfield U."
+  creator: "Giovanni, Nikki. Subfield B. Subfield C. Subfield D. Subfield Q. Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield R. Subfield T. Subfield U."
 creator_100_v:
   doc_id: "991012172649703811"
   creator_vern: "מעקלער, ד.ל."
@@ -48,7 +48,7 @@ creator_110:
   creator: "Dictionary of American history: 110. Subfield B. Subfield C. Subfield D. Subfield E. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield T."
 creator_111:
   doc_id: "991012132499760619"
-  creator: "Dictionary of American history: 111. Subfield C. Subfield D. Subfield E. Subfield J. Subfield L. Subfield N. Subfield O. Subfield P. Subfield T."
+  creator: "Dictionary of American history: 111. Subfield C. Subfield D. Subfield J. Subfield E.  Subfield L. Subfield N. Subfield O. Subfield P. Subfield T."
 contributor_700:
   doc_id: "991012132499760620"
   creator: "Dictionary of American history: 700. Subfield B. Subfield C. Subfield D. Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield T. Subfield U."


### PR DESCRIPTION
BL-45 and BL-91 relating to creator facets and display
- update creator_facet mappings in traject 
- update links in the creator display so that they only link to the creator_facet. 
- non-facet data displays as plain text
- add helper method so that plain text displays are correct in the index view
- update specs based on new mappings
- see http://localhost:3006/catalog/991020062159703811 for example
- Platini, Giacomo should link to author_creator facet results
- composer should display as plain text
![screen shot 2017-12-07 at 11 11 10 am](https://user-images.githubusercontent.com/15167238/33725172-5eaf9954-db3f-11e7-9151-ea5b40787c40.png)
