### PR TITLE
Add a precision operator to advanced searches.

### DIFF
--- a/.docker/cli/Dockerfile
+++ b/.docker/cli/Dockerfile
@@ -1,0 +1,10 @@
+FROM tulcob_app:latest
+
+RUN apt-get update -qq \
+      && apt-get install -y vim ctags tmux \
+      && apt-get clean \
+      && cd; wget -qO - https://raw.github.com/dkinzer/.vim/master/deploy.sh | bash
+
+WORKDIR /tul_cob
+
+CMD ["bash"]

--- a/.docker/sp/Dockerfile
+++ b/.docker/sp/Dockerfile
@@ -1,22 +1,13 @@
-FROM ruby:2.4.1
+FROM tulcob_app:latest
 
 RUN apt-get update -qq \
       && apt-get install -y \
-      build-essential \
-      libpq-dev \
-      nodejs \
       apache2 \
       libapache2-mod-shib2 \
       libapache2-mod-passenger \
       && apt-get clean \
       && a2enmod ssl \
       && a2enmod proxy_http
-
-ADD Gemfile .
-
-ADD Gemfile.lock .
-
-RUN bundle install
 
 WORKDIR /var/www/html/tul_cob
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -21,6 +21,7 @@ class CatalogController < ApplicationController
     config.advanced_search[:query_parser] ||= "dismax"
     config.advanced_search[:form_solr_parameters] ||= {}
     config.advanced_search[:form_solr_parameters]["facet.field"] ||= %w(format library_facet language_facet availability_facet)
+    config.advanced_search[:fields_row_count] = 3
 
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -28,6 +28,10 @@ module AdvancedHelper
       op == "AND"
     end
   end
+
+  def advanced_search_config
+    blacklight_config.fetch(:advanced_search, {})
+  end
 end
 
 module BlacklightAdvancedSearch
@@ -37,11 +41,11 @@ module BlacklightAdvancedSearch
     def keyword_op
       # NOTs get added to the query. Only AND/OR are operations
       @keyword_op = []
-      unless @params[:q1].blank? || @params[:q2].blank? || @params[:op2] == "NOT"
-        @keyword_op << @params[:op2] if @params[:f1] != @params[:f2]
+      unless @params[:q_1].blank? || @params[:q_2].blank? || @params[:op_1] == "NOT"
+        @keyword_op << @params[:op_1] if @params[:f_1] != @params[:f_2]
       end
-      unless @params[:q3].blank? || @params[:op3] == "NOT" || (@params[:q1].blank? && @params[:q2].blank?)
-        @keyword_op << @params[:op3] unless [@params[:f1], @params[:f2]].include?(@params[:f3]) && ((@params[:f1] == @params[:f3] && !@params[:q1].blank?) || (@params[:f2] == @params[:f3] && !@params[:q2].blank?))
+      unless @params[:q_3].blank? || @params[:op_2] == "NOT" || (@params[:q_1].blank? && @params[:q_2].blank?)
+        @keyword_op << @params[:op_2] unless [@params[:f_1], @params[:f_2]].include?(@params[:f_3]) && ((@params[:f_1] == @params[:f_3] && !@params[:q_1].blank?) || (@params[:f_2] == @params[:f_3] && !@params[:q_2].blank?))
       end
       @keyword_op
     end
@@ -52,30 +56,30 @@ module BlacklightAdvancedSearch
 
         return @keyword_queries unless @params[:search_field] == ::AdvancedController.blacklight_config.advanced_search[:url_key]
 
-        q1 = @params[:q1]
-        q2 = @params[:q2]
-        q3 = @params[:q3]
+        q1 = @params[:q_1]
+        q2 = @params[:q_2]
+        q3 = @params[:q_3]
 
         been_combined = false
