### PR TITLE
Bl 244 update home page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -228,9 +228,9 @@ class CatalogController < ApplicationController
     #    :years_25 => { label: 'within 25 Years', fq: "pub_date:[#{Time.zone.now.year - 25 } TO *]" }
     # }
 
-    config.add_facet_field "availability_facet", label: "Availability"
-    config.add_facet_field "library_facet", label: "Library", limit: true, show: true
-    config.add_facet_field "format", label: "Resource Type", limit: true, show: true
+    config.add_facet_field "availability_facet", label: "Availability", home: true
+    config.add_facet_field "library_facet", label: "Library", limit: true, show: true, home: true
+    config.add_facet_field "format", label: "Resource Type", limit: true, show: true, home: true
     config.add_facet_field "pub_date_sort", label: "Date", range: true
     config.add_facet_field "creator_facet", label: "Author/creator", limit: true, show: true
     config.add_facet_field "subject_facet", label: "Subject", limit: true, show: false

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module BlacklightHelper
+  include Blacklight::BlacklightHelperBehavior
+
+  def only_home_facets(solr_parameters, user_paramters)
+    solr_parameters["facet.field"], solr_parameters["facet.pivot"] = home_facets, [] unless has_search_parameters?
+  end
+end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module BlacklightHelper
-  include Blacklight::BlacklightHelperBehavior
-
-  def only_home_facets(solr_parameters, user_paramters)
-    solr_parameters["facet.field"], solr_parameters["facet.pivot"] = home_facets, [] unless has_search_parameters?
-  end
-end

--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FacetsHelper
+  include Blacklight::FacetsHelperBehavior
+
+  def render_home_facets
+    render_facet_partials home_facets
+  end
+
+  def home_facets
+    blacklight_config.facet_fields.select { |_, v| v[:home] }.keys
+  end
+end

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,0 +1,22 @@
+<% # main container for facets/limits menu -%>
+<% if has_facet_values?  %>
+<div id="facets" class="facets sidenav">
+
+<div class="top-panel-heading panel-heading">
+   <button type="button" class="facets-toggle" data-toggle="collapse" data-target="#facet-panel-collapse">
+     <span class="sr-only">Toggle facets</span>
+     <span class="icon-bar"></span>
+     <span class="icon-bar"></span>
+     <span class="icon-bar"></span>
+   </button>
+
+   <h2 class='facets-heading'>
+     <%= t('blacklight.search.facets.title') %>
+   </h2>
+ </div>
+
+ <div id="facet-panel-collapse" class="collapse panel-group">
+   <%= has_search_parameters? ? render_facet_partials : render_home_facets %>
+ </div>
+</div>
+<% end %>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,0 +1,7 @@
+<div class="page-header row">
+  <h2 class="col-md-8 page-heading">Try our new beta Library Search</h2>
+</div>
+
+<div id="getting-started">
+  <h3 class='section-heading'>Based on user feedback, Temple University Libraries is in the process of building an enhanced version of the Library Search. This is still under development, as we continue develop and add new features through spring 2018. Try out the new beta and let us know what you think at asktulibrary@temple.edu!</h3>
+</div>

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "library_stdnums"
 
 # A set of custom traject macros (extractors and normalizers) used by the
@@ -26,11 +28,11 @@ module Traject
       end
 
       def creator_name_trim_punctuation(name)
-        name.sub(/ *[ ,\/;:] *\Z/, '').sub(/( *[[:word:]]{3,})\. *\Z/, '\1')
+        name.sub(/ *[ ,\/;:] *\Z/, "").sub(/( *[[:word:]]{3,})\. *\Z/, '\1')
       end
 
       def creator_role_trim_punctuation(role)
-        role.sub(/ *[ ,.\/;:] *\Z/, '')
+        role.sub(/ *[ ,.\/;:] *\Z/, "")
       end
 
       def extract_creator

--- a/spec/features/home_facets_spec.rb
+++ b/spec/features/home_facets_spec.rb
@@ -6,9 +6,9 @@ RSpec.feature "Advanced Search" do
 
   describe "Facets rendered" do
     it "Only a subset of all the facets render on the homepage" do
-      visit  "/catalog"
+      visit "/catalog"
       home_facets = page.all(".facet_limit").length
-      visit  "/catalog?search_field=all_fields"
+      visit "/catalog?search_field=all_fields"
       search_facets = page.all(".facet_limit").length
       expect(home_facets).to be < search_facets
     end

--- a/spec/features/home_facets_spec.rb
+++ b/spec/features/home_facets_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Facets rendered" do
+  it "Only a subset of all the facets render on the homepage" do
+    visit  "/catalog"
+    home_facets = page.all(".facet_limit").length
+    visit  "/catalog?search_field=all_fields"
+    search_facets = page.all(".facet_limit").length
+    expect(home_facets).to be < search_facets
+  end
+end

--- a/spec/features/home_facets_spec.rb
+++ b/spec/features/home_facets_spec.rb
@@ -2,12 +2,15 @@
 
 require "rails_helper"
 
-describe "Facets rendered" do
-  it "Only a subset of all the facets render on the homepage" do
-    visit  "/catalog"
-    home_facets = page.all(".facet_limit").length
-    visit  "/catalog?search_field=all_fields"
-    search_facets = page.all(".facet_limit").length
-    expect(home_facets).to be < search_facets
+RSpec.feature "Advanced Search" do
+
+  describe "Facets rendered" do
+    it "Only a subset of all the facets render on the homepage" do
+      visit  "/catalog"
+      home_facets = page.all(".facet_limit").length
+      visit  "/catalog?search_field=all_fields"
+      search_facets = page.all(".facet_limit").length
+      expect(home_facets).to be < search_facets
+    end
   end
 end

--- a/spec/features/indices_spec.rb
+++ b/spec/features/indices_spec.rb
@@ -15,9 +15,10 @@ RSpec.feature "Indices", type: :feature do
     context "publicly available pages" do
       scenario "User visits home page" do
         visit "/"
-        expect(page).to have_text "Welcome!"
+        expect(page).to have_text "Try our new beta Library Search"
         within("#facets") do
-          expect(page).to have_text "Date"
+          expect(page).to have_text "Availability"
+          expect(page).to have_text "Library"
           expect(page).to have_text "Resource Type"
         end
       end


### PR DESCRIPTION
BL-244 This updates the text that displays on the home page.  It also uses the blacklight has_search_paramters? method to limit the facets displayed on the home page.  
- The home page should show only the facets for availability, library, and resource type.
![screen shot 2018-01-15 at 9 23 56 am](https://user-images.githubusercontent.com/15167238/34946695-d9dbfe4c-f9d5-11e7-8bc1-0f985d1f3e66.png)
- When search terms are used, all facets should render.
![screen shot 2018-01-15 at 9 24 55 am](https://user-images.githubusercontent.com/15167238/34946732-fbd5d45a-f9d5-11e7-9ca9-d6a2897b6e5a.png)

