### PR TITLE
Refactor specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ coverage
 config/alma.yml
 config/bento.yml
 config/deploy_to.yml
+
+spec/examples.txt

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,3 +133,6 @@ Lint/EndAlignment:
 # Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
 Lint/RequireParentheses:
   Enabled: true
+
+Rails:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :development, :test do
   gem "pretender"
   gem 'rails-controller-testing'
   gem 'faker'
+  gem 'rubocop'
 end
 
 gem "rsolr", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     alma (0.2.4)
       ezwadl
     arel (7.1.4)
+    ast (2.3.0)
     autoprefixer-rails (7.2.1)
       execjs
     awesome_print (1.8.0)
@@ -243,7 +244,11 @@ GEM
       marc
       scrub_rb (~> 1.0)
     orm_adapter (0.5.0)
+    parallel (1.12.1)
+    parser (2.4.0.2)
+      ast (~> 2.3)
     parslet (1.8.0)
+    powerpack (0.1.1)
     pretender (0.3.1)
       actionpack
     pry (0.11.2)
@@ -283,6 +288,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (3.0.0)
     rake (12.3.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
@@ -314,6 +320,13 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
+    rubocop (0.52.1)
+      parallel (~> 1.10)
+      parser (>= 2.4.0.2, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
@@ -382,6 +395,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
+    unicode-display_width (1.3.0)
     vcr (3.0.3)
     warden (1.2.7)
       rack (>= 1.0)
@@ -440,6 +454,7 @@ DEPENDENCIES
   rails-controller-testing
   rsolr (~> 1.0)
   rspec-rails
+  rubocop
   sass-rails (~> 5.0)
   simplecov
   solr_wrapper (>= 0.3)

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,4 +1,6 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe CatalogController, type: :controller do
 
@@ -21,20 +23,19 @@ RSpec.describe CatalogController, type: :controller do
   describe "GET index as json" do
     render_views
     before do
-      get(:index, params: {q: "education"}, :format => :json)
-      #binding.pry
+      get(:index, params: { q: "education" }, format: :json)
     end
     let(:docs) { JSON.parse(response.body)["response"]["docs"] }
     # Collect the keys from the document hashes into a single array
-    let(:docs_keys) { docs.collect {|doc| doc.keys}.flatten.uniq }
+    let(:docs_keys) { docs.collect { |doc| doc.keys }.flatten.uniq }
     let(:expected_keys) {
       %w[ id imprint_display creator_display pub_date
           format isbn_display lccn_display
         ]
     }
 
-    context 'an individual index result' do
-      it 'has an the expected fields' do
+    context "an individual index result" do
+      it "has an the expected fields" do
         expected_keys.each do |key|
           expect(docs_keys).to include key
         end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe UsersController, type: :controller do
           end
 
           it "redirects to root" do
-            expect(subject).to redirect_to('http://test.host/')
+            expect(subject).to redirect_to("http://test.host/")
           end
         end
 
@@ -152,7 +152,7 @@ RSpec.describe UsersController, type: :controller do
           end
 
           it "redirects to root" do
-            expect(subject).to redirect_to('http://test.host/')
+            expect(subject).to redirect_to("http://test.host/")
           end
         end
 
@@ -162,7 +162,7 @@ RSpec.describe UsersController, type: :controller do
           end
 
           it "redirects to root" do
-            expect(subject).to redirect_to('http://test.host/')
+            expect(subject).to redirect_to("http://test.host/")
           end
         end
       end

--- a/spec/features/advanced_search.rb
+++ b/spec/features/advanced_search.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require "yaml"
 include ApplicationHelper
 
-RSpec.feature "Advanced Search", type: :feature do
+RSpec.feature "Advanced Search" do
   let (:fixtures) {
     YAML.load_file("#{fixture_path}/features.yml")
   }

--- a/spec/features/availability_response_spec.rb
+++ b/spec/features/availability_response_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "rails_helper"
 require "yaml"
 

--- a/spec/features/availability_response_spec.rb
+++ b/spec/features/availability_response_spec.rb
@@ -2,33 +2,36 @@
 require "rails_helper"
 require "yaml"
 
-describe Alma::AvailabilityResponse do
+RSpec.feature "Availability" do
 
-  before(:all) do
-    Alma.configure
-  end
+  describe Alma::AvailabilityResponse do
 
-  describe "availability attribute" do
-    let(:availability) { Alma::Bib.get_availability([1, 2]).availability }
-
-    it "returns a hash" do
-      expect(availability).to be_a Hash
+    before(:all) do
+      Alma.configure
     end
 
-    it "has the expected keys" do
-      expect(availability.keys).to eql %w{1 2}
-    end
+    describe "availability attribute" do
+      let(:availability) { Alma::Bib.get_availability([1, 2]).availability }
 
-    describe "availability hash members value" do
-      it "has the expected keys" do
-        expect(availability["1"]).to have_key "holdings"
+      it "returns a hash" do
+        expect(availability).to be_a Hash
       end
-    end
 
-    describe "holdings data in availability hash" do
       it "has the expected keys" do
-        keys = %w{availability location call_number inventory_type}
-        expect(availability["1"]["holdings"].first.keys).to include(*keys)
+        expect(availability.keys).to eql %w{1 2}
+      end
+
+      describe "availability hash members value" do
+        it "has the expected keys" do
+          expect(availability["1"]).to have_key "holdings"
+        end
+      end
+
+      describe "holdings data in availability hash" do
+        it "has the expected keys" do
+          keys = %w{availability location call_number inventory_type}
+          expect(availability["1"]["holdings"].first.keys).to include(*keys)
+        end
       end
     end
   end

--- a/spec/features/basic_page_elements_spec.rb
+++ b/spec/features/basic_page_elements_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 
-RSpec.feature "Basic Page Elements", type: :feature do
+RSpec.feature "Basic Page Elements" do
 
   feature "Check the home page for nav elements when anonymous" do
     scenario "Go to the home page" do

--- a/spec/features/basic_page_elements_spec.rb
+++ b/spec/features/basic_page_elements_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 
@@ -23,7 +25,7 @@ RSpec.feature "Basic Page Elements" do
     before do
       DatabaseCleaner.clean
       user = FactoryBot.create(:user)
-      login_as(user, :scope => :user)
+      login_as(user, scope: :user)
 
     end
 

--- a/spec/features/basic_page_elements_spec.rb
+++ b/spec/features/basic_page_elements_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Basic Page Elements", type: :feature do
         expect(page).to have_text "Bookmarks"
         expect(page).to have_text "History"
         expect(page).to have_text "Login"
-        expect(page).to_not have_text "Library Account"
+        expect(page).to have_no_text "Library Account"
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.feature "Basic Page Elements", type: :feature do
     scenario "Go to the home page" do
       visit "/"
       within(".navbar-right") do
-        expect(page).to_not have_text "Login"
+        expect(page).to have_no_text "Login"
         expect(page).to have_text "Library Account"
         expect(page).to have_text "Log Out"
       end

--- a/spec/features/bento_search_spec.rb
+++ b/spec/features/bento_search_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "yaml"
 
-RSpec.feature "Bento Searches", type: :feature do
+RSpec.feature "Bento Searches" do
   let (:fixtures) {
     YAML.load_file("#{fixture_path}/search_features.yml")
   }

--- a/spec/features/indices_spec.rb
+++ b/spec/features/indices_spec.rb
@@ -6,7 +6,7 @@ require "traject/command_line"
 require "yaml"
 require "pry"
 
-RSpec.feature "Indices", type: :feature do
+RSpec.feature "Indices" do
   let (:fixtures) {
     YAML.load_file("#{fixture_path}/features.yml")
   }

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require "yaml"
 include ApplicationHelper
 
-RSpec.feature "RecordPageFields", type: :feature do
+RSpec.feature "RecordPageFields" do
   let (:fixtures) {
     YAML.load_file("#{fixture_path}/features.yml")
   }

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "RecordPageFields" do
     YAML.load_file("#{fixture_path}/features.yml")
   }
 
-  feature "MARC Title Statement Fields", :focus do
+  feature "MARC Title Statement Fields" do
     let (:item) { fixtures.fetch("title_statement") }
     scenario "User visits a document with full title statement" do
       visit "catalog/#{item['doc_id']}"

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "RecordPageFields" do
     YAML.load_file("#{fixture_path}/features.yml")
   }
 
