### PR TITLE
Disable spelling suggestions during advanced search.

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -26,8 +26,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def disable_advanced_spellcheck(solr_parameters)
-    params = get_params
-    if !params.empty? && params["search_field"] == "advanced"
+    if blacklight_params["search_field"] == "advanced"
       # @See BL-234
       solr_parameters["spellcheck"] = "false"
     end
@@ -37,13 +36,12 @@ class SearchBuilder < Blacklight::SearchBuilder
 
     def dereference_with(method, solr_parameters)
       query = solr_parameters["q"] || ""
-      params = get_params
 
       # Search misbehaves if we alter non advanced search query.
-      if !query.empty? && !params.empty? && params["search_field"] == "advanced"
+      if !query.empty? && blacklight_params["search_field"] == "advanced"
         # We need the original values in the search for use in creating
         # a de-referenced version of the query.
-        fields = get_params.select { |k| k.match(/^q_/) }
+        fields = blacklight_params.select { |k| k.match(/^q_/) }
 
         # We de-reference values in order to be able to quote them; otherwise,
         # solr throws a 500 error: https://stackoverflow.com/a/10183238/256854
@@ -59,7 +57,7 @@ class SearchBuilder < Blacklight::SearchBuilder
         solr_parameters["q"] = queries.join(" ")
 
         # De-referenced values have to be added as solr request parameters.
-        ops = params.fetch("op_row", [])
+        ops = blacklight_params.fetch("op_row", [])
         ops.zip(fields).each { |op, f|
           k, v = f
           solr_parameters[k] = send(method, v, op)
@@ -71,8 +69,8 @@ class SearchBuilder < Blacklight::SearchBuilder
     def append_start_flank(value, op)
       return if value.nil?
 
-      # value is always fresh from params so we don't have to worry about
-      # process duplication/mutation but we do have to reapply processes.
+      # value is always fresh from blacklight_params so we don't have to worry
+      # about process duplication/mutation but we do have to reapply processes.
       if op == "begins_with"
         to_phrase("#{BEGINS_WITH_TAG} #{value}", "is")
       else
@@ -83,8 +81,8 @@ class SearchBuilder < Blacklight::SearchBuilder
     def to_phrase(value, op)
       return if value.nil?
 
-      # value is always fresh from params so we don't have to worry about
-      # process duplication/mutation but we do have to reapply processes.
+      # value is always fresh from blacklight_params so we don't have to worry
+      # about process duplication/mutation but we do have to reapply processes.
       if op == "is"
         "\"#{value}\""
       elsif op == "begins_with"
@@ -113,13 +111,5 @@ class SearchBuilder < Blacklight::SearchBuilder
     def param_dereference(q, k)
       local_param, _, connector = q
       "_query_:\"{#{local_param} v=$#{k}}\" #{connector}"
-    end
-
-    def get_params
-      if scope.respond_to? :params
-        scope.params || {}
-      else
-        {}
-      end
     end
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -4,30 +4,31 @@ require "rails_helper"
 
 RSpec.describe SearchBuilder , type: :model do
   let(:context) { CatalogController.new }
+  let(:params) { ActionController::Parameters.new }
   let(:search_builder) { SearchBuilder.new(context) }
   let(:begins_with_tag) { SearchBuilder::BEGINS_WITH_TAG }
 
   subject { search_builder }
 
+  before(:example) do
+    allow(search_builder).to receive(:blacklight_params).and_return(params)
+  end
+
+
   describe ".disable_advanced_spellcheck" do
     let(:solr_parameters) { Blacklight::Solr::Request.new(spellcheck: "true") }
 
     context "when not doing an advanced search" do
-      let(:params) { ActionController::Parameters.new }
-
       it "does not disable the spellcheck" do
-        allow(context).to receive(:params).and_return(params)
         subject.disable_advanced_spellcheck(solr_parameters)
         expect(solr_parameters["spellcheck"]).to eq("true")
       end
-
     end
 
     context "when doing an advanced search" do
       let(:params) { ActionController::Parameters.new(search_field: "advanced") }
 
       it "disables the spellcheck" do
-        allow(context).to receive(:params).and_return(params)
         subject.disable_advanced_spellcheck(solr_parameters)
         expect(solr_parameters["spellcheck"]).to eq("false")
       end
@@ -39,7 +40,6 @@ RSpec.describe SearchBuilder , type: :model do
     context "passing empty solr_parameters" do
       it "does nothing" do
         solr_parameters = Blacklight::Solr::Request.new
-        allow(context).to receive(:params).and_return({})
 
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q"]).to be_nil
@@ -51,13 +51,11 @@ RSpec.describe SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new("op_row" => ["contains", "contains", "contains"], "q_1" => "Hello") }
 
       it "does not dereference the key value" do
