### PR TITLE
Bl 203 advanced facets

### DIFF
--- a/app/assets/javascripts/tulcob.js.coffee
+++ b/app/assets/javascripts/tulcob.js.coffee
@@ -3,7 +3,4 @@ $(document).on "turbolinks:load", ->
   $('.chosen-select').chosen
     allow_single_deselect: true
     no_results_text: 'No results matched'
-    width: '250px'
-
-
-  $('select').trigger 'chosen:updated'
+    width: '100%'

--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -61,7 +61,7 @@ input[type="radio"] + label {
 }
 
 .chosen-container-multi .chosen-choices {
-  border-radius: 4px;
+  border-radius: 4px !important;
   min-height: 34px;
   padding: 0 5px 3.25px;
 }

--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -28,7 +28,7 @@
 
 /* === LISTS === */
 
-ul {
+dd ul {
   display: table;
   list-style: none;
   margin: 0;
@@ -65,11 +65,6 @@ input[type="radio"] + label {
   min-height: 34px;
   padding: 0 5px 3.25px;
 }
-
-.chosen-container {
-  margin-left: 20px;
-}
-
 /* === AVAILABILITY === */
 
 .availability {

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -20,7 +20,7 @@ class CatalogController < ApplicationController
     config.advanced_search[:url_key] ||= "advanced"
     config.advanced_search[:query_parser] ||= "dismax"
     config.advanced_search[:form_solr_parameters] ||= {}
-    config.advanced_search[:form_solr_parameters]["facet.field"] ||= %w(format library_facet)
+    config.advanced_search[:form_solr_parameters]["facet.field"] ||= %w(format library_facet language_facet availability_facet)
 
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/app/views/advanced/_advanced_search_facets.html.erb
+++ b/app/views/advanced/_advanced_search_facets.html.erb
@@ -1,11 +1,11 @@
 <% facets_from_request(facet_field_names).each do |display_facet| %>
 
-  <div class="form-group limit-input">
+  <div class="form-group advanced-search-facet row">
     <%= label_tag display_facet.name.parameterize, :class => "col-sm-3 control-label" do %>
       <%= facet_field_label(display_facet.name) %>
     <% end %>
-      <%= content_tag(:select,
-        :multiple => true,
+    <div class="col-sm-4">
+      <%= content_tag(:select, :multiple => true,
         :name   => "f_inclusive[#{display_facet.name}][]",
         :id     => display_facet.name.parameterize,
         :class  => "form-control custom-select chosen-select",
@@ -16,6 +16,6 @@
           <% end %>
         <% end %>
       <% end %>
+    </div>
   </div>
-
 <% end %>


### PR DESCRIPTION
BL-203 Add availability and language facets to advanced search.  I realized the chosen gem styles weren't applying, so made some changes to the css to get it working.  Facets should display in this order: 
![screen shot 2017-12-13 at 12 58 51 pm](https://user-images.githubusercontent.com/15167238/33954169-6d1c7032-e005-11e7-8341-f235d04fa9f4.png)
