### PR TITLE
Bl 259 links to titles

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -258,9 +258,9 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
 
     config.add_show_field "title_statement_vern_display", label: "Title Statement"
-    config.add_show_field "title_uniform_display", label: "Uniform title"
+    config.add_show_field "title_uniform_display", label: "Uniform title", helper_method: :list_with_links
     config.add_show_field "title_uniform_vern_display", label: "Uniform title"
-    config.add_show_field "title_addl_display", label: "Additional titles"
+    config.add_show_field "title_addl_display", label: "Additional titles", helper_method: :list_with_links
     config.add_show_field "title_addl_vern_display", label: "Additional titles"
     config.add_show_field "creator_display", label: "Author/Creator", helper_method: :browse_creator, multi: true
     config.add_show_field "creator_vern_display", label: "Author/Creator", helper_method: :browse_creator

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,9 +10,12 @@ module ApplicationHelper
   end
 
   def get_search_params(field, query)
-    if field == "subject_display"
+    case field
+    when "subject_display"
       { controller: "catalog", action: "index", search_field: "subject", q: query.gsub(/>|—/, "") }
-    elsif field == "title_uniform_display" || field == "title_addl_display"
+    when "title_uniform_display"
+      { controller: "catalog", action: "index", search_field: "title", q: query }
+    when "title_addl_display"
       { controller: "catalog", action: "index", search_field: "title", q: query }
     else
       { controller: "catalog", action: "index", search_field: field, q: query }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,8 @@ module ApplicationHelper
   def get_search_params(field, query)
     if field == "subject_display"
       { controller: "catalog", action: "index", search_field: "subject", q: query.gsub(/>|—/, "") }
+    elsif field == "title_uniform_display" || field == "title_addl_display"
+      { controller: "catalog", action: "index", search_field: "title", q: query }
     else
       { controller: "catalog", action: "index", search_field: field, q: query }
     end

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature "RecordPageFields" do
         visit "catalog/#{item_130['doc_id']}"
         within "dd.blacklight-title_uniform_display" do
           expect(page).to have_text(item_130["title_uniform"])
+          expect(page).to have_link(item_130["title_uniform"])
         end
       end
 
@@ -38,6 +39,7 @@ RSpec.feature "RecordPageFields" do
         visit "catalog/#{item_240['doc_id']}"
         within "dd.blacklight-title_uniform_display" do
           expect(page).to have_text(item_240["title_uniform"])
+          expect(page).to have_link(item_240["title_uniform"])
         end
       end
 
@@ -46,6 +48,7 @@ RSpec.feature "RecordPageFields" do
         visit "catalog/#{item_730['doc_id']}"
         within "dd.blacklight-title_uniform_display" do
           expect(page).to have_text(item_730["title_uniform"])
+          expect(page).to have_link(item_730["title_uniform"])
         end
       end
 
@@ -64,6 +67,7 @@ RSpec.feature "RecordPageFields" do
       visit "catalog/#{item_210['doc_id']}"
       within "dd.blacklight-title_addl_display" do
         expect(page).to have_text(item_210["title_addl"])
+        expect(page).to have_link(item_210["title_addl"])
       end
     end
 
@@ -72,6 +76,7 @@ RSpec.feature "RecordPageFields" do
       visit "catalog/#{item_246['doc_id']}"
       within "dd.blacklight-title_addl_display" do
         expect(page).to have_text(item_246["title_addl"])
+        expect(page).to have_link(item_246["title_addl"])
       end
     end
 
@@ -80,6 +85,7 @@ RSpec.feature "RecordPageFields" do
       visit "catalog/#{item_247['doc_id']}"
       within "dd.blacklight-title_addl_display" do
         expect(page).to have_text(item_247["title_addl"])
+        expect(page).to have_link(item_247["title_addl"])
       end
     end
 
@@ -88,6 +94,7 @@ RSpec.feature "RecordPageFields" do
       visit "catalog/#{item_740['doc_id']}"
       within "dd.blacklight-title_addl_display" do
         expect(page).to have_text(item_740["title_addl"])
+        expect(page).to have_link(item_740["title_addl"])
       end
     end
 


### PR DESCRIPTION
BL-259 Adds the list_with_links helper method to title_addl_display and title_uniform_display
- refactor get_search_params now that there are three different fields using it
- add specs for links
- title_addl_display and title_uniform_display use list_with_links helper method
Going to record 991036813219903811 should display the additional titles as links.  
<img width="486" alt="screen shot 2018-01-19 at 11 13 09 am" src="https://user-images.githubusercontent.com/15167238/35159950-c97c4a3e-fd09-11e7-86d1-5da1936774c5.png">
