### PR TITLE
Fix creator contributor

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,11 +30,12 @@ module ApplicationHelper
   def browse_creator(args)
     creator = args[:document][args[:field]]
     creator.map do |name|
-      linked_subfield = name.split("|").first.sub(/ *[ ,.\/;:] *\Z/, "")
-      newname = link_to(linked_subfield, root_url + "/?f[creator_facet][]=#{linked_subfield}").html_safe
-      plain_text_subfields = name.split("|").second.sub(/ *[ ,.\/;:] *\Z/, "")
+      linked_subfields = name.split("|").first.sub(/ *[ ,\/;:] *\Z/, '').sub(/( *[[:word:]]{3,})\. *\Z/, '\1')
+      newname = link_to(linked_subfields, root_url + "/?f[creator_facet][]=#{linked_subfields}").html_safe
+      plain_text_subfields = name.split("|").second
       creator = newname
       if plain_text_subfields.present?
+        plain_text_subfields = plain_text_subfields.sub(/ *[ ,.\/;:] *\Z/, '')
         creator = newname + " " + plain_text_subfields
       end
       creator
@@ -45,7 +46,7 @@ module ApplicationHelper
     creator = args[:document][args[:field]]
     creator.map do |name|
       plain_text_subfields = name.gsub("|", " ")
-      creator = plain_text_subfields
+      creator = plain_text_subfields.sub(/ *[ ,\/;:] *\Z/, '').sub(/( *[[:word:]]{3,})\. *\Z/, '\1')
     end
     creator
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,9 +30,9 @@ module ApplicationHelper
   def browse_creator(args)
     creator = args[:document][args[:field]]
     creator.map do |name|
-      linked_subfield = name.split("|").first
+      linked_subfield = name.split("|").first.sub(/ *[ ,.\/;:] *\Z/, "")
       newname = link_to(linked_subfield, root_url + "/?f[creator_facet][]=#{linked_subfield}").html_safe
-      plain_text_subfields = name.split("|").second
+      plain_text_subfields = name.split("|").second.sub(/ *[ ,.\/;:] *\Z/, "")
       creator = newname
       if plain_text_subfields.present?
         creator = newname + " " + plain_text_subfields

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,8 +37,8 @@ module ApplicationHelper
       if plain_text_subfields.present?
         creator = newname + " " + plain_text_subfields
       end
+      creator
     end
-    creator
   end
 
   def creator_index_separator(args)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,12 +30,12 @@ module ApplicationHelper
   def browse_creator(args)
     creator = args[:document][args[:field]]
     creator.map do |name|
-      linked_subfields = name.split("|").first.sub(/ *[ ,\/;:] *\Z/, '').sub(/( *[[:word:]]{3,})\. *\Z/, '\1')
+      linked_subfields = name.split("|").first
       newname = link_to(linked_subfields, root_url + "/?f[creator_facet][]=#{linked_subfields}").html_safe
       plain_text_subfields = name.split("|").second
       creator = newname
       if plain_text_subfields.present?
-        plain_text_subfields = plain_text_subfields.sub(/ *[ ,.\/;:] *\Z/, '')
+        plain_text_subfields = plain_text_subfields
         creator = newname + " " + plain_text_subfields
       end
       creator
@@ -46,7 +46,7 @@ module ApplicationHelper
     creator = args[:document][args[:field]]
     creator.map do |name|
       plain_text_subfields = name.gsub("|", " ")