-        allow(context).to receive(:params).and_return(params)
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q"]).to eq("_query_:\"{}Hello\"")
       end
 
       it "does not set a custom solr_parameter for q_1 field." do
-        allow(context).to receive(:params).and_return(params)
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q_1"]).to be_nil
       end
@@ -68,13 +66,11 @@ RSpec.describe SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new("op_row" => ["contains", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
 
       it "dereferences the key value" do
-        allow(context).to receive(:params).and_return(params)
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
       end
 
       it "sets a custom solr_parameter for q_1 field." do
-        allow(context).to receive(:params).and_return(params)
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q_1"]).to eq("Hello")
       end
@@ -85,13 +81,11 @@ RSpec.describe SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new("op_row" => ["begins_with", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
 
       it "dereferences the key value" do
-        allow(context).to receive(:params).and_return(params)
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
       end
 
       it "quotes the passed in value." do
-        allow(context).to receive(:params).and_return(params)
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q_1"]).to eq("\"#{begins_with_tag} Hello\"")
       end
@@ -102,13 +96,11 @@ RSpec.describe SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new("op_row" => ["begins_with", "contains", "contains"], "q_1" => "Hello", "q_2" => "World", search_field: "advanced") }
 
       it "dereferences multiple key values" do
-        allow(context).to receive(:params).and_return(params)
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\" ")
       end
 
       it "quotes the passed if used" do
-        allow(context).to receive(:params).and_return(params)
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q_1"]).to eq("\"#{begins_with_tag} Hello\"")
         expect(solr_parameters["q_2"]).to eq("World")
