### PR TITLE
Fix search with colons fail.

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -34,17 +34,15 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def escape_colons(solr_parameters)
-    queries = parse_queries(solr_parameters["q"])
+    query = solr_parameters["q"] || ""
 
-    # [ c, l, q ] = [ connector, local_param, query ]
-    solr_parameters["q"] = queries
-      .map { |q| c, l, q = q; [c, l, q.gsub(":", "\\:")] }
-      .map(&:join)
-      .join(" ")
+    return unless !query.empty?
 
-    # In the advanced search context the dereferenced values must be escaped.
+    # In the advanced search context dereferenced values must be escaped.
     if blacklight_params["search_field"] == "advanced"
-      fields.each { |k, v| solr_parameters[k] = v.gsub(":", "\\:") }
+      fields.each { |k, v| solr_parameters[k] = v.gsub(/:/, " ") }
+    else
+      solr_parameters["q"] = query.gsub(/:/, " ")
     end
   end
 

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -46,14 +46,18 @@ class SearchBuilder < Blacklight::SearchBuilder
         # We de-reference values in order to be able to quote them; otherwise,
         # solr throws a 500 error: https://stackoverflow.com/a/10183238/256854
         #
-        # First we generate something like:
-        # [[["{}", "foo", "AND"], "q_1"], [["{}", "bar", "OR"], "q_2"]]
-        # And then we map that to ["_query_:..", "_query_:..."]
+        # First we take the query string and generate something like:
+        # [[["AND _query_:", "foo", "bar"], "q_1"], [["OR _query_:", "biz", "buz"], "q_2"]]
+        # And then we transform and rejoin that into a dereferenced query:
+        #
+        # "AND _query_:\"{foo v=$q_1}\" OR _query_:\"{biz v=$q_2}\""
+        #
         # @see :parse_queries, and :param_dereference methods below for more
         # details.
         queries = parse_queries(solr_parameters["q"])
           .zip(fields.keys)
           .map { |q, k| param_dereference(q, k) }
+
         solr_parameters["q"] = queries.join(" ")
 
         # De-referenced values have to be added as solr request parameters.
@@ -93,23 +97,26 @@ class SearchBuilder < Blacklight::SearchBuilder
     end
 
     # Given a blacklight solr query string in the form
-    # "_query_:\"{}foo\" (AND|OR|NOT) (__query:\"{}bar\")..."
-    # parses it to return an array of query components:
-    # [["{}", "foo", AND], ["{}", "bar", nil]]
+    # "AND _query_:\"{foo} bar\" NOT _query:\"{biz} buz\""
+    # splits it into its components (connector, local params, query)
+    # ["AND _query_:", "foo", "bar"], ["NOT", "biz", "buz"]]
     def parse_queries(query_string)