-  feature "MARC Title Statement Fields" do
+  feature "MARC Title Statement Fields", :focus do
     let (:item) { fixtures.fetch("title_statement") }
     scenario "User visits a document with full title statement" do
       visit "catalog/#{item['doc_id']}"

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -244,7 +244,7 @@ RSpec.feature "RecordPageFields" do
     let (:item_260_year_only) { fixtures.fetch("imprint_260_year_only") }
     scenario "User visits a document including year only in subfield 'c'" do
       visit "catalog/#{item_260_year_only['doc_id']}"
-        expect(page).to have_no_css("dd.blacklight-date_copyright_display")
+      expect(page).to have_no_css("dd.blacklight-date_copyright_display")
     end
 
     let (:item_264) { fixtures.fetch("imprint_264") }

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -212,7 +212,7 @@ RSpec.feature "RecordPageFields", type: :feature do
     let (:item_264_4) { fixtures.fetch("imprint_264_4") }
     scenario "User visits a document with imprint indicator2 value 4" do
       visit "catalog/#{item_264_4['doc_id']}"
-      expect(page).to_not have_text(item_264_4["imprint"])
+      expect(page).to have_no_text(item_264_4["imprint"])
     end
   end
 
@@ -244,7 +244,7 @@ RSpec.feature "RecordPageFields", type: :feature do
     let (:item_260_year_only) { fixtures.fetch("imprint_260_year_only") }
     scenario "User visits a document including year only in subfield 'c'" do
       visit "catalog/#{item_260_year_only['doc_id']}"
