### PR TITLE
Update trim punctuation

### DIFF
--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -16,6 +16,10 @@ solr_url = ERB.new(solr_config["url"]).result
 require "traject/macros/marc21_semantics"
 extend  Traject::Macros::Marc21Semantics
 
+# Overrides the trim_punctuation method to remove periods preceded by parentheses
+require "traject/macros/custom_marc21"
+
+
 # To have access to the traject marc format/carrier classifier
 require "traject/macros/marc_format_classifier"
 extend Traject::Macros::MarcFormats

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -28,7 +28,7 @@ module Traject
       end
 
       def creator_name_trim_punctuation(name)
-        name.sub(/ *[ ,\/;:] *\Z/, "").sub(/( *[[:word:]]{3,})\. *\Z/, '\1')
+        name.sub(/ *[ ,\/;:] *\Z/, "").sub(/( *[[:word:]]{3,})\. *\Z/, '\1').sub(/(?<=\))\./ , "")
       end
 
       def creator_role_trim_punctuation(role)

--- a/lib/traject/macros/custom_marc21.rb
+++ b/lib/traject/macros/custom_marc21.rb
@@ -1,22 +1,34 @@
-require 'traject/marc_extractor'
-require 'traject/translation_map'
-require 'traject/util'
-require 'base64'
-require 'json'
-require 'marc/fastxmlwriter'
+# frozen_string_literal: true
+
+require "traject/marc_extractor"
+require "traject/translation_map"
+require "traject/util"
+require "base64"
+require "json"
+require "marc/fastxmlwriter"
 
 module Traject::Macros
   # Some of these may be generic for any MARC, but we haven't done
   # the analytical work to think it through, some of this is
   # def specific to Marc21.
   module Marc21
+    # Trims punctuation mostly from end, and occasionally from beginning
+    # of string. Not nearly as complex logic as SolrMarc's version, just
+    # pretty simple.
+    #
+    # Removes
+    # * trailing: comma, slash, semicolon, colon (possibly preceded and followed by whitespace)
+    # * trailing period if it is preceded by at least three letters (possibly preceded and followed by whitespace)
+    # * single square bracket characters if they are the start and/or end
+    #   chars and there are no internal square brackets.
+    #
+    # Returns altered string, doesn't change original arg.
     def self.trim_punctuation(str)
-
       # If something went wrong and we got a nil, just return it
       return str unless str
 
       # trailing: comma, slash, semicolon, colon (possibly preceded and followed by whitespace)
-      str = str.sub(/ *[ ,\/;:] *\Z/, '')
+      str = str.sub(/ *[ ,\/;:] *\Z/, "")
 
       # trailing period if it is preceded by at least three letters (possibly preceded and followed by whitespace)
       str = str.sub(/( *[[:word:]]{3,})\. *\Z/, '\1')

--- a/lib/traject/macros/custom_marc21.rb
+++ b/lib/traject/macros/custom_marc21.rb
@@ -1,0 +1,37 @@
+require 'traject/marc_extractor'
+require 'traject/translation_map'
+require 'traject/util'
+require 'base64'
+require 'json'
+require 'marc/fastxmlwriter'
+
+module Traject::Macros
+  # Some of these may be generic for any MARC, but we haven't done
+  # the analytical work to think it through, some of this is
+  # def specific to Marc21.
+  module Marc21
+    def self.trim_punctuation(str)
+
+      # If something went wrong and we got a nil, just return it
+      return str unless str
+
+      # trailing: comma, slash, semicolon, colon (possibly preceded and followed by whitespace)
+      str = str.sub(/ *[ ,\/;:] *\Z/, '')
+
+      # trailing period if it is preceded by at least three letters (possibly preceded and followed by whitespace)
+      str = str.sub(/( *[[:word:]]{3,})\. *\Z/, '\1')
+
+      # single square bracket characters if they are the start and/or end
+      #   chars and there are no internal square brackets.
+      str = str.sub(/\A\[?([^\[\]]+)\]?\Z/, '\1')
+
+      # removes period when preceded by a paentheses
+      str = str.sub(/(?<=\))\./ , "")
+
+      # trim any leading or trailing whitespace
+      str.strip!
+
+      return str
+    end
+  end
+end

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -31,6 +31,9 @@
       <subfield code='b'>.I25 v.35</subfield>
     </datafield>
     <datafield ind1='1' ind2=' ' tag='100'>
+      <subfield code='a'>4 Learning (Firm).</subfield>
+    </datafield>
+    <datafield ind1='1' ind2=' ' tag='100'>
       <subfield code='a'>Whitney, Ellen M.</subfield>
     </datafield>
     <datafield ind1='1' ind2='4' tag='245'>

--- a/spec/models/traject_indexer_spec.rb
+++ b/spec/models/traject_indexer_spec.rb
@@ -6,78 +6,113 @@ require "traject/macros/custom"
 include Traject::Macros::MarcFormats
 include Traject::Macros::Custom
 
-RSpec.describe "four_digit_year(field):" do
-  describe "four_digit_year(field)" do
-    context "when field is nil" do
-      it "returns nil" do
-        expect(four_digit_year nil).to eq(nil)
+RSpec.describe "custom methods" do
+
+  describe "#four_digit_year(field):" do
+    describe "#four_digit_year(field)" do
+      context "when field is nil" do
+        it "returns nil" do
+          expect(four_digit_year nil).to eq(nil)
+        end
       end
-    end
 