-      query_string.split("_query_:")
-        .select { |q| q[0..1] == "\"{" }
-        .map { |q| q.scan(/{(.*)}(.*)\".?(AND|OR|NOT)?/) }
-        .map { |q| q.flatten }
+      query_string
+        .scan(/((AND|OR|NOT|AND NOT)?\s*_query_:\"{.*?}.*?\")/)
+        .map { |q, _| q.scan(/(.*)\"{(.*)}(.*)\"/) }
+        .map(&:flatten)
     end
 
-    # Given an array q representing the components of a single query:
-    # i.e. ["{}", "foo", "AND"], generates a new string representation
-    # of the query.
+    # Given an array representing the components of a single query, and
+    # a parameter key: i.e. ["AND _query_:", "foo", "bar"], key
+    # generates dereferenced representation of the query.
+    #
+    # "AND _query_:\"{foo v=$key}\""
+    #
     # @see https://lucene.apache.org/solr/guide/6_6/local-parameters-in-queries.html
     # For details on local parameter dereferencing syntax.
     def param_dereference(q, k)
-      local_param, _, connector = q
-      "_query_:\"{#{local_param} v=$#{k}}\" #{connector}"
+      connector, local_param, _ = q
+      "#{connector}\"{#{local_param} v=$#{k}}\""
     end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -15,7 +15,7 @@ class SearchBuilder < Blacklight::SearchBuilder
     [ :begins_with_search ] +
     [ :exact_phrase_search ] +
     [ :disable_advanced_spellcheck ] +
-    [ :escape_colons ]
+    [ :substitute_colons ]
 
 
   def begins_with_search(solr_parameters)
@@ -33,12 +33,12 @@ class SearchBuilder < Blacklight::SearchBuilder
     end
   end
 
-  def escape_colons(solr_parameters)
+  def substitute_colons(solr_parameters)
     query = solr_parameters["q"] || ""
 
     return unless !query.empty?
 
-    # In the advanced search context dereferenced values must be escaped.
+    # In the advanced the query is dereferenced.
     if blacklight_params["search_field"] == "advanced"
       fields.each { |k, v| solr_parameters[k] = v.gsub(/:/, " ") }
     else

--- a/spec/features/searches_spec.rb
+++ b/spec/features/searches_spec.rb
@@ -203,4 +203,25 @@ RSpec.feature "Searches" do
       end
     end
   end
+
+
+  feature "Search for an item with a colon in title" do
+    let (:item) { fixtures.fetch("has_a_colon") }
+    scenario "using default serch" do
+      visit "/"
+      fill_in "q", with: item["title_statement"]
+      click_button "Search"
+      within(".document-position-0 h3") do
+        expect(page).to have_text item["exact_title"]
+      end
+    end
+    scenario "using advanced serch" do
+      visit "/advanced"
+      fill_in "q_1", with: item["title_statement"]
+      click_button "advanced-search-submit"
+      within(".document-position-0 h3") do
+        expect(page).to have_text item["exact_title"]
+      end
+    end
+  end
 end

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -26007,4 +26007,114 @@
       <subfield code="f">MEDIA</subfield>
     </datafield>
   </record>
+  <record>
+    <leader>01044cam a2200289 i 4500</leader>
+    <controlfield tag="005">20111129105838.0</controlfield>
+    <controlfield tag="008">781007s1966    nbuc     b    000 0 eng d</controlfield>
+    <controlfield tag="001">991023012549703811</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(PPT)b50390545-01tuli_inst</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(OCoLC)ocn768308275</subfield>
+      <subfield code="9">ExL</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(OCoLC)4280382</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">LDL</subfield>
+      <subfield code="c">LDL</subfield>
+      <subfield code="d">PPT</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+      <subfield code="a">n-us---</subfield>
+    </datafield>
+    <datafield tag="079" ind1=" " ind2=" ">
+      <subfield code="a">ocm04280382</subfield>
+    </datafield>
+    <datafield tag="090" ind1=" " ind2=" ">
+      <subfield code="a">BV741</subfield>
+      <subfield code="b">.L588 1966 Littell</subfield>
+    </datafield>
+    <datafield tag="100" ind1="1" ind2=" ">
+      <subfield code="a">Littell, Franklin H.</subfield>
+      <subfield code="q">(Franklin Hamlin),</subfield>
+      <subfield code="d">1917-2009.</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+      <subfield code="a">Religious liberty :</subfield>
+      <subfield code="b">the positive dimension : an address /</subfield>
+      <subfield code="c">by Franklin H. Littell at Doane College on April 26, 1966.</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="a">[Crete, Neb.] :</subfield>
+      <subfield code="b">Doane College,</subfield>
+      <subfield code="c">[1966]</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+      <subfield code="a">22 p. :</subfield>
+      <subfield code="b">port. ;</subfield>
+      <subfield code="c">22 cm.</subfield>
+    </datafield>
+    <datafield tag="504" ind1=" " ind2=" ">
+      <subfield code="a">Includes bibliographical references.</subfield>
+    </datafield>
+    <datafield tag="590" ind1=" " ind2=" ">
+      <subfield code="a">Given by Drs. Jonathan and Susan Sachs in honor of Drs. Franklin and Marcia Sachs Littell.</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+      <subfield code="a">Freedom of religion</subfield>
+      <subfield code="z">United States.</subfield>
+    </datafield>
+    <datafield tag="740" ind1="0" ind2=" ">
+      <subfield code="a">Franklin and Marcia Sachs Littell Collection.</subfield>
+      <subfield code="5">PPT</subfield>
+    </datafield>
+    <datafield tag="907" ind1=" " ind2=" ">
+      <subfield code="a">.b50390545</subfield>
+      <subfield code="b">s    </subfield>
+      <subfield code="c">-</subfield>
+    </datafield>
+    <datafield tag="902" ind1=" " ind2=" ">
+      <subfield code="a">130919</subfield>
+    </datafield>
+    <datafield tag="998" ind1=" " ind2=" ">
+      <subfield code="b">0</subfield>
+      <subfield code="c">111129</subfield>
+      <subfield code="d">m</subfield>
+      <subfield code="e">a</subfield>
+      <subfield code="f">-</subfield>
+      <subfield code="g">0</subfield>
+    </datafield>
+    <datafield tag="998" ind1=" " ind2=" ">
+      <subfield code="a">11/29/11</subfield>
+      <subfield code="s">OCLC</subfield>
+      <subfield code="c">RM</subfield>
+    </datafield>
+    <datafield tag="945" ind1=" " ind2=" ">
+      <subfield code="l">srare</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield tag="HLD" ind1="0" ind2=" ">
+      <subfield code="b">SCRC</subfield>
+      <subfield code="c">rarestacks</subfield>
+      <subfield code="h">BV741</subfield>
+      <subfield code="i">.L588 1966 Littell</subfield>
+      <subfield code="8">22307851340003811</subfield>
+    </datafield>
+    <datafield tag="ITM" ind1=" " ind2=" ">
+      <subfield code="r">22307851340003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">rarestacks</subfield>
+      <subfield code="9">39074027330349</subfield>
+      <subfield code="e">rarestacks</subfield>
+      <subfield code="8">23307851320003811</subfield>
+      <subfield code="a">4</subfield>
+      <subfield code="q">2017-06-20 10:58:36</subfield>
+      <subfield code="i">BV741 .L588 1966 Littell</subfield>
+      <subfield code="d">SCRC</subfield>
+      <subfield code="f">SCRC</subfield>
+  </record>
 </collection>

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -26116,5 +26116,6 @@
       <subfield code="i">BV741 .L588 1966 Littell</subfield>
       <subfield code="d">SCRC</subfield>
       <subfield code="f">SCRC</subfield>
+    </datafield>
   </record>
 </collection>

--- a/spec/fixtures/search_features.yml
+++ b/spec/fixtures/search_features.yml
@@ -54,3 +54,7 @@ results_queries:
     query_type:
       - "title"
       - "subtitle"
+has_a_colon:
+  doc_id: "991023012549703811"
+  title_statement: "Religious liberty :the positive dimension : an address"
+  exact_title: " Religious liberty : the positive dimension : an address / by Franklin H. Littell at Doane College on April 26, 1966."

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe SearchBuilder , type: :model do
     allow(search_builder).to receive(:blacklight_params).and_return(params)
   end
 
-  describe ".escape_colons" do
+  describe ".substitute_colons" do
     let(:solr_parameters) { Blacklight::Solr::Request.new(q: "foo :: bar:buzz") }
 
     before(:example) do
-      subject.escape_colons(solr_parameters)
+      subject.substitute_colons(solr_parameters)
     end
 
     context "when not doing an advanced search" do

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -15,40 +15,15 @@ RSpec.describe SearchBuilder , type: :model do
   end
 
   describe ".escape_colons" do
-    let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{ foo:bar }Hello:World\"") }
+    let(:solr_parameters) { Blacklight::Solr::Request.new(q: "foo :: bar:buzz") }
 
     before(:example) do
       subject.escape_colons(solr_parameters)
     end
 
     context "when not doing an advanced search" do
-      it "does not escape colons in _query_: tag" do
-        expect(solr_parameters["q"]).to match(/_query_:/)
-      end
-
-      it "does not escape colons within the local parameters section" do
-        expect(solr_parameters["q"]).to match(/foo:bar/)
-      end
-
-      it "escapes the colons within the query section" do
-        expect(solr_parameters["q"]).to match(/Hello\\:World/)
-      end
-    end
-
-    context "when doing a multi query" do
-      let(:solr_parameters) {
-        Blacklight::Solr::Request.new(
-          q: "_query_:\"{ foo:bar }Hello:World : ::\" AND _query_:\"{bizz:buzz} foo : bum\""
-        )
-      }
-
-      it "does not escape colons within any local param section" do
-        expect(solr_parameters["q"]).to match(/bizz:buzz/)
-      end
-
-      it "escapes all the colons within the query sections" do
-        expect(solr_parameters["q"]).to match(/ \\: \\:\\:/)
-        expect(solr_parameters["q"]).to match(/foo \\: bum/)
+      it "substitutes all the colons with spaces" do
+        expect(solr_parameters["q"]).to eq("foo    bar buzz")
       end
     end
 
@@ -59,9 +34,9 @@ RSpec.describe SearchBuilder , type: :model do
         q_2: ":foo ::: bar",
       ) }
 
-      it "escapse colons in the addtional query values: q_1, q_2, q_3" do
-        expect(solr_parameters["q_1"]).to eq("\\:")
-        expect(solr_parameters["q_2"]).to eq("\\:foo \\:\\:\\: bar")
+      it "substitue colons in the addtional query values: q_1, q_2, q_3" do
+        expect(solr_parameters["q_1"]).to eq(" ")
+        expect(solr_parameters["q_2"]).to eq(" foo     bar")
       end
     end
   end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences the key value" do
         subject.begins_with_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\"")
       end
 
       it "sets a custom solr_parameter for q_1 field." do
@@ -82,7 +82,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences the key value" do
         subject.begins_with_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\"")
       end
 
       it "quotes the passed in value." do