-        expect(page).to_not have_css("dd.blacklight-date_copyright_display")
+        expect(page).to have_no_css("dd.blacklight-date_copyright_display")
     end
 
     let (:item_264) { fixtures.fetch("imprint_264") }
@@ -668,7 +668,7 @@ RSpec.feature "RecordPageFields", type: :feature do
     let (:item_542_0) { fixtures.fetch("note_copyright_542_0") }
     scenario "User visits a document with note copyright indicator 1 value 0" do
       visit "catalog/#{item_542_0['doc_id']}"
-      expect(page).to_not have_text(item_542_0["note_copyright"])
+      expect(page).to have_no_text(item_542_0["note_copyright"])
     end
 
     let (:item_542_1) { fixtures.fetch("note_copyright_542_1") }
@@ -1029,7 +1029,7 @@ RSpec.feature "RecordPageFields", type: :feature do
     let (:item_086) { fixtures.fetch("sudoc_086") }
     scenario "User visits a document with sudoc indicator1 value unassigned" do
       visit "catalog/#{item_086['doc_id']}"
-      expect(page).to_not have_text(item_086["sudoc"])
+      expect(page).to have_no_text(item_086["sudoc"])
     end
 
     let (:item_086_0) { fixtures.fetch("sudoc_086_0") }
@@ -1043,7 +1043,7 @@ RSpec.feature "RecordPageFields", type: :feature do
     let (:item_086_1) { fixtures.fetch("sudoc_086_1") }
     scenario "User visits a document with udoc indicator1 value1" do
       visit "catalog/#{item_086_1['doc_id']}"