@@ -120,7 +112,6 @@ RSpec.describe SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new("op_row" => ["begins_with", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
 
       it "quotes the passed in value." do
-        allow(context).to receive(:params).and_return(params)
         subject.begins_with_search(solr_parameters)
         subject.exact_phrase_search(solr_parameters)
         expect(solr_parameters["q_1"]).to eq("\"#{begins_with_tag} Hello\"")
@@ -133,9 +124,9 @@ RSpec.describe SearchBuilder , type: :model do
       let(:params2) { ActionController::Parameters.new("op_row" => ["contains", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
 
       it "does not quote the value." do
-        allow(context).to receive(:params).and_return(params1)
+        allow(search_builder).to receive(:blacklight_params).and_return(params1)
         subject.begins_with_search(solr_parameters)
-        allow(context).to receive(:params).and_return(params2)
+        allow(search_builder).to receive(:blacklight_params).and_return(params2)
         subject.exact_phrase_search(solr_parameters)
         expect(solr_parameters["q_1"]).to eq("Hello")
       end
@@ -146,7 +137,6 @@ RSpec.describe SearchBuilder , type: :model do
     context "passing empty solr_parameters" do
       it "does nothing" do
         solr_parameters = Blacklight::Solr::Request.new
-        allow(context).to receive(:params).and_return({})
 
         subject.exact_phrase_search(solr_parameters)
         expect(solr_parameters["q"]).to be_nil
@@ -158,13 +148,11 @@ RSpec.describe SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new("op_row" => ["contains", "contains", "contains"], "q_1" => "Hello") }
 
       it "does not dereferences the key value" do
-        allow(context).to receive(:params).and_return(params)
         subject.exact_phrase_search(solr_parameters)
         expect(solr_parameters["q"]).to eq("_query_:\"{}Hello\"")
       end
 
       it "does not set a custom solr_parameter for q_1 field." do
-        allow(context).to receive(:params).and_return(params)
         subject.exact_phrase_search(solr_parameters)
         expect(solr_parameters["q_1"]).to be_nil
       end
@@ -175,13 +163,11 @@ RSpec.describe SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new("op_row" => ["contains", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
 
       it "dereferences the key value" do
-        allow(context).to receive(:params).and_return(params)
         subject.exact_phrase_search(solr_parameters)
         expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
       end
 
       it "sets a custom solr_parameter for q_1 field." do
-        allow(context).to receive(:params).and_return(params)
         subject.exact_phrase_search(solr_parameters)
         expect(solr_parameters["q_1"]).to eq("Hello")
       end
@@ -192,13 +178,11 @@ RSpec.describe SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new("op_row" => ["is", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
 
       it "dereferences the key value" do
-        allow(context).to receive(:params).and_return(params)
         subject.exact_phrase_search(solr_parameters)
         expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
       end
 
       it "quotes the passed in value." do
-        allow(context).to receive(:params).and_return(params)
         subject.exact_phrase_search(solr_parameters)
         expect(solr_parameters["q_1"]).to eq("\"Hello\"")
       end
@@ -209,13 +193,11 @@ RSpec.describe SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new("op_row" => ["is", "contains", "contains"], "q_1" => "Hello", "q_2" => "World", search_field: "advanced") }
 
       it "dereferences multiple key values" do
-        allow(context).to receive(:params).and_return(params)
         subject.exact_phrase_search(solr_parameters)
         expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\" ")
       end
 
       it "quotes the passed if used" do
-        allow(context).to receive(:params).and_return(params)
         subject.exact_phrase_search(solr_parameters)
         expect(solr_parameters["q_1"]).to eq("\"Hello\"")
         expect(solr_parameters["q_2"]).to eq("World")
@@ -228,9 +210,9 @@ RSpec.describe SearchBuilder , type: :model do
       let(:params2) { ActionController::Parameters.new("op_row" => ["is", "contains", "contains"], "q_1" => "Hello", search_field: "advanced") }
 
       it "quotes the passed in value." do
-        allow(context).to receive(:params).and_return(params1)
+        allow(search_builder).to receive(:blacklight_params).and_return(params1)
         subject.begins_with_search(solr_parameters)
-        allow(context).to receive(:params).and_return(params2)
+        allow(search_builder).to receive(:blacklight_params).and_return(params2)
         subject.exact_phrase_search(solr_parameters)
         expect(solr_parameters["q_1"]).to eq("\"Hello\"")
       end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -9,6 +9,32 @@ RSpec.describe SearchBuilder , type: :model do
 
   subject { search_builder }
 
+  describe ".disable_advanced_spellcheck" do
+    let(:solr_parameters) { Blacklight::Solr::Request.new(spellcheck: "true") }
+
+    context "when not doing an advanced search" do
+      let(:params) { ActionController::Parameters.new }
+
+      it "does not disable the spellcheck" do
+        allow(context).to receive(:params).and_return(params)
+        subject.disable_advanced_spellcheck(solr_parameters)
+        expect(solr_parameters["spellcheck"]).to eq("true")
+      end
+
+    end
+
+    context "when doing an advanced search" do
+      let(:params) { ActionController::Parameters.new(search_field: "advanced") }
+
+      it "disables the spellcheck" do
+        allow(context).to receive(:params).and_return(params)
+        subject.disable_advanced_spellcheck(solr_parameters)
+        expect(solr_parameters["spellcheck"]).to eq("false")
+      end
+    end
+  end
+
+
   describe "#begins_with_search" do
     context "passing empty solr_parameters" do
       it "does nothing" do


### PR DESCRIPTION
REF BL-234

There are some odd spelling suggestions made when the advanced search query is executed.  I tried many options to fix this but nothing work.  The blunt solution is to disable spelling suggestions altogether when in the advanced search contetext.

QA Steps
===
- Make a search in advanced for "the sun" using the :begins_with precision method.
- [ ] Verify that 2 results show up without any extra spelling suggestions.