### PR TITLE
Bl 207 solr display fields

### DIFF
--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -45,7 +45,7 @@ to_field("format", marc_formats, &normalize_format)
 # Title fields
 # primary title
 to_field "title_t", extract_marc("245a")
-to_field "title_display", extract_marc("245a", trim_punctuation: true, alternate_script: false), &to_single_string
+to_field "title_display", extract_marc("245abnpkfg", trim_punctuation: true, alternate_script: false), &to_single_string
 to_field "title_vern_display", extract_marc("245a", trim_punctuation: true, alternate_script: :only)
 to_field "title_statement_display", extract_marc("245abcfgknps", alternate_script: false)
 to_field "title_statement_vern_display", extract_marc("245abcfgknps", alternate_script: :only)
@@ -150,7 +150,7 @@ to_field "performance_display", extract_marc("382abdenprst")
 to_field "music_no_display", extract_marc("383abcde")
 
 # Series fields
-to_field "title_series_display", extract_marc("830av:490av:440anpv", alternate_script: false)
+to_field "title_series_display", extract_marc("830av:490av:440anpv:800abcdefghjklmnopqrstuv:810abcdeghklmnoprstuv:811acdefghjklnpqstuv", alternate_script: false)
 to_field "title_series_vern_display", extract_marc("830a:490a:440anp", alternate_script: :only)
 # to_field "date_series", extract_marc("362a")
 to_field "volume_series_display", extract_marc("830v:490v:440v")

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -45,7 +45,7 @@ to_field("format", marc_formats, &normalize_format)
 # Title fields
 # primary title
 to_field "title_t", extract_marc("245a")