-      expect(page).to_not have_text(item_086_1["sudoc"])
+      expect(page).to have_no_text(item_086_1["sudoc"])
     end
   end
 
@@ -1186,7 +1186,7 @@ RSpec.feature "RecordPageFields", type: :feature do
     let (:item_600) { fixtures.fetch("subject_600") }
     scenario "Has button for Aeon request" do
       visit "catalog/#{item_600['doc_id']}"
-      expect(page).to_not have_css(".aeon-request")
+      expect(page).to have_no_css(".aeon-request")
     end
   end
 end

--- a/spec/features/searches_spec.rb
+++ b/spec/features/searches_spec.rb
@@ -183,18 +183,18 @@ RSpec.feature "Searches" do
     let (:test_queries) { fixtures.fetch("results_queries") }
     scenario "Test queries" do
       test_queries.each do |test_item|
-        search_string = ''
-        test_item['query_type'].each do |query_field|
+        search_string = ""
+        test_item["query_type"].each do |query_field|
           test_item[query_field].each do |search_term|
             search_string += search_term + " "
           end
         end
-        visit '/'
-        fill_in 'q', with: search_string
-        click_button 'Search'
+        visit "/"
+        fill_in "q", with: search_string
+        click_button "Search"
         #save_and_open_page
         within first(".document-position-0 h3") do
-          test_item['query_type'].each do |query_field|
+          test_item["query_type"].each do |query_field|
             test_item[query_field].each do |search_term|
               expect(page).to have_text search_term
             end

--- a/spec/features/searches_spec.rb
+++ b/spec/features/searches_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require "yaml"
 include ApplicationHelper
 
-RSpec.feature "Searches", type: :feature do
+RSpec.feature "Searches" do
   let (:fixtures) {
     YAML.load_file("#{fixture_path}/search_features.yml")
   }

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helpe
   describe "#guided_search" do
 
     example "empty search fields" do
-      expect(helper.guided_search.empty?).to be(true)
+      expect(helper.guided_search).to be_empty
     end
 
     example "one search field" do

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -1,4 +1,6 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 # Specs in this file have access to a helper object that includes
 # the CatalogHelper. For example:
@@ -13,15 +15,15 @@ require 'rails_helper'
 RSpec.describe CatalogHelper, type: :helper do
   describe "#isbn_data_attribute" do
     context "document contains an isbn" do
-      let(:document) { {isbn_display: ["123456789"]} }
-      it 'returns the data-isbn string' do
+      let(:document) { { isbn_display: ["123456789"] } }
+      it "returns the data-isbn string" do
         expect(isbn_data_attribute(document)).to eql "data-isbn=123456789"
       end
     end
 
     context "document contains multiple isbn" do
-      let(:document) { {isbn_display: ["23445667890","123456789"]} }
-      it 'returns the data-isbn string' do
+      let(:document) { { isbn_display: ["23445667890", "123456789"] } }
+      it "returns the data-isbn string" do
         expect(isbn_data_attribute(document)).to eql "data-isbn=23445667890"
       end
     end
@@ -29,7 +31,7 @@ RSpec.describe CatalogHelper, type: :helper do
 
     context "document contains an isbn" do
       let(:document) { {} }
-      it 'returns the data-isbn string' do
+      it "returns the data-isbn string" do
         expect(isbn_data_attribute(document)).to eql ""
       end
     end

--- a/spec/lib/traject/macros/marc_format_classifier_spec.rb
+++ b/spec/lib/traject/macros/marc_format_classifier_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 require "traject"
-require 'traject/macros/marc_format_classifier'
+require "traject/macros/marc_format_classifier"
 
 # Include custom traject macros
 require "traject/macros/custom"
@@ -16,7 +16,7 @@ end
 
 def classifier_for(filename)
   record = MARC::XMLReader.new(file_fixture(filename).to_s).to_a.first
