### PR TITLE
Add a minimum height to book image box.

### DIFF
--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -135,3 +135,7 @@ div.navbar-masquerade {
   max-width: 100px;
   height: auto;
 }
+
+.thumbnail.col-sm-3.col-lg-2.book-format {
+  min-height: 150px;
+}


### PR DESCRIPTION
Adds a minimum height to the book cover image box so that empty images don't
have a squished box by default.