### PR TITLE
BL-206 Move pub date to facet partial and display on one line

### DIFF
--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -65,6 +65,15 @@ input[type="radio"] + label {
   min-height: 34px;
   padding: 0 5px 3.25px;
 }
+
+.begin-pub-date {
+  margin-left: 20px;
+  margin-right: -10px;
+}
+
+.end-pub-date {
+  margin-left: -20px;
+}
 /* === AVAILABILITY === */
 
 .availability {

--- a/app/views/advanced/_advanced_search_facets.html.erb
+++ b/app/views/advanced/_advanced_search_facets.html.erb
@@ -4,7 +4,7 @@
     <%= label_tag display_facet.name.parameterize, :class => "col-sm-3 control-label" do %>
       <%= facet_field_label(display_facet.name) %>
     <% end %>
-    <div class="col-sm-4">
+    <div class="col-sm-5">
       <%= content_tag(:select, :multiple => true,
         :name   => "f_inclusive[#{display_facet.name}][]",
         :id     => display_facet.name.parameterize,
@@ -19,3 +19,21 @@
     </div>
   </div>
 <% end %>
+<div class="row">
+  <div class="col-sm-10">
+    <div class="col-sm-3 control-label">
+      <%= label_tag "publication_date" do %>
+        Publication Year
+      <% end %>
+    </div>
+    <div class="col-sm-3 col-sm-offset-1 begin-pub-date">
+      <%= render_range_input("pub_date_sort", :begin) %>
+    </div>
+    <div class="col-sm-1">
+      -
+    </div>
+    <div class="col-sm-3 end-pub-date">
+      <%= render_range_input("pub_date_sort", :end) %>
+    </div>
+  </div>
+</div>

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -14,12 +14,6 @@
   <div id="advanced_search" class="form-group">
     <%= render 'advanced/advanced_search_fields' %>
     <%= render 'advanced_search_facets' %>
-      <%= label_tag "publication_date", :class => "col-sm-3 control-label" do %>
-          Publication Year
-      <% end %>
-      <div class="col-sm-9">
-          <%= render_range_input("pub_date", :begin) %> - <%= render_range_input("pub_date", :end) %>
-      </div>
   </div>
 
   <hr>

--- a/spec/features/advanced_search.rb
+++ b/spec/features/advanced_search.rb
@@ -12,7 +12,10 @@ RSpec.feature "Advanced Search", type: :feature do
   feature "Advanced Search" do
     let (:facets) {
       [ "Library",
-        "Resource Type"
+        "Resource Type",
+        "Availability",
+        "Languages",
+        "Publication Year"
       ]
     }
     context "advanced search page displays facets" do


### PR DESCRIPTION
BL-206 Update pub date in advanced search
- move publication year code to the facet partial
- display on one line
- update specs to include the new advanced facets