-  return MarcFormatClassifier.new( record )
+  return MarcFormatClassifier.new(record)
 end
 
 RSpec.describe MarcFormatClassifier, type: :lib do

--- a/spec/models/traject_indexer_spec.rb
+++ b/spec/models/traject_indexer_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "#to_marc_normalized" do
     end
 
     context "a string that is flanked" do
-      let(:input) { "matchbeginswith foo matchendswith"}
+      let(:input) { "matchbeginswith foo matchendswith" }
       it "does not reflank a string" do
         expect(subject).to eq(input)
       end

--- a/spec/models/traject_indexer_spec.rb
+++ b/spec/models/traject_indexer_spec.rb
@@ -8,19 +8,25 @@ include Traject::Macros::Custom
 
 RSpec.describe "four_digit_year(field):" do
   describe "four_digit_year(field)" do
-    it "returns nil if given nil" do
-      expect(four_digit_year nil).to eq(nil)
+    context "when field is nil" do
+      it "returns nil" do
+        expect(four_digit_year nil).to eq(nil)
+      end
     end
 
-    it "returns nil if given empty string" do
-      expect(four_digit_year "").to eq(nil)
-      expect(four_digit_year "\n").to eq(nil)
-      expect(four_digit_year "\n\n").to eq(nil)
-      expect(four_digit_year "      ").to eq(nil)
+    context "when given an empty string" do
+      it "returns nil" do
+        expect(four_digit_year "").to eq(nil)
+        expect(four_digit_year "\n").to eq(nil)
+        expect(four_digit_year "\n\n").to eq(nil)
+        expect(four_digit_year "      ").to eq(nil)
+      end
     end
 
-    it "returns nil for Roman Numerals" do
-      expect(four_digit_year "MCCXLV").to eq(nil)
+    context "when contains Roman Numerals" do
+      it "returns nil" do
+        expect(four_digit_year "MCCXLV").to eq(nil)
+      end
     end
 
     it "returns nil for [n.d.],''" do
@@ -76,4 +82,3 @@ RSpec.describe "#to_marc_normalized" do
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,7 +97,7 @@ RSpec.configure do |config|
   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
+  #config.disable_monkey_patching!
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require "webmock/rspec"
 require "vcr"
 require "database_cleaner"
 require "capybara/rspec"
+
 WebMock.disable_net_connect!(allow_localhost: true)
 
 SPEC_ROOT = File.dirname __FILE__
@@ -78,8 +79,9 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -97,22 +99,22 @@ RSpec.configure do |config|
   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  #config.disable_monkey_patching!
+  config.disable_monkey_patching!
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
-  #if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    #config.default_formatter = 'doc'
-  #end
+    #if config.files_to_run.one?
+      # Use the documentation formatter for detailed output,
+      # unless a formatter has already been configured
+      # (e.g. via a command-line flag).
+      #config.default_formatter = 'doc'
+    #end
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  #config.profile_examples = 10
+  config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ require "webmock/rspec"
 require "vcr"
 require "database_cleaner"
 require "capybara/rspec"
-
 WebMock.disable_net_connect!(allow_localhost: true)
 
 SPEC_ROOT = File.dirname __FILE__
@@ -81,7 +80,6 @@ RSpec.configure do |config|
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
-=begin
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -127,7 +125,7 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
+
   config.add_setting :bento_expected_fields,
     default: [ :title, :authors, :publisher, :link ]
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,17 +102,17 @@ RSpec.configure do |config|
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
-  if config.files_to_run.one?
+  #if config.files_to_run.one?
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
-  end
+    #config.default_formatter = 'doc'
+  #end
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  #config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
Lots of changes in the spec files here.
- Add the rubocop gem and changed spec files to get rid of syntax offenses
- Uncomment methods in the spec_helper file
- Cleans up code by removing explicit statements of spec type,  be_methodname rather that expressing a boolean value, using capybara negative selectors 
-Add context to conditional specs