### PR TITLE
Fix first boolean operator dropped.

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -46,14 +46,18 @@ class SearchBuilder < Blacklight::SearchBuilder
         # We de-reference values in order to be able to quote them; otherwise,
         # solr throws a 500 error: https://stackoverflow.com/a/10183238/256854
         #
-        # First we generate something like:
-        # [[["{}", "foo", "AND"], "q_1"], [["{}", "bar", "OR"], "q_2"]]
-        # And then we map that to ["_query_:..", "_query_:..."]
+        # First we take the query string and generate something like:
+        # [[["AND _query_:", "foo", "bar"], "q_1"], [["OR _query_:", "biz", "buz"], "q_2"]]
+        # And then we transform and rejoin that into a dereferenced query:
+        #
+        # "AND _query_:\"{foo v=$q_1}\" OR _query_:\"{biz v=$q_2}\""
+        #
         # @see :parse_queries, and :param_dereference methods below for more
         # details.
         queries = parse_queries(solr_parameters["q"])
           .zip(fields.keys)
           .map { |q, k| param_dereference(q, k) }
+
         solr_parameters["q"] = queries.join(" ")
 
         # De-referenced values have to be added as solr request parameters.
@@ -93,23 +97,26 @@ class SearchBuilder < Blacklight::SearchBuilder
     end
 
     # Given a blacklight solr query string in the form
-    # "_query_:\"{}foo\" (AND|OR|NOT) (__query:\"{}bar\")..."
-    # parses it to return an array of query components:
-    # [["{}", "foo", AND], ["{}", "bar", nil]]
+    # "AND _query_:\"{foo} bar\" NOT _query:\"{biz} buz\""
+    # splits it into its components (connector, local params, query)
+    # ["AND _query_:", "foo", "bar"], ["NOT", "biz", "buz"]]
     def parse_queries(query_string)
-      query_string.split("_query_:")
-        .select { |q| q[0..1] == "\"{" }
-        .map { |q| q.scan(/{(.*)}(.*)\".?(AND|OR|NOT)?/) }
-        .map { |q| q.flatten }
+      query_string
+        .scan(/((AND|OR|NOT|AND NOT)?\s*_query_:\"{.*?}.*?\")/)
+        .map { |q, _| q.scan(/(.*)\"{(.*)}(.*)\"/) }
+        .map(&:flatten)
     end
 
-    # Given an array q representing the components of a single query:
-    # i.e. ["{}", "foo", "AND"], generates a new string representation
-    # of the query.
+    # Given an array representing the components of a single query, and
+    # a parameter key: i.e. ["AND _query_:", "foo", "bar"], key
+    # generates dereferenced representation of the query.
+    #
+    # "AND _query_:\"{foo v=$key}\""
+    #
     # @see https://lucene.apache.org/solr/guide/6_6/local-parameters-in-queries.html
     # For details on local parameter dereferencing syntax.
     def param_dereference(q, k)
-      local_param, _, connector = q
-      "_query_:\"{#{local_param} v=$#{k}}\" #{connector}"
+      connector, local_param, _ = q
+      "#{connector}\"{#{local_param} v=$#{k}}\""
     end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -61,9 +61,13 @@ class SearchBuilder < Blacklight::SearchBuilder
         solr_parameters["q"] = queries.join(" ")
 
         # De-referenced values have to be added as solr request parameters.
+        # TODO: move to it's own preprocessor
         ops = blacklight_params.fetch("op_row", [])
         ops.zip(fields).each { |op, f|
           k, v = f
+          # REF BL-253
+          # advanced_search moves prefix BOOLEAN to query connector.
+          v = v.gsub(/^\s*(AND NOT|OR|NOT|AND)\s*/, "") unless v.nil?
           solr_parameters[k] = send(method, v, op)
         }
 
@@ -102,7 +106,7 @@ class SearchBuilder < Blacklight::SearchBuilder
     # ["AND _query_:", "foo", "bar"], ["NOT", "biz", "buz"]]
     def parse_queries(query_string)
       query_string
-        .scan(/((AND|OR|NOT|AND NOT)?\s*_query_:\"{.*?}.*?\")/)
+        .scan(/((AND NOT|OR|NOT|AND)?\s*_query_:\"{.*?}.*?\")/)
         .map { |q, _| q.scan(/(.*)\"{(.*)}(.*)\"/) }
         .map(&:flatten)
     end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -108,12 +108,17 @@ RSpec.describe SearchBuilder , type: :model do
     end
 
     context "passing advanced subqueries where start query is qualified" do
-      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "NOT _query_:\"{}Hello\" AND _query_:\"{}World\"") }
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "NOT _query_:\"{} NOT Hello\" AND _query_:\"{}World\"") }
       let(:params) { ActionController::Parameters.new("op_row" => ["begins_with", "contains", "contains"], "q_1" => "Hello", "q_2" => "World", search_field: "advanced") }
 
       it "does not drop the first query qualifier" do
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q"]).to eq("NOT _query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\"")
+      end
+
+      it "removes the prefixed BOOLEAN from a reference value" do
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q_1"]).to eq("\"#{begins_with_tag} Hello\"")
       end
     end
 

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences the key value" do
         subject.begins_with_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\"")
       end
 
       it "sets a custom solr_parameter for q_1 field." do
@@ -82,7 +82,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences the key value" do
         subject.begins_with_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\"")
       end
 
       it "quotes the passed in value." do
@@ -97,13 +97,23 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences multiple key values" do
         subject.begins_with_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\"")
       end
 
       it "quotes the passed if used" do
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q_1"]).to eq("\"#{begins_with_tag} Hello\"")
         expect(solr_parameters["q_2"]).to eq("World")
+      end
+    end
+
+    context "passing advanced subqueries where start query is qualified" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "NOT _query_:\"{}Hello\" AND _query_:\"{}World\"") }
+      let(:params) { ActionController::Parameters.new("op_row" => ["begins_with", "contains", "contains"], "q_1" => "Hello", "q_2" => "World", search_field: "advanced") }
+
+      it "does not drop the first query qualifier" do
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q"]).to eq("NOT _query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\"")
       end
     end
 
@@ -164,7 +174,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences the key value" do
         subject.exact_phrase_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\"")
       end
 
       it "sets a custom solr_parameter for q_1 field." do
@@ -179,7 +189,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences the key value" do
         subject.exact_phrase_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\"")
       end
 
       it "quotes the passed in value." do
@@ -194,7 +204,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences multiple key values" do
         subject.exact_phrase_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\"")
       end
 
       it "quotes the passed if used" do


### PR DESCRIPTION
REF BL-253

The `parse_queries` method used by some of our search_builder processing
is erroneoulsy dropping boolean operators from the first query.

This change refactors that method so that no information is lost.

 ## QA Steps
 * In libqa or locally run an advanced search query where the first query is "contains" "NOT moon" and the second query is connected with (*) AND  "contains" full.  Note the results.
 * Pull in the code and run the same query
 - [ ] Verify that the new search is limited as expected.