-to_field "title_display", extract_marc("245abnpkfg", trim_punctuation: true, alternate_script: false), &to_single_string
+to_field "title_display", extract_marc("245a", trim_punctuation: true, alternate_script: false), &to_single_string
 to_field "title_vern_display", extract_marc("245a", trim_punctuation: true, alternate_script: :only)
 to_field "title_statement_display", extract_marc("245abcfgknps", alternate_script: false)
 to_field "title_statement_vern_display", extract_marc("245abcfgknps", alternate_script: :only)

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -156,7 +156,7 @@ to_field "title_series_vern_display", extract_marc("830a:490a:440anp", alternate
 to_field "volume_series_display", extract_marc("830v:490v:440v")
 
 # Note fields
-to_field "note_display", extract_marc("500a:508a:511a:515a:518a:521ab:530abcd:533abcdefmn:534pabcefklmnt:538aiu:546ab:550a:586a:588a")
+to_field "note_display", extract_marc("500a:508a:511a:515a:518a:521ab:525a:530abcd:533abcdefmn:534pabcefklmnt:538aiu:546ab:550a:586a:588a")
 to_field "note_with_display", extract_marc("501a")
 to_field "note_diss_display", extract_marc("502abcdgo")
 to_field "note_biblio_display", extract_marc("504a")

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -192,8 +192,13 @@ module Traject
 
       def extract_copyright
         lambda do |rec, acc|
+          rec.fields(["260"]).each do |field|
+            unless field["c"].nil?
+              acc << four_digit_year(field["c"]) if field["c"].include?("c") || field["c"].include?("p") || field["c"].include?("\u00A9")
+            end
+          end
           rec.fields(["264"]).each do |field|
-            acc << four_digit_year(field["c"])  if field.indicator2 == "4"
+            acc << four_digit_year(field["c"]) if field.indicator2 == "4"
           end
         end
       end

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -217,6 +217,36 @@ RSpec.feature "RecordPageFields", type: :feature do
   end
 
   feature "MARC Copyright notice date" do
+    let (:item_260_c) { fixtures.fetch("imprint_260_c") }
+    scenario "User visits a document with date_copyright including 'c'" do
+      visit "catalog/#{item_260_c['doc_id']}"
+      within "dd.blacklight-date_copyright_display" do
+        expect(page).to have_text(item_260_c["date_copyright"])
+      end
+    end
+
+    let (:item_260_p) { fixtures.fetch("imprint_260_p") }
+    scenario "User visits a document with date_copyright including 'p'" do
+      visit "catalog/#{item_260_p['doc_id']}"
+      within "dd.blacklight-date_copyright_display" do
+        expect(page).to have_text(item_260_p["date_copyright"])
+      end
+    end
+
+    let (:item_260_copyright) { fixtures.fetch("imprint_260_copyright") }
+    scenario "User visits a document with date_copyright including copyright symbol" do
+      visit "catalog/#{item_260_copyright['doc_id']}"
+      within "dd.blacklight-date_copyright_display" do
+        expect(page).to have_text(item_260_copyright["date_copyright"])
+      end
+    end
+
+    let (:item_260_year_only) { fixtures.fetch("imprint_260_year_only") }
+    scenario "User visits a document including year only in subfield 'c'" do
+      visit "catalog/#{item_260_year_only['doc_id']}"
+        expect(page).to_not have_css("dd.blacklight-date_copyright_display")
+    end
+
     let (:item_264) { fixtures.fetch("imprint_264") }
     scenario "User visits a document with date_copyright" do
       visit "catalog/#{item_264['doc_id']}"

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -521,6 +521,14 @@ RSpec.feature "RecordPageFields", type: :feature do
       end
     end
 
+    let (:item_525) { fixtures.fetch("note_525") }
+    scenario "User visits a document with note" do
+      visit "catalog/#{item_525['doc_id']}"
+      within "dd.blacklight-note_display" do
+        expect(page).to have_text(item_525["note"])
+      end
+    end
+
     let (:item_530) { fixtures.fetch("note_530") }
     scenario "User visits a document with note" do
       visit "catalog/#{item_530['doc_id']}"

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -305,6 +305,30 @@ RSpec.feature "RecordPageFields", type: :feature do
       end
     end
 
+    let (:item_800) { fixtures.fetch("title_series_800") }
+    scenario "User visits a document with series title" do
+      visit "catalog/#{item_800['doc_id']}"
+      within "dd.blacklight-title_series_display" do
+        expect(page).to have_text(item_800["title_series"])
+      end
+    end
+
+    let (:item_810) { fixtures.fetch("title_series_810") }
+    scenario "User visits a document with series title" do
+      visit "catalog/#{item_810['doc_id']}"
+      within "dd.blacklight-title_series_display" do
+        expect(page).to have_text(item_810["title_series"])
+      end
+    end
+
+    let (:item_811) { fixtures.fetch("title_series_811") }
+    scenario "User visits a document with series title" do
+      visit "catalog/#{item_811['doc_id']}"
+      within "dd.blacklight-title_series_display" do
+        expect(page).to have_text(item_811["title_series"])
+      end
+    end
+
     let (:item_830) { fixtures.fetch("title_series_830") }
     scenario "User visits a document with series title vernacular" do
       visit "catalog/#{item_830['doc_id']}"

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -64,6 +64,18 @@ contributor_700_v:
 imprint_260:
   doc_id: "991012132499760623"
   imprint: "Dictionary of American history: 260. Subfield B. Subfield C. Subfield E. Subfield F. Subfield G. Subfield 3."
+imprint_260_c:
+  doc_id: "991012181699703811"
+  date_copyright: "2005"
+imprint_260_p:
+  doc_id: "991012032049703811"
+  date_copyright: "1983"
+imprint_260_copyright:
+  doc_id: "991012032209703811"
+  date_copyright: "1983"
+imprint_260_year_only:
+  doc_id: "991012036199703811"
+  date_copyright: "1979"
 imprint_264:
   doc_id: "991012163279703811"
   imprint: "Santa Barbara, California : Santa Barbara Museum of Art, 2016."

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -171,6 +171,9 @@ note_518:
 note_521:
   doc_id: "991012132499760645"
   note: "Dictionary of American history: 521. Subfield B."
+note_525:
+  doc_id: "991012036199703811"
+  note: "Translation of Fuchs über Ernst Fuchs. Subfield a."
 note_530:
   doc_id: "991012132499760646"
   note: "Dictionary of American history: 530. Subfield B. Subfield C. Subfield D."

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -106,6 +106,17 @@ title_series_490:
 title_series_440:
   doc_id: "991012132499760631"
   title_series: "Dictionary of American history: 440. Subfield N. Subfield P. Subfield V."
+title_series_800:
+  doc_id: "991012171319703811"
+  title_series: "United States. Congress. Senate. Subfield d. Subfield e. Subfield f. Subfield g. Subfield h. Subfield j. Subfield k. Subfield l. Subfield m. Subfield n. Subfield o. Subfield p. Subfield q. Subfield r. Subfield s. Executive report ; Subfield u. 109-5."
+title_series_810:
+  doc_id: "991012171179703811"
+  title_series: "United States. Congress. Senate. Subfield d. Subfield e.  Subfield g. Subfield h. Subfield k. Subfield l. Subfield m. Subfield n. Subfield o. Subfield p. Subfield r. Subfield s. Executive report ; Subfield u. 109-5."
+
+title_series_811:
+  doc_id: "991012177359703811"
+  title_series: "United States. Senate. Subfield d. Subfield e. Subfield f.  Subfield g. Subfield h. Subfield j. Subfield k. Subfield l.  Subfield n. Subfield p. Subfield q. Subfield s. Executive report ; Subfield u. 109-5."
+
 duration_306:
   doc_id: "991012132499760632"
   duration: "Dictionary of American history: 306."

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -1555,6 +1555,9 @@
     <datafield ind1=' ' ind2=' ' tag='500'>
       <subfield code='a'>Translation of Fuchs über Ernst Fuchs.</subfield>
     </datafield>
+    <datafield ind1=' ' ind2=' ' tag='525'>
+      <subfield code='a'>Subfield a.</subfield>
+    </datafield>
     <datafield ind1='1' ind2='0' tag='600'>
       <subfield code='a'>Fuchs, Ernst,</subfield>
       <subfield code='d'>1930-2015</subfield>

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -20128,6 +20128,29 @@
       <subfield code='a'>Andaloro, Maria,</subfield>
       <subfield code='e'>editor.</subfield>
     </datafield>
+    <datafield ind1='1' ind2=' ' tag='800'>
+      <subfield code='a'>United States.</subfield>
+      <subfield code='b'>Congress.</subfield>
+      <subfield code='c'>Senate.</subfield>
+      <subfield code='d'>Subfield d.</subfield>
+      <subfield code='e'>Subfield e.</subfield>
+      <subfield code='f'>Subfield f.</subfield>
+      <subfield code='g'>Subfield g.</subfield>
+      <subfield code='h'>Subfield h.</subfield>
+      <subfield code='j'>Subfield j.</subfield>
+      <subfield code='k'>Subfield k.</subfield>
+      <subfield code='l'>Subfield l.</subfield>
+      <subfield code='m'>Subfield m.</subfield>
+      <subfield code='n'>Subfield n.</subfield>
+      <subfield code='o'>Subfield o.</subfield>
+      <subfield code='p'>Subfield p.</subfield>
+      <subfield code='q'>Subfield q.</subfield>
+      <subfield code='r'>Subfield r.</subfield>
+      <subfield code='s'>Subfield s.</subfield>
+      <subfield code='t'>Executive report ;</subfield>
+      <subfield code='u'>Subfield u.</subfield>
+      <subfield code='v'>109-5.</subfield>
+    </datafield>
     <datafield ind1='4' ind2='2' tag='856'>
       <subfield code='z'>Access table of contents</subfield>
       <subfield code='u'>http://www.liberdomus.it/liberdomus/nrdcc/abstracts/D0121052122.pdf</subfield>
@@ -20230,10 +20253,6 @@
       <subfield code='a'>3 p. ;</subfield>
       <subfield code='c'>24 cm.</subfield>
     </datafield>
-    <datafield ind1='1' ind2=' ' tag='490'>
-      <subfield code='a'>Exec. rept. / 109th Congress, 1st session, Senate ;</subfield>
-      <subfield code='v'>109-5</subfield>
-    </datafield>
     <datafield ind1=' ' ind2=' ' tag='500'>
       <subfield code='a'>Caption title.</subfield>
     </datafield>
@@ -20285,8 +20304,21 @@
     <datafield ind1='1' ind2=' ' tag='810'>
       <subfield code='a'>United States.</subfield>
       <subfield code='b'>Congress.</subfield>
-      <subfield code='b'>Senate.</subfield>
+      <subfield code='c'>Senate.</subfield>
+      <subfield code='d'>Subfield d.</subfield>
+      <subfield code='e'>Subfield e.</subfield>
+      <subfield code='g'>Subfield g.</subfield>
+      <subfield code='h'>Subfield h.</subfield>
+      <subfield code='k'>Subfield k.</subfield>
+      <subfield code='l'>Subfield l.</subfield>
+      <subfield code='m'>Subfield m.</subfield>
+      <subfield code='n'>Subfield n.</subfield>
+      <subfield code='o'>Subfield o.</subfield>
+      <subfield code='p'>Subfield p.</subfield>
+      <subfield code='r'>Subfield r.</subfield>
+      <subfield code='s'>Subfield s.</subfield>
       <subfield code='t'>Executive report ;</subfield>
+      <subfield code='u'>Subfield u.</subfield>
       <subfield code='v'>109-5.</subfield>
     </datafield>
     <datafield ind1='4' ind2='1' tag='856'>
@@ -20429,6 +20461,25 @@
     <datafield ind1=' ' ind2='0' tag='650'>
       <subfield code='a'>Large astronomical telescopes</subfield>
       <subfield code='z'>United States.</subfield>
+    </datafield>
+    <datafield ind1='1' ind2=' ' tag='811'>
+      <subfield code='a'>United States.</subfield>
+      <subfield code='c'>Senate.</subfield>
+      <subfield code='d'>Subfield d.</subfield>
+      <subfield code='e'>Subfield e.</subfield>
+      <subfield code='f'>Subfield f.</subfield>
+      <subfield code='g'>Subfield g.</subfield>
+      <subfield code='h'>Subfield h.</subfield>
+      <subfield code='j'>Subfield j.</subfield>
+      <subfield code='k'>Subfield k.</subfield>
+      <subfield code='l'>Subfield l.</subfield>
+      <subfield code='n'>Subfield n.</subfield>
+      <subfield code='p'>Subfield p.</subfield>
+      <subfield code='q'>Subfield q.</subfield>
+      <subfield code='s'>Subfield s.</subfield>
+      <subfield code='t'>Executive report ;</subfield>
+      <subfield code='u'>Subfield u.</subfield>
+      <subfield code='v'>109-5.</subfield>
     </datafield>
     <datafield ind1='4' ind2='1' tag='856'>
       <subfield code='u'>http://purl.access.gpo.gov/GPO/LPS65514</subfield>

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -649,7 +649,7 @@
     <datafield ind1=' ' ind2=' ' tag='260'>
       <subfield code='a'>New York, N.Y. :</subfield>
       <subfield code='b'>Praeger,</subfield>
-      <subfield code='c'>1983.</subfield>
+      <subfield code='c'>©1983.</subfield>
     </datafield>
     <datafield ind1=' ' ind2=' ' tag='300'>
       <subfield code='a'>xii, 355 p. :</subfield>
@@ -770,7 +770,7 @@
       <subfield code='b'>D. Reidel ;</subfield>
       <subfield code='a'>Hingham, MA :</subfield>
       <subfield code='b'>Sold and distributed in the U.S.A. by Kluwer Boston,</subfield>
-      <subfield code='c'>1983.</subfield>
+      <subfield code='c'>p1983.</subfield>
     </datafield>
     <datafield ind1=' ' ind2=' ' tag='300'>
       <subfield code='a'>xii, 237 p. :</subfield>


### PR DESCRIPTION
BL-207 Update mappings for title_series_display, date_copyright_display, and note_display fields
- title_series: Add several new fields and create specs for them
- date_copyright: Update logic in the extract_copyright macro to include records with a "c", "p", or copyright symbol in 260c and create tests for each case.
- note_display:  Add the 525a field and create test.