-    context "when given an empty string" do
-      it "returns nil" do
-        expect(four_digit_year "").to eq(nil)
-        expect(four_digit_year "\n").to eq(nil)
-        expect(four_digit_year "\n\n").to eq(nil)
-        expect(four_digit_year "      ").to eq(nil)
+      context "when given an empty string" do
+        it "returns nil" do
+          expect(four_digit_year "").to eq(nil)
+          expect(four_digit_year "\n").to eq(nil)
+          expect(four_digit_year "\n\n").to eq(nil)
+          expect(four_digit_year "      ").to eq(nil)
+        end
       end
-    end
 
-    context "when contains Roman Numerals" do
-      it "returns nil" do
-        expect(four_digit_year "MCCXLV").to eq(nil)
+      context "when contains Roman Numerals" do
+        it "returns nil" do
+          expect(four_digit_year "MCCXLV").to eq(nil)
+        end
       end
-    end
 
-    it "returns nil for [n.d.],''" do
-      expect(four_digit_year '[n.d.],""').to eq(nil)
-    end
+      it "returns nil for [n.d.],''" do
+        expect(four_digit_year '[n.d.],""').to eq(nil)
+      end
 
-    it "extracts year from MCCXLV [1745],1745" do
-      expect(four_digit_year "MCCXLV [1745],1745").to eq("1745")
-    end
+      it "extracts year from MCCXLV [1745],1745" do
+        expect(four_digit_year "MCCXLV [1745],1745").to eq("1745")
+      end
 
-    it "extracts the first possible 4 digit numeral" do
-      expect(four_digit_year "1918-1966.,1918   ").to eq("1918")
-    end
+      it "extracts the first possible 4 digit numeral" do
+        expect(four_digit_year "1918-1966.,1918   ").to eq("1918")
+      end
 
-    it "extracts the first possible 4 digit numeral" do
-      expect(four_digit_year "'18-1966.,1918   ").to eq("1966")
-      expect(four_digit_year "c1993.,1993").to eq("1993")
-      expect(four_digit_year "©2012,2012").to eq("2012")
+      it "extracts the first possible 4 digit numeral" do
+        expect(four_digit_year "'18-1966.,1918   ").to eq("1966")
+        expect(four_digit_year "c1993.,1993").to eq("1993")
+        expect(four_digit_year "©2012,2012").to eq("2012")
+      end
     end
   end
-end
 
-RSpec.describe "#to_marc_normalized" do
+  describe "#to_marc_normalized" do
+    describe "#flank(field)" do
+      let(:input) {}
+      subject { Traject::Macros::Custom.flank input }
+      context "nil" do
+        it "returns an empty string" do
+          expect(subject).to be_nil
+        end
+      end
 
-  describe "#flank(field)" do
-    let(:input) {}
-    subject { Traject::Macros::Custom.flank input }
-    context "nil" do
-      it "returns an empty string" do
-        expect(subject).to be_nil
+      context "empty string" do
+        let(:input) { "" }
+        it "returns an empty string" do
+          expect(subject).to eq("")
+        end
+      end
+
+      context "non empty string" do
+        let(:input) { "foo" }
+        it "returns a flanked string" do
+          expect(subject).to eq("matchbeginswith foo matchendswith")
+        end
+      end
+
+      context "a string that is flanked" do
+        let(:input) { "matchbeginswith foo matchendswith" }
+        it "does not reflank a string" do
+          expect(subject).to eq(input)
+        end
       end
     end
+  end
 
-    context "empty string" do
-      let(:input) { "" }
-      it "returns an empty string" do
-        expect(subject).to eq("")
+  describe "#creator_name_trim_punctuation(name)" do
+    context "removes trailing comma, slash" do
+      let(:input) { "Richard M. Restak." }
+      it "removes trailing period" do
+        expect(creator_name_trim_punctuation(input)).to eq("Richard M. Restak")
       end
-    end
 
-    context "non empty string" do
-      let(:input) { "foo" }
-      it "returns a flanked string" do
-        expect(subject).to eq("matchbeginswith foo matchendswith")
+      let(:input) { "Richard M. Restak," }
+      it "removes trailing comma" do
+        expect(creator_name_trim_punctuation(input)).to eq("Richard M. Restak")
       end
-    end
 
-    context "a string that is flanked" do
-      let(:input) { "matchbeginswith foo matchendswith" }
-      it "does not reflank a string" do
-        expect(subject).to eq(input)
+      let(:input) { "Richard M. Restak/" }
+      it "removes trailing slash" do
+        expect(creator_name_trim_punctuation(input)).to eq("Richard M. Restak")
+      end
+
+      context "keeps period if preceded by characters other than parentheses" do
+        let(:input) { "Richard M. Restak" }
+        it "retains period after middle initial" do
+          expect(creator_name_trim_punctuation(input)).to eq("Richard M. Restak")
+        end
+      end
+
+      context "removes period following parentheses" do
+        let(:input) { "4 Learning (Firm)." }
+        it "retains period after middle initial" do
+          expect(creator_name_trim_punctuation(input)).to eq("4 Learning (Firm)")
+        end
       end
     end
   end


### PR DESCRIPTION
BL-230 Testing revealed that trailing periods preceded by a parentheses were not being removed.  
- overrides traject's trim_punctuation macro for creator_facets
- updates the creator_name_trim_punctuation method so that names on record pages link to the facet
- adds specs to test several different punctuation contexts
- in the spec/marc_fixture.xml file record 991012024509703811, you should expect the period to be visible in the middle initial of Whitney, Ellen M. and removed from 4 Learning(Firm)
![screen shot 2018-01-18 at 12 15 47 pm](https://user-images.githubusercontent.com/15167238/35111593-9ca76d06-fc49-11e7-88eb-efd7514f159e.png)