-        @keyword_queries[@params[:f1]] = q1 unless @params[:q1].blank?
-        unless @params[:q2].blank?
-          if @keyword_queries.key?(@params[:f2])
-            @keyword_queries[@params[:f2]] = "(#{@keyword_queries[@params[:f2]]}) " + @params[:op2] + " (#{q2})"
+        @keyword_queries[@params[:f_1]] = q1 unless @params[:q_1].blank?
+        unless @params[:q_2].blank?
+          if @keyword_queries.key?(@params[:f_2])
+            @keyword_queries[@params[:f_2]] = "(#{@keyword_queries[@params[:f_2]]}) " + @params[:op_1] + " (#{q2})"
             been_combined = true
-          elsif @params[:op2] == "NOT"
-            @keyword_queries[@params[:f2]] = "NOT " + q2
+          elsif @params[:op_1] == "NOT"
+            @keyword_queries[@params[:f_2]] = "NOT " + q2
           else
-            @keyword_queries[@params[:f2]] = q2
+            @keyword_queries[@params[:f_2]] = q2
           end
         end
-        unless @params[:q3].blank?
-          if @keyword_queries.key?(@params[:f3])
-            @keyword_queries[@params[:f3]] = "(#{@keyword_queries[@params[:f3]]})" unless been_combined
-            @keyword_queries[@params[:f3]] = "#{@keyword_queries[@params[:f3]]} " + @params[:op3] + " (#{q3})"
-          elsif @params[:op3] == "NOT"
-            @keyword_queries[@params[:f3]] = "NOT " + q3
+        unless @params[:q_3].blank?
+          if @keyword_queries.key?(@params[:f_3])
+            @keyword_queries[@params[:f_3]] = "(#{@keyword_queries[@params[:f_3]]})" unless been_combined
+            @keyword_queries[@params[:f_3]] = "#{@keyword_queries[@params[:f_3]]} " + @params[:op_2] + " (#{q3})"
+          elsif @params[:op_2] == "NOT"
+            @keyword_queries[@params[:f_3]] = "NOT " + q3
           else
-            @keyword_queries[@params[:f3]] = q3
+            @keyword_queries[@params[:f_3]] = q3
           end
         end
       end
