### PR TITLE
Short circuit electronic_resource_display map when PRT field present.

### DIFF
--- a/lib/tasks/tulsearch.rake
+++ b/lib/tasks/tulsearch.rake
@@ -19,9 +19,15 @@ namespace :fortytu do
   end
 end
 
-desc "Ingest a single file into solr and commit"
+desc "Ingest a single file or all XML files in the sammple_data folder"
 task :ingest, [:filepath] => [:environment] do |t, args|
-  args.with_defaults(filepath: "sample_data/alma_bibs.xml")
-  `traject -c app/models/traject_indexer.rb #{args[:filepath]}`
+  if args[:filepath]
+    `traject -c app/models/traject_indexer.rb #{args[:filepath]}`
+  else
+    Dir.glob("sample_data/**/*.xml").each do |file|
+      `traject -c app/models/traject_indexer.rb #{file}`
+    end
+  end
+
   `traject -c app/models/traject_indexer.rb -x commit`
 end

--- a/sample_data/bl-196-example-data.xml
+++ b/sample_data/bl-196-example-data.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <leader>01993cam a2200493 i 4500</leader>
+    <controlfield tag="005">20160528094552.0</controlfield>
+    <controlfield tag="006">m |o d | </controlfield>
+    <controlfield tag="007">cr_|||||||||||</controlfield>
+    <controlfield tag="008">160502s2016 ne ob 001 0 eng </controlfield>
+    <controlfield tag="001">991023251419703811</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+      <subfield code="a">2016018023</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+      <subfield code="z">9789027242716 (hb : alk. paper)</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+      <subfield code="a">9789027266996 (MyiLibrary)</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+      <subfield code="a">9027266999</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(PPT)b61550863-01tuli_inst</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(CaONFJC)34015435</subfield>
+      <subfield code="9">ExL</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(OCoLC)0948669551</subfield>
+    </datafield>
+    <datafield tag="037" ind1=" " ind2=" ">
+      <subfield code="a">922986</subfield>
+      <subfield code="b">MIL</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">CaONFJC</subfield>
+      <subfield code="e">rda</subfield>
+      <subfield code="c">CaONFJC</subfield>
+    </datafield>
+    <datafield tag="042" ind1=" " ind2=" ">
+      <subfield code="a">pcc</subfield>
+    </datafield>
+    <datafield tag="090" ind1=" " ind2=" ">
+      <subfield code="a">P302.77</subfield>
+      <subfield code="b">.O33 2016eb</subfield>
+    </datafield>
+    <datafield tag="245" ind1="0" ind2="0">
+      <subfield code="a">Occupy</subfield>
+      <subfield code="h">[electronic resource] :</subfield>
+      <subfield code="b">the spatial dynamics of discourse in global protest movements /</subfield>
+      <subfield code="c">Edited by Luisa Mart&#xED;n Rojo.</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="1">
+      <subfield code="a">Amsterdam ;</subfield>
+      <subfield code="a">Philadelphia :</subfield>
+      <subfield code="b">John Benjamins Publishing Company,</subfield>
+      <subfield code="c">[2016]</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+      <subfield code="a">1 online resource.</subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+      <subfield code="a">text</subfield>
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+      <subfield code="a">computer</subfield>
+      <subfield code="b">c</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+      <subfield code="a">online resource</subfield>
+      <subfield code="b">cr</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="490" ind1="0" ind2=" ">
+      <subfield code="a">Benjamins current topics,</subfield>
+      <subfield code="x">1874-0081 ;</subfield>
+      <subfield code="v">83</subfield>
+    </datafield>
+    <datafield tag="590" ind1=" " ind2=" ">
+      <subfield code="a">Access is available to the Temple Community through use of a networked computer with a Temple IP address.</subfield>
+    </datafield>
+    <datafield tag="504" ind1=" " ind2=" ">
+      <subfield code="a">Includes bibliographical references and index.</subfield>
+    </datafield>
+    <datafield tag="588" ind1=" " ind2=" ">
+      <subfield code="a">Description based on print version record and CIP data provided by publisher.</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+      <subfield code="a">Discourse analysis</subfield>
+      <subfield code="x">Political aspects.</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+      <subfield code="a">Protest movements</subfield>
+      <subfield code="x">Political aspects.</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+      <subfield code="a">Public communication</subfield>
+      <subfield code="x">Political aspects.</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+      <subfield code="a">Communication in politics.</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="0">
+      <subfield code="a">Electronic books.</subfield>
+    </datafield>
+    <datafield tag="700" ind1="1" ind2=" ">
+      <subfield code="a">Mart&#xED;n Rojo, Luisa,</subfield>
+      <subfield code="e">editor.</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+      <subfield code="a">MyiLibrary.</subfield>
+    </datafield>
+    <datafield tag="776" ind1="0" ind2="8">
+      <subfield code="i">Print version:</subfield>
+      <subfield code="t">Occupy</subfield>
+      <subfield code="d">Amsterdam ; Philadelphia : John Benjamins Publishing Company, [2016]</subfield>
+      <subfield code="z">9789027242716</subfield>
+      <subfield code="w">(DLC) 2016007748</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="0">
+      <subfield code="u">http://libproxy.temple.edu/login?url=http://lib.myilibrary.com/detail.asp?id=922986</subfield>
+      <subfield code="z">Connect to MyiLibrary resource.</subfield>
+    </datafield>
+    <datafield tag="907" ind1=" " ind2=" ">
+      <subfield code="a">.b61550863</subfield>
+      <subfield code="b">w </subfield>
+      <subfield code="c">-</subfield>
+    </datafield>
+    <datafield tag="902" ind1=" " ind2=" ">
+      <subfield code="a">170531</subfield>
+    </datafield>
+    <datafield tag="998" ind1=" " ind2=" ">
+      <subfield code="b">1</subfield>
+      <subfield code="c">160620</subfield>
+      <subfield code="d">m</subfield>
+      <subfield code="e">@</subfield>
+      <subfield code="f">-</subfield>
+      <subfield code="g">0</subfield>
+    </datafield>
+    <datafield tag="998" ind1=" " ind2=" ">
+      <subfield code="a">06/20/16</subfield>
+      <subfield code="s">COUTTS</subfield>
+      <subfield code="c">MRTL</subfield>
+    </datafield>
+    <datafield tag="945" ind1=" " ind2=" ">
+      <subfield code="l">w </subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield tag="PRT" ind1=" " ind2=" ">
+      <subfield code="a">53382957990003811</subfield>
+      <subfield code="b">https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991023251419703811</subfield>
+      <subfield code="f">Connect to MyiLibrary resource.</subfield>
+      <subfield code="d">MAIN</subfield>
+      <subfield code="8">53382957990003811</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/spec/fixtures/marc_files/url_field_examples.xml
+++ b/spec/fixtures/marc_files/url_field_examples.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
+  <record>
+    <!-- 0. Neigther PRT nor 856 fiels -->
+  </record>
+  <record>
+    <!-- 1. Only singele PRT field  -->
+    <datafield tag="PRT" ind1=" " ind2=" ">
+      <subfield code="a">foo</subfield>
+      <subfield code="b">https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991026913959703811</subfield>
+      <subfield code="f">Access full text online.</subfield>
+      <subfield code="d">MAIN</subfield>
+      <subfield code="8">53377910870003811</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 2. Only multiple PRT field  -->
+    <datafield tag="PRT" ind1=" " ind2=" ">
+      <subfield code="a">foo</subfield>
+      <subfield code="b">https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991026913959703811</subfield>
+      <subfield code="f">Access full text online.</subfield>
+      <subfield code="d">MAIN</subfield>
+      <subfield code="8">53377910870003811</subfield>
+    </datafield>
+    <datafield tag="PRT" ind1=" " ind2=" ">
+      <subfield code="a">bar</subfield>
+      <subfield code="b">https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991026913959703811</subfield>
+      <subfield code="f">Access full text online.</subfield>
+      <subfield code="d">MAIN</subfield>
+      <subfield code="8">53377910870003811</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 3. Only single 856 field (no exception) -->
+    <datafield tag="856" ind1="4" ind2="0">
+      <subfield code="z">foo</subfield>
+      <subfield code="u">http://foobar.com</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 4. Only multiple 856 fields (no exceptions) -->
+    <datafield tag="856" ind1="4" ind2="1">
+      <subfield code="z">z</subfield>
+      <subfield code="3">3</subfield>
+      <subfield code="u">http://foobar.com</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="1">
+      <subfield code="y">y</subfield>
+      <subfield code="u">http://foobar.com</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="1">
+      <subfield code="u">http://foobar.com</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 5. Only single 856 field (with exception) -->
+    <datafield tag="856" ind1="4" ind2="1">
+      <subfield code="z">book review</subfield>
+      <subfield code="u">http://foobar.com</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 6. Multiple 856 fields (with exceptions) -->
+    NOT_FULL_TEXT = /book review|publisher description|sample text|table of contents/i
+    <datafield tag="856" ind1="4" ind2="1">
+      <subfield code="z">BOOK review</subfield>
+      <subfield code="u">http://foobar.com</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="1">
+      <subfield code="z">pubLisher description</subfield>
+      <subfield code="u">http://foobar.com</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="1">
+      <subfield code="z">tabLe of Contents</subfield>
+      <subfield code="u">http://foobar.com</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 7. PRT field and 856 field (with exception)  -->
+    <datafield tag="PRT" ind1=" " ind2=" ">
+      <subfield code="a">foo</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="1">
+      <subfield code="z">BOOK review</subfield>
+      <subfield code="u">http://foobar.com</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 8. PRT field and 856 field (no exception)  -->
+    <datafield tag="PRT" ind1=" " ind2=" ">
+      <subfield code="a">foo</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="1">
+      <subfield code="z">bar</subfield>
+      <subfield code="u">http://foobar.com</subfield>
+    </datafield>
+  </record>
+</collection>


### PR DESCRIPTION
REF BL-196

 ## Description
 * Adds tests for the indexing methods `extract_electronic_resource` and
   `extract_url_more_links`
 * Refactors said methods
 * Adds new functionality to methods (short circuit the
   electronic_resource_display map of 856 field when PRT field is/are
   present)
 * refactors `rake ingest` task to ingest all files within sample_data folder is no file is passed to it.

 QA Steps
 ===
 * Set up locally
 * Run `rake ingest` task
 * Search for "Occupy the spatial dynamics of discourse in global protest movements / Edited by Luisa Martín Rojo."
 * Compare that document to current version on libqa: https://libqa.library.temple.edu/catalog/catalog/991026913959703811
 - [x] Verify that new version does not include the "Access full text online" under the "Availability" section