@@ -97,13 +97,23 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences multiple key values" do
         subject.begins_with_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\"")
       end
 
       it "quotes the passed if used" do
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q_1"]).to eq("\"#{begins_with_tag} Hello\"")
         expect(solr_parameters["q_2"]).to eq("World")
+      end
+    end
+
+    context "passing advanced subqueries where start query is qualified" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "NOT _query_:\"{}Hello\" AND _query_:\"{}World\"") }
+      let(:params) { ActionController::Parameters.new("op_row" => ["begins_with", "contains", "contains"], "q_1" => "Hello", "q_2" => "World", search_field: "advanced") }
+
+      it "does not drop the first query qualifier" do
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q"]).to eq("NOT _query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\"")
       end
     end
 
@@ -164,7 +174,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences the key value" do
         subject.exact_phrase_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\"")
       end
 
       it "sets a custom solr_parameter for q_1 field." do
@@ -179,7 +189,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences the key value" do
         subject.exact_phrase_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\"")
       end
 
       it "quotes the passed in value." do
@@ -194,7 +204,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences multiple key values" do
         subject.exact_phrase_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\"")
       end
 
       it "quotes the passed if used" do


### PR DESCRIPTION
## Description

REF BL-252

Searches with : in them fail because : is a special field operator character in solr that modifies how the query operates.  Since our users do not know the names of any of our fields, it does not make sense to have this feature enabled.  Otherwise, it is just an unnecessary hurdle for our users.

In order to disable the feature, we need to substitute the colons with spaces. Escaping the character
doesn't work. 

## Dependencies
* Depends on #201, review and merge that first.

## QA Steps
* Before pulling down the code try searching for "Religious liberty in : America  the First Amendment in historical and contemporary perspective / Bruce T. Murray." locally.  You should get nothing.
- [ ] After pulling down the code verify that the same search pulls one record.