-      creator = plain_text_subfields.sub(/ *[ ,\/;:] *\Z/, '').sub(/( *[[:word:]]{3,})\. *\Z/, '\1')
+      creator = plain_text_subfields
     end
     creator
   end

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -78,7 +78,7 @@ to_field "title_sort", marc_sortable_title
 
 # Creator/contributor fields
 to_field "creator_t", extract_marc_with_flank("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true)
-to_field "creator_facet", extract_marc("100abcdq:110abcd:111acdj:700abcdq:710abcd:711acdj")
+to_field "creator_facet", extract_marc("100abcdq:110abcd:111acdj:700abcdq:710abcd:711acdj", trim_punctuation: true)
 to_field "creator_display", extract_creator
 to_field "contributor_display", extract_contributor
 to_field "creator_vern_display", extract_creator_vern

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -25,22 +25,30 @@ module Traject
         end
       end
 
+      def creator_name_trim_punctuation(name)
+        name.sub(/ *[ ,\/;:] *\Z/, '').sub(/( *[[:word:]]{3,})\. *\Z/, '\1')
+      end
+
+      def creator_role_trim_punctuation(role)
+        role.sub(/ *[ ,.\/;:] *\Z/, '')
+      end
+
       def extract_creator
         lambda do |rec, acc|
           rec.fields("100").each do |f|
             linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
-            acc << linked_subfields + "|" + plain_text_subfields
+            acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           rec.fields("110").each do |f|
             linked_subfields = [f["a"], f["b"], f["c"], f["d"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["m"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
-            acc << linked_subfields + "|" + plain_text_subfields
+            acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           rec.fields("111").each do |f|
             linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
-            acc << linked_subfields + "|" + plain_text_subfields
+            acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
         end
       end
@@ -50,17 +58,17 @@ module Traject
           MarcExtractor.cached("100abcdejlmnopqrtu", alternate_script: :only).collect_matching_lines(rec) do |f|
             linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
-            acc << linked_subfields + "|" + plain_text_subfields
+            acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           MarcExtractor.cached("110abcdelmnopt", alternate_script: :only).collect_matching_lines(rec) do |f|
             linked_subfields = [f["a"], f["b"], f["c"], f["d"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["m"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
-            acc << linked_subfields + "|" + plain_text_subfields
+            acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           MarcExtractor.cached("111acdejlnopt", alternate_script: :only).collect_matching_lines(rec) do |f|
             linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
-            acc << linked_subfields + "|" + plain_text_subfields
+            acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
         end
       end
@@ -70,17 +78,17 @@ module Traject
           rec.fields("700").each do |f|
             linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
-            acc << linked_subfields + "|" + plain_text_subfields
+            acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           rec.fields("710").each do |f|
             linked_subfields = [f["a"], f["b"], f["c"], f["d"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["m"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
-            acc << linked_subfields + "|" + plain_text_subfields
+            acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           rec.fields("711").each do |f|
             linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
-            acc << linked_subfields + "|" + plain_text_subfields
+            acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
         end
       end
@@ -90,17 +98,17 @@ module Traject
           MarcExtractor.cached("700abcdejlmnopqrtu", alternate_script: :only).collect_matching_lines(rec) do |f|
             linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
-            acc << linked_subfields + "|" + plain_text_subfields
+            acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           MarcExtractor.cached("710abcdelmnopt", alternate_script: :only).collect_matching_lines(rec) do |f|
             linked_subfields = [f["a"], f["b"], f["c"], f["d"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["m"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
-            acc << linked_subfields + "|" + plain_text_subfields
+            acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           MarcExtractor.cached("711acdejlnopt", alternate_script: :only).collect_matching_lines(rec) do |f|
             linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
-            acc << linked_subfields + "|" + plain_text_subfields
+            acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
         end
       end

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -39,16 +39,16 @@ title_addl_740:
   title_addl: "Dictionary of American history: 740. Subfield N. Subfield P."
 creator_100:
   doc_id: "991012132499760617"
-  creator: "Giovanni, Nikki. Subfield B. Subfield C. Subfield D. Subfield Q. Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield R. Subfield T. Subfield U."
+  creator: "Giovanni, Nikki. Subfield B. Subfield C. Subfield D. Subfield Q Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield R. Subfield T. Subfield U"
 creator_100_v:
   doc_id: "991012172649703811"
-  creator_vern: "מעקלער, ד.ל."
+  creator_vern: "מעקלער, ד.ל"
 creator_110:
   doc_id: "991012132499760618"
-  creator: "Dictionary of American history: 110. Subfield B. Subfield C. Subfield D. Subfield E. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield T."
+  creator: "Dictionary of American history: 110. Subfield B. Subfield C. Subfield D Subfield E. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield T"
 creator_111:
   doc_id: "991012132499760619"
-  creator: "Dictionary of American history: 111. Subfield C. Subfield D. Subfield J. Subfield E.  Subfield L. Subfield N. Subfield O. Subfield P. Subfield T."
+  creator: "Dictionary of American history: 111. Subfield C. Subfield D. Subfield J Subfield E.  Subfield L. Subfield N. Subfield O. Subfield P. Subfield T"
 contributor_700:
   doc_id: "991012132499760620"
   creator: "Dictionary of American history: 700. Subfield B. Subfield C. Subfield D. Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield T. Subfield U."

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -39,16 +39,16 @@ title_addl_740:
   title_addl: "Dictionary of American history: 740. Subfield N. Subfield P."
 creator_100:
   doc_id: "991012132499760617"
-  creator: "Giovanni, Nikki. Subfield B. Subfield C. Subfield D. Subfield Q Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield R. Subfield T. Subfield U"
+  creator: "Giovanni, Nikki. Subfield B. Subfield C. Subfield D. Subfield Q. Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield R. Subfield T. Subfield U"
 creator_100_v:
   doc_id: "991012172649703811"
   creator_vern: "מעקלער, ד.ל"
 creator_110:
   doc_id: "991012132499760618"
-  creator: "Dictionary of American history: 110. Subfield B. Subfield C. Subfield D Subfield E. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield T"
+  creator: "Dictionary of American history: 110. Subfield B. Subfield C. Subfield D. Subfield E. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield T"
 creator_111:
   doc_id: "991012132499760619"
-  creator: "Dictionary of American history: 111. Subfield C. Subfield D. Subfield J Subfield E.  Subfield L. Subfield N. Subfield O. Subfield P. Subfield T"
+  creator: "Dictionary of American history: 111. Subfield C. Subfield D. Subfield J. Subfield E.  Subfield L. Subfield N. Subfield O. Subfield P. Subfield T"
 contributor_700:
   doc_id: "991012132499760620"
   creator: "Dictionary of American history: 700. Subfield B. Subfield C. Subfield D. Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield T. Subfield U."


### PR DESCRIPTION
BL-45 and BL-230 Fixes behavior related to splitting the creator and contributor fields
- Move the creator call inside block so that it displays all creators
- Use trim_punctuation macro for creator_facet
- Use the same regex logic in the browser_creator and creator_index helper methods to display creators and have the links work to creator_facet
- Update fixture file for punctuation