@@ -133,9 +137,9 @@ module BlacklightAdvancedSearch
         .select { |q, v| ! my_params[q].blank? }
         .map { |q, v|
 
-        position = q.to_s.scan(/\d+$/)[0]
-        f = "f#{position}".to_sym
-        op = "op#{position}".to_sym
+        position = q.to_s.scan(/_\d+$/)[0]
+        f = "f_#{position}".to_sym
+        op = "op_#{position}".to_sym
         field = search_field_def_for_key(my_params[f]).to_h
         label = field[:label].to_s
         query = my_params[op].to_s + " " + my_params[q]

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -3,14 +3,115 @@
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
-  self.default_processor_chain += %i[add_advanced_parse_q_to_solr add_advanced_search_to_solr]
   include BlacklightRangeLimit::RangeLimitBuilder
 
-  ##
-  # @example Adding a new step to the processor chain
-  #   self.default_processor_chain += [:add_custom_data_to_query]
-  #
-  #   def add_custom_data_to_query(solr_parameters)
-  #     solr_parameters[:custom] = blacklight_params[:user_value]
-  #   end
+  BEGINS_WITH_TAG = "matchbeginswith"
+  ENDS_WITH_TAG = "matchendswith"
+
+  self.default_processor_chain +=
+    %i[add_advanced_parse_q_to_solr add_advanced_search_to_solr ] +
+    # Process order matters; :begins_with_search assumes :exact_phrase_search
+    # happens after it, see the note for :to_phrase method for extra context.
+    [ :begins_with_search ] +
+    [ :exact_phrase_search ]
+
+
+  def begins_with_search(solr_parameters)
+    dereference_with(:append_start_flank, solr_parameters)
+  end
+
+  def exact_phrase_search(solr_parameters)
+    dereference_with(:to_phrase, solr_parameters)
+  end
+
+  private
+
+    def dereference_with(method, solr_parameters)
+      query = solr_parameters["q"] || ""
+      params = get_params
+
+      # Search misbehaves if we alter non advanced search query.
+      if !query.empty? && !params.empty? && params["search_field"] == "advanced"
+
+        # We need the original values in the search for use in creating
+        # a de-referenced version of the query.
+        fields = get_params.select { |k| k.match(/^q_/) }
+
+        # We de-reference values in order to be able to quote them; otherwise,
+        # solr throws a 500 error: https://stackoverflow.com/a/10183238/256854
+        #
+        # First we generate something like:
+        # [[["{}", "foo", "AND"], "q_1"], [["{}", "bar", "OR"], "q_2"]]
+        # And then we map that to ["_query_:..", "_query_:..."]
+        # @see :parse_queries, and :param_dereference methods below for more
+        # details.
+        queries = parse_queries(solr_parameters["q"])
+          .zip(fields.keys)
+          .map { |q, k| param_dereference(q, k) }
+        solr_parameters["q"] = queries.join(" ")
+
+        # De-referenced values have to be added as solr request parameters.
+        ops = params.fetch("op_row", [])
+        ops.zip(fields).each { |op, f|
+          k, v = f
+          solr_parameters[k] = send(method, v, op)
+        }
+
+      end
+    end
+
+    def append_start_flank(value, op)
+      return if value.nil?
+
+      # value is always fresh from params so we don't have to worry about
+      # process duplication/mutation but we do have to reapply processes.
+      if op == "begins_with"
+        to_phrase("#{BEGINS_WITH_TAG} #{value}", "is")
+      else
+        value
+      end
+    end
+
+    def to_phrase(value, op)
+      return if value.nil?
+
+      # value is always fresh from params so we don't have to worry about
+      # process duplication/mutation but we do have to reapply processes.
+      if op == "is"
+        "\"#{value}\""
+      elsif op == "begins_with"
+        append_start_flank(value, op)
+      else
+        value
+      end
+    end
+
+    # Given a blacklight solr query string in the form
+    # "_query_:\"{}foo\" (AND|OR|NOT) (__query:\"{}bar\")..."
+    # parses it to return an array of query components:
+    # [["{}", "foo", AND], ["{}", "bar", nil]]
+    def parse_queries(query_string)
+      query_string.split("_query_:")
+        .select { |q| q[0..1] == "\"{" }
+        .map { |q| q.scan(/{(.*)}(.*)\".?(AND|OR|NOT)?/) }
+        .map { |q| q.flatten }
+    end
+
+    # Given an array q representing the components of a single query:
+    # i.e. ["{}", "foo", "AND"], generates a new string representation
+    # of the query.
+    # @see https://lucene.apache.org/solr/guide/6_6/local-parameters-in-queries.html
+    # For details on local parameter dereferencing syntax.
+    def param_dereference(q, k)
+      local_param, _, connector = q
+      "_query_:\"{#{local_param} v=$#{k}}\" #{connector}"
+    end
+
+    def get_params
+      if scope.respond_to? :params
+        scope.params || {}
+      else
+        {}
+      end
+    end
 end

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -51,10 +51,10 @@ to_field "title_uniform_vern_display", extract_marc("130adfklmnoprs:240adfklmnop
 to_field "title_addl_display", extract_marc("210ab:246abfgnp:247abcdefgnp:740anp", alternate_script: false)
 to_field "title_addl_vern_display", extract_marc("210ab:246abfgnp:247abcdefgnp:740anp", alternate_script: :only)
 
-to_field "title_t", extract_marc("245a")
-to_field "subtitle_t", extract_marc("245b")
-to_field "title_statement_t", extract_marc("245abfgknps")
-to_field "title_uniform_t", extract_marc("130adfklmnoprs:240adfklmnoprs:730abcdefgklmnopqrst")
+to_field "title_t", extract_marc_with_flank("245a")
+to_field "subtitle_t", extract_marc_with_flank("245b")
+to_field "title_statement_t", extract_marc_with_flank("245abfgknps")
+to_field "title_uniform_t", extract_marc_with_flank("130adfklmnoprs:240adfklmnoprs:730abcdefgklmnopqrst")
 
 ATOZ = ("a".."z").to_a.join("")
 ATOU = ("a".."u").to_a.join("")
@@ -68,7 +68,7 @@ to_field "title_addl_t",
     247abcdefgnp
     740anp
                }.join(":"))
-to_field "title_added_entry_t", extract_marc(%W{
+to_field "title_added_entry_t", extract_marc_with_flank(%W{
   700gklmnoprst
   710fgklmnopqrst
   711fgklnpst
@@ -77,14 +77,14 @@ to_field "title_added_entry_t", extract_marc(%W{
 to_field "title_sort", marc_sortable_title
 
 # Creator/contributor fields
-to_field "creator_t", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true)
+to_field "creator_t", extract_marc_with_flank("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true)
 to_field "creator_facet", extract_marc("100abcdq:110abcd:111acdj:700abcdq:710abcd:711acdj")
 to_field "creator_display", extract_creator
 to_field "contributor_display", extract_contributor
 to_field "creator_vern_display", extract_creator_vern
 to_field "contributor_vern_display", extract_contributor_vern
 
-to_field "creator_t", extract_marc("245c:100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejqu:710abcde:711acdej", trim_punctuation: true)
+to_field "creator_t", extract_marc_with_flank("245c:100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejqu:710abcde:711acdej", trim_punctuation: true)
 to_field "author_sort", marc_sortable_author
 
 # Publication fields
@@ -95,8 +95,8 @@ to_field "edition_display", extract_marc("250a:254a", trim_punctuation: true, al
 to_field "pub_date", extract_pub_date
 to_field "date_copyright_display", extract_copyright
 
-to_field "pub_location_t", extract_marc("260a:264a", trim_punctuation: true)
-to_field "publisher_t", extract_marc("260b:264b", trim_punctuation: true)
+to_field "pub_location_t", extract_marc_with_flank("260a:264a", trim_punctuation: true)
+to_field "publisher_t", extract_marc_with_flank("260b:264b", trim_punctuation: true)
 to_field "pub_date_sort", marc_publication_date
 
 # Physical characteristics fields -3xx
@@ -114,7 +114,7 @@ to_field "title_series_display", extract_marc("830av:490av:440anpv:800abcdefghjk
 to_field "title_series_vern_display", extract_marc("830a:490a:440anp", alternate_script: :only)
 # to_field "date_series", extract_marc("362a")
 
-to_field "title_series_t", extract_marc("830av:490av:440anpv")
+to_field "title_series_t", extract_marc_with_flank("830av:490av:440anpv")
 
 # Note fields
 to_field "note_display", extract_marc("500a:508a:511a:515a:518a:521ab:525a:530abcd:533abcdefmn:534pabcefklmnt:538aiu:546ab:550a:586a:588a")
@@ -144,7 +144,7 @@ to_field "subject_era_facet", extract_marc("648a:650y:651y:654y:655y:690y:647y",
 to_field "subject_region_facet", marc_geo_facet
 to_field "genre_facet", extract_marc("600v:610v:611v:630v:648v:650v:651v:655av:647v", trim_punctuation: true)
 
-to_field "subject_t", extract_marc(%W(
+to_field "subject_t", extract_marc_with_flank(%W(
   600#{ATOU}
   610#{ATOU}
   611#{ATOU}
@@ -153,7 +153,7 @@ to_field "subject_t", extract_marc(%W(
   650abcde
   653a:654abcde
                                    ).join(":"))
-to_field "subject_addl_t", extract_marc("600vwxyz:610vwxyz:611vwxyz:630vwxyz:647vwxyz:648avwxyz:650vwxyz:651aegvwxyz:654vwxyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvwxyz")
+to_field "subject_addl_t", extract_marc_with_flank("600vwxyz:610vwxyz:611vwxyz:630vwxyz:647vwxyz:648avwxyz:650vwxyz:651aegvwxyz:654vwxyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvwxyz")
 
 # Location fields
 to_field "call_number_display", extract_marc("HLDhi")

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -1,40 +1,26 @@
 <div class="advanced-search-fields container">
+  <% (1..advanced_search_config[:fields_row_count]).each do |count| %>
   <div class="row">
-    <div class="form-group col-sm-2">
-      <%= select_tag('f1', options_for_select(advanced_key_value, search_fields_for_advanced_search), :class=>"advanced-search-select form-control") %>
+    <div class="col-sm-2">
+    <%= select_tag("f_#{count}", options_for_select(advanced_key_value, search_fields_for_advanced_search), :class=>"form-control") %>
     </div>
-    <div class="col-sm-4">
-      <%= text_field_tag "q1", label_tag_default_for(:q1), :class => 'form-control advanced_search_input', autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
+
+    <div class="col-sm-2">
+      <%= select_tag("op_row[]", options_for_select({"contains"=> :contains, "is (exact)" => :is, "begins with" => :begins_with}.sort, "contains"), :class => "form-control" ) %>
+    </div>
+
+    <div class="col-sm-3">
+    <%= text_field_tag "q_#{count}", label_tag_default_for("q_#{count}"), :class => "form-control", autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
     </div>
   </div>
   <div class="row booleans">
+  <% if count != advanced_search_config[:fields_row_count] %>
     <div class="col-sm-5 col-sm-offset-2">
-      <%= radio_button_tag("op2", "AND", booleans(:op2, "AND")) %><label> AND</label>
-      <%= radio_button_tag("op2", "OR", booleans(:op2, "OR")) %><label> OR</label>
-      <%= radio_button_tag("op2", "NOT", booleans(:op2, "NOT")) %><label> NOT</label>
+    <%= radio_button_tag("op_#{count}", "AND", booleans("op_#{count}", "AND")) %><label> AND</label>
+    <%= radio_button_tag("op_#{count}", "OR", booleans("op_#{count}", "OR")) %><label> OR</label>
+    <%= radio_button_tag("op_#{count}", "NOT", booleans("op_#{count}", "NOT")) %><label> NOT</label>
     </div>
+  <% end %>
   </div>
-  <div class="row">
-    <div class="form-group col-sm-2">
-      <%= select_tag('f2', options_for_select(advanced_key_value, search_fields_for_advanced_search), :class=>"advanced-search-select form-control") %>
-    </div>
-    <div class="col-sm-4">
-      <%= text_field_tag "q2", label_tag_default_for(:q2), :class => 'form-control advanced_search_input', autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
-    </div>
-  </div>
-  <div class="row booleans">
-    <div class="col-sm-5 col-sm-offset-2">
-      <%= radio_button_tag("op3", "AND", booleans(:op3, "AND")) %><label> AND</label>
-      <%= radio_button_tag("op3", "OR", booleans(:op3, "OR")) %><label> OR</label>
-      <%= radio_button_tag("op3", "NOT", booleans(:op3, "NOT")) %><label> NOT</label>
-    </div>
-  </div>
-  <div class="row">
-    <div class="form-group col-sm-2">
-      <%= select_tag('f3', options_for_select(advanced_key_value, search_fields_for_advanced_search), :class=>"advanced-search-select form-control") %>
-    </div>
-    <div class="col-sm-4">
-      <%= text_field_tag "q3", label_tag_default_for(:q3), :class => 'form-control advanced_search_input', autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
-    </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -15,11 +15,11 @@
     <%= render 'advanced/advanced_search_fields' %>
     <%= render 'advanced_search_facets' %>
   </div>
-
-  <hr>
+<hr>
 
   <div class="sort-submit-buttons clearfix">
     <%= render 'advanced_search_submit_btns' %>
   </div>
 
 <% end %>
+

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -1,6 +1,5 @@
 <% doc_presenter = show_presenter(document) %>
 <%# default partial to display solr document fields in catalog show view -%>
-
   <div class="show_page_records">
     <dl class="dl-horizontal  dl-invert">
     <% document_show_fields(document).each do |field_name, field| %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,6 @@ module Tulcob
       g.test_framework :rspec, spec: true
       g.fixture_replacement :factory_bot
     end
+    #config.log_level = :debug
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,15 @@
 version: "3.2"
 
 services:
-
   app:
     build:
       context: .
       dockerfile: .docker/app/Dockerfile
     command: "bundle exec rails s -p 3000 -b '0.0.0.0'"
-    tty: true
-    stdin_open: true
     volumes:
       - .:/tul_cob
+    tty: true
+    stdin_open: true
     ports:
       - "3000"
     environment:
@@ -21,6 +20,10 @@ services:
     build:
       context: .
       dockerfile: .docker/sp/Dockerfile
+    image: "tulcob_app:latest"
+    tty: true
+    depends_on:
+      - "app"
     ports:
       - "80"
       - "443"
@@ -44,3 +47,21 @@ services:
       - /opt/solr/conf
     volumes:
       - $PWD/solr/conf:/opt/solr/conf
+
+  cli:
+    build:
+      context: .
+      dockerfile: .docker/cli/Dockerfile
+    image: "tulcob_app:latest"
+    tty: true
+    depends_on:
+      - "app"
+    volumes:
+      - .:/tul_cob
+    ports:
+      - "3000"
+    environment:
+      SOLR_URL: "http://solr:8983/solr/blacklight"
+      LC_ALL: "C.UTF-8"
+      TERM: "xterm"
+

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -282,6 +282,25 @@ module Traject
           end
         end
       end
+
+      def extract_marc_with_flank(*args)
+        marc_proc = extract_marc(*args)
+
+        lambda do |record, accumulator, context|
+          accumulator << marc_proc.call(record, accumulator, context)
+          accumulator.map! { |v| flank v }
+        end
+      end
+
+      def flank(string = "", starts = nil, ends = nil)
+        starts ||= "matchbeginswith"
+        ends ||= "matchendswith"
+        if !string.to_s.empty? && !string.match(/^#{starts}/)
+          "#{starts} #{string} #{ends}"
+        else
+          string
+        end
+      end
     end
   end
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -2,9 +2,213 @@
 
 require "rails_helper"
 
-RSpec.describe SearchBuilder, type: :model do
-  describe "Simple instantiation test in lieu of implementation" do
-    subject { SearchBuilder.new(any_args) }
-    it { is_expected.to be }
+RSpec.describe SearchBuilder , type: :model do
+  let(:context) { CatalogController.new }
+  let(:search_builder) { SearchBuilder.new(context) }
+  let(:begins_with_tag) { SearchBuilder::BEGINS_WITH_TAG }
+
+  subject { search_builder }
+
+  describe "#begins_with_search" do
+    context "passing empty solr_parameters" do
+      it "does nothing" do
+        solr_parameters = Blacklight::Solr::Request.new
+        allow(context).to receive(:params).and_return({})
+
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q"]).to be_nil
+      end
+    end
+
+    context "Passing non advanced query." do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{}Hello\"") }
+      let(:params) { ActionController::Parameters.new("op_row" => ["contains", "contains", "contains"], "q_1" => "Hello") }
+
+      it "does not dereference the key value" do
+        allow(context).to receive(:params).and_return(params)
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q"]).to eq("_query_:\"{}Hello\"")
+      end
+
+      it "does not set a custom solr_parameter for q_1 field." do
+        allow(context).to receive(:params).and_return(params)
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q_1"]).to be_nil
+      end
+    end
+
+    context "passing advanced query with :contains precision" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{}Hello\"") }
+      let(:params) { ActionController::Parameters.new("op_row" => ["contains", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
+
+      it "dereferences the key value" do
+        allow(context).to receive(:params).and_return(params)
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+      end
+
+      it "sets a custom solr_parameter for q_1 field." do
+        allow(context).to receive(:params).and_return(params)
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q_1"]).to eq("Hello")
+      end
+    end
+
+    context "passing advanced query  with :begins_with precision" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{}Hello\"") }
+      let(:params) { ActionController::Parameters.new("op_row" => ["begins_with", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
+
+      it "dereferences the key value" do
+        allow(context).to receive(:params).and_return(params)
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+      end
+
+      it "quotes the passed in value." do
+        allow(context).to receive(:params).and_return(params)
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q_1"]).to eq("\"#{begins_with_tag} Hello\"")
+      end
+    end
+
+    context "passing advanced subqueries with :begins_with precision" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{}Hello\" AND _query_:\"{}World\"") }
+      let(:params) { ActionController::Parameters.new("op_row" => ["begins_with", "contains", "contains"], "q_1" => "Hello", "q_2" => "World", search_field: "advanced") }
+
+      it "dereferences multiple key values" do
+        allow(context).to receive(:params).and_return(params)
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\" ")
+      end
+
+      it "quotes the passed if used" do
+        allow(context).to receive(:params).and_return(params)
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q_1"]).to eq("\"#{begins_with_tag} Hello\"")
+        expect(solr_parameters["q_2"]).to eq("World")
+      end
+    end
+
+    context "process exact_phrase_search after :begins_with" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{}Hello\"") }
+      let(:params) { ActionController::Parameters.new("op_row" => ["begins_with", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
+
+      it "quotes the passed in value." do
+        allow(context).to receive(:params).and_return(params)
+        subject.begins_with_search(solr_parameters)
+        subject.exact_phrase_search(solr_parameters)
+        expect(solr_parameters["q_1"]).to eq("\"#{begins_with_tag} Hello\"")
+      end
+    end
+
+    context "process contains after :begins_with" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{}Hello\"") }
+      let(:params1) { ActionController::Parameters.new("op_row" => ["begins_with", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
+      let(:params2) { ActionController::Parameters.new("op_row" => ["contains", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
+
+      it "does not quote the value." do
+        allow(context).to receive(:params).and_return(params1)
+        subject.begins_with_search(solr_parameters)
+        allow(context).to receive(:params).and_return(params2)
+        subject.exact_phrase_search(solr_parameters)
+        expect(solr_parameters["q_1"]).to eq("Hello")
+      end
+    end
+  end
+
+  describe "#exact_phrase_search" do
+    context "passing empty solr_parameters" do
+      it "does nothing" do
+        solr_parameters = Blacklight::Solr::Request.new
+        allow(context).to receive(:params).and_return({})
+
+        subject.exact_phrase_search(solr_parameters)
+        expect(solr_parameters["q"]).to be_nil
+      end
+    end
+
+    context "passing non advanced query" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{}Hello\"") }
+      let(:params) { ActionController::Parameters.new("op_row" => ["contains", "contains", "contains"], "q_1" => "Hello") }
+
+      it "does not dereferences the key value" do
+        allow(context).to receive(:params).and_return(params)
+        subject.exact_phrase_search(solr_parameters)
+        expect(solr_parameters["q"]).to eq("_query_:\"{}Hello\"")
+      end
+
+      it "does not set a custom solr_parameter for q_1 field." do
+        allow(context).to receive(:params).and_return(params)
+        subject.exact_phrase_search(solr_parameters)
+        expect(solr_parameters["q_1"]).to be_nil
+      end
+    end
+
+    context "passing advanced query with :contains precision" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{}Hello\"") }
+      let(:params) { ActionController::Parameters.new("op_row" => ["contains", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
+
+      it "dereferences the key value" do
+        allow(context).to receive(:params).and_return(params)
+        subject.exact_phrase_search(solr_parameters)
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+      end
+
+      it "sets a custom solr_parameter for q_1 field." do
+        allow(context).to receive(:params).and_return(params)
+        subject.exact_phrase_search(solr_parameters)
+        expect(solr_parameters["q_1"]).to eq("Hello")
+      end
+    end
+
+    context "passing advanced query with :is precision" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{}Hello\"") }
+      let(:params) { ActionController::Parameters.new("op_row" => ["is", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
+
+      it "dereferences the key value" do
+        allow(context).to receive(:params).and_return(params)
+        subject.exact_phrase_search(solr_parameters)
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+      end
+
+      it "quotes the passed in value." do
+        allow(context).to receive(:params).and_return(params)
+        subject.exact_phrase_search(solr_parameters)
+        expect(solr_parameters["q_1"]).to eq("\"Hello\"")
+      end
+    end
+
+    context "passing advanced subqueries with :is precision" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{}Hello\" AND _query_:\"{}World\"") }
+      let(:params) { ActionController::Parameters.new("op_row" => ["is", "contains", "contains"], "q_1" => "Hello", "q_2" => "World", search_field: "advanced") }
+
+      it "dereferences multiple key values" do
+        allow(context).to receive(:params).and_return(params)
+        subject.exact_phrase_search(solr_parameters)
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\" ")
+      end
+
+      it "quotes the passed if used" do
+        allow(context).to receive(:params).and_return(params)
+        subject.exact_phrase_search(solr_parameters)
+        expect(solr_parameters["q_1"]).to eq("\"Hello\"")
+        expect(solr_parameters["q_2"]).to eq("World")
+      end
+    end
+
+    context "process exact_phrase_search with :is after begins_with_search with :begins_with" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{}Hello\"") }
+      let(:params1) { ActionController::Parameters.new("op_row" => ["begins_with", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
+      let(:params2) { ActionController::Parameters.new("op_row" => ["is", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
+
+      it "quotes the passed in value." do
+        allow(context).to receive(:params).and_return(params1)
+        subject.begins_with_search(solr_parameters)
+        allow(context).to receive(:params).and_return(params2)
+        subject.exact_phrase_search(solr_parameters)
+        expect(solr_parameters["q_1"]).to eq("\"Hello\"")
+      end
+    end
+
   end
 end

--- a/spec/models/traject_indexer_spec.rb
+++ b/spec/models/traject_indexer_spec.rb
@@ -2,7 +2,9 @@
 
 require "rspec"
 require "traject/macros/marc_format_classifier"
+require "traject/macros/custom"
 include Traject::Macros::MarcFormats
+include Traject::Macros::Custom
 
 RSpec.describe "four_digit_year(field):" do
   describe "four_digit_year(field)" do
@@ -40,3 +42,38 @@ RSpec.describe "four_digit_year(field):" do
     end
   end
 end
+
+RSpec.describe "#to_marc_normalized" do
+
+  describe "#flank(field)" do
+    let(:input) {}
+    subject { Traject::Macros::Custom.flank input }
+    context "nil" do
+      it "returns an empty string" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "empty string" do
+      let(:input) { "" }
+      it "returns an empty string" do
+        expect(subject).to eq("")
+      end
+    end
+
+    context "non empty string" do
+      let(:input) { "foo" }
+      it "returns a flanked string" do
+        expect(subject).to eq("matchbeginswith foo matchendswith")
+      end
+    end
+
+    context "a string that is flanked" do
+      let(:input) { "matchbeginswith foo matchendswith"}
+      it "does not reflank a string" do
+        expect(subject).to eq(input)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
REF BL-133

Adds a precision operator to allow searches on :is, :begins_with and the
default :contains.

This change requires a Solr reindex to take effect.

Currently *_t fields are automatically flanked with `matchbeginswith`
and `matchendswith`.  On a :begins_with the solr query is changed under
the hood to search for "matchwithbegins foo bar".

The :is "for exact" phrase works in a similar way, by updating the
search value to be quoted instead of free.

## QA Steps
*  Download the PR locally and reindex.
- [ ] Do a an advanced search with :is and :contains and :begins_with and
verity that they work as you may expect them to.

## Additional changes.
* I added a new container called "cli" to docker-compose, this adds an
editor which to containers in cases where we need to attach to the
container and edit something directly we don't have to always download
an editor first.

* I made it so that both cli and sh containers now use the base app
container in order to reuse that container image.