### PR TITLE
Normalize &/and queries

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -34,17 +34,15 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def escape_colons(solr_parameters)
-    queries = parse_queries(solr_parameters["q"])
+    query = solr_parameters["q"] || ""
 
-    # [ c, l, q ] = [ connector, local_param, query ]
-    solr_parameters["q"] = queries
-      .map { |q| c, l, q = q; [c, l, q.gsub(":", "\\:")] }
-      .map(&:join)
-      .join(" ")
+    return unless !query.empty?
 
-    # In the advanced search context the dereferenced values must be escaped.
+    # In the advanced search context dereferenced values must be escaped.
     if blacklight_params["search_field"] == "advanced"
-      fields.each { |k, v| solr_parameters[k] = v.gsub(":", "\\:") }
+      fields.each { |k, v| solr_parameters[k] = v.gsub(/:/, " ") }
+    else
+      solr_parameters["q"] = query.gsub(/:/, " ")
     end
   end
 

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -46,14 +46,18 @@ class SearchBuilder < Blacklight::SearchBuilder
         # We de-reference values in order to be able to quote them; otherwise,
         # solr throws a 500 error: https://stackoverflow.com/a/10183238/256854
         #
-        # First we generate something like:
-        # [[["{}", "foo", "AND"], "q_1"], [["{}", "bar", "OR"], "q_2"]]
-        # And then we map that to ["_query_:..", "_query_:..."]
+        # First we take the query string and generate something like:
+        # [[["AND _query_:", "foo", "bar"], "q_1"], [["OR _query_:", "biz", "buz"], "q_2"]]
+        # And then we transform and rejoin that into a dereferenced query:
+        #
+        # "AND _query_:\"{foo v=$q_1}\" OR _query_:\"{biz v=$q_2}\""
+        #
         # @see :parse_queries, and :param_dereference methods below for more
         # details.
         queries = parse_queries(solr_parameters["q"])
           .zip(fields.keys)
           .map { |q, k| param_dereference(q, k) }
+
         solr_parameters["q"] = queries.join(" ")
 
         # De-referenced values have to be added as solr request parameters.
@@ -93,23 +97,26 @@ class SearchBuilder < Blacklight::SearchBuilder
     end
 
     # Given a blacklight solr query string in the form
-    # "_query_:\"{}foo\" (AND|OR|NOT) (__query:\"{}bar\")..."
-    # parses it to return an array of query components:
-    # [["{}", "foo", AND], ["{}", "bar", nil]]
+    # "AND _query_:\"{foo} bar\" NOT _query:\"{biz} buz\""
+    # splits it into its components (connector, local params, query)
+    # ["AND _query_:", "foo", "bar"], ["NOT", "biz", "buz"]]
     def parse_queries(query_string)
-      query_string.split("_query_:")
-        .select { |q| q[0..1] == "\"{" }
-        .map { |q| q.scan(/{(.*)}(.*)\".?(AND|OR|NOT)?/) }
-        .map { |q| q.flatten }
+      query_string
+        .scan(/((AND|OR|NOT|AND NOT)?\s*_query_:\"{.*?}.*?\")/)
+        .map { |q, _| q.scan(/(.*)\"{(.*)}(.*)\"/) }
+        .map(&:flatten)
     end
 
-    # Given an array q representing the components of a single query:
-    # i.e. ["{}", "foo", "AND"], generates a new string representation
-    # of the query.
+    # Given an array representing the components of a single query, and
+    # a parameter key: i.e. ["AND _query_:", "foo", "bar"], key
+    # generates dereferenced representation of the query.
+    #
+    # "AND _query_:\"{foo v=$key}\""
+    #
     # @see https://lucene.apache.org/solr/guide/6_6/local-parameters-in-queries.html
     # For details on local parameter dereferencing syntax.
     def param_dereference(q, k)
-      local_param, _, connector = q
-      "_query_:\"{#{local_param} v=$#{k}}\" #{connector}"
+      connector, local_param, _ = q
+      "#{connector}\"{#{local_param} v=$#{k}}\""
     end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -15,7 +15,8 @@ class SearchBuilder < Blacklight::SearchBuilder
     [ :begins_with_search ] +
     [ :exact_phrase_search ] +
     [ :disable_advanced_spellcheck ] +
-    [ :substitute_colons ]
+    [ :substitute_colons ] +
+    [ :normalize_and_search ]
 
 
   def begins_with_search(solr_parameters)
@@ -43,6 +44,19 @@ class SearchBuilder < Blacklight::SearchBuilder
       fields.each { |k, v| solr_parameters[k] = v.gsub(/:/, " ") }
     else
       solr_parameters["q"] = query.gsub(/:/, " ")
+    end
+  end
+
+  def normalize_and_search(solr_parameters)
+    query = solr_parameters["q"] || ""
+
+    return unless !query.empty?
+
+    # In the advanced the query is dereferenced.
+    if blacklight_params["search_field"] == "advanced"
+      fields.each { |k, v| solr_parameters[k] = v.gsub(/ & /, " and ") }
+    else
+      solr_parameters["q"] = query.gsub(/ & /, " and ")
     end
   end
 

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -15,7 +15,7 @@ class SearchBuilder < Blacklight::SearchBuilder
     [ :begins_with_search ] +
     [ :exact_phrase_search ] +
     [ :disable_advanced_spellcheck ] +
-    [ :escape_colons ]
+    [ :substitute_colons ]
 
 
   def begins_with_search(solr_parameters)
@@ -33,12 +33,12 @@ class SearchBuilder < Blacklight::SearchBuilder
     end
   end
 
-  def escape_colons(solr_parameters)
+  def substitute_colons(solr_parameters)
     query = solr_parameters["q"] || ""
 
     return unless !query.empty?
 
-    # In the advanced search context dereferenced values must be escaped.
+    # In the advanced the query is dereferenced.
     if blacklight_params["search_field"] == "advanced"
       fields.each { |k, v| solr_parameters[k] = v.gsub(/:/, " ") }
     else

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe SearchBuilder , type: :model do
     allow(search_builder).to receive(:blacklight_params).and_return(params)
   end
 
-  describe ".escape_colons" do
+  describe ".substitute_colons" do
     let(:solr_parameters) { Blacklight::Solr::Request.new(q: "foo :: bar:buzz") }
 
     before(:example) do
-      subject.escape_colons(solr_parameters)
+      subject.substitute_colons(solr_parameters)
     end
 
     context "when not doing an advanced search" do

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -14,11 +14,52 @@ RSpec.describe SearchBuilder , type: :model do
     allow(search_builder).to receive(:blacklight_params).and_return(params)
   end
 
-  describe ".substitute_colons" do
+  describe "#normalize_and_search" do
+    let(:solr_parameters) { Blacklight::Solr::Request.new(q: "foo & bar") }
+
+    before(:example) do
+      subject.normalize_and_search(solr_parameters)
+    end
+
+    context "when search is empty" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new }
+      it "does nothing when search is empty" do
+        expect(solr_parameters["q"]).to be_nil
+      end
+    end
+
+    context "when not doing an advanced search" do
+      it "substitutes all the & with and" do
+        expect(solr_parameters["q"]).to eq("foo and bar")
+      end
+    end
+
+    context "when doing an advanced search" do
+      let(:params) { ActionController::Parameters.new(
+        search_field: "advanced",
+        q_1:  "foo & bar",
+        q_2: "bizz & buzz",
+      ) }
+
+      it "substitue colons in the addtional query values: q_1, q_2, q_3" do
+        expect(solr_parameters["q_1"]).to eq("foo and bar")
+        expect(solr_parameters["q_2"]).to eq("bizz and buzz")
+      end
+    end
+  end
+
+  describe "#substitute_colons" do
     let(:solr_parameters) { Blacklight::Solr::Request.new(q: "foo :: bar:buzz") }
 
     before(:example) do
       subject.substitute_colons(solr_parameters)
+    end
+
+    context "when search is empty" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new }
+      it "does nothing when search is empty" do
+        expect(solr_parameters["q"]).to be_nil
+      end
     end
 
     context "when not doing an advanced search" do

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -15,40 +15,15 @@ RSpec.describe SearchBuilder , type: :model do
   end
 
   describe ".escape_colons" do
-    let(:solr_parameters) { Blacklight::Solr::Request.new(q: "_query_:\"{ foo:bar }Hello:World\"") }
+    let(:solr_parameters) { Blacklight::Solr::Request.new(q: "foo :: bar:buzz") }
 
     before(:example) do
       subject.escape_colons(solr_parameters)
     end
 
     context "when not doing an advanced search" do
-      it "does not escape colons in _query_: tag" do
-        expect(solr_parameters["q"]).to match(/_query_:/)
-      end
-
-      it "does not escape colons within the local parameters section" do
-        expect(solr_parameters["q"]).to match(/foo:bar/)
-      end
-
-      it "escapes the colons within the query section" do
-        expect(solr_parameters["q"]).to match(/Hello\\:World/)
-      end
-    end
-
-    context "when doing a multi query" do
-      let(:solr_parameters) {
-        Blacklight::Solr::Request.new(
-          q: "_query_:\"{ foo:bar }Hello:World : ::\" AND _query_:\"{bizz:buzz} foo : bum\""
-        )
-      }
-
-      it "does not escape colons within any local param section" do
-        expect(solr_parameters["q"]).to match(/bizz:buzz/)
-      end
-
-      it "escapes all the colons within the query sections" do
-        expect(solr_parameters["q"]).to match(/ \\: \\:\\:/)
-        expect(solr_parameters["q"]).to match(/foo \\: bum/)
+      it "substitutes all the colons with spaces" do
+        expect(solr_parameters["q"]).to eq("foo    bar buzz")
       end
     end
 
@@ -59,9 +34,9 @@ RSpec.describe SearchBuilder , type: :model do
         q_2: ":foo ::: bar",
       ) }
 
-      it "escapse colons in the addtional query values: q_1, q_2, q_3" do
-        expect(solr_parameters["q_1"]).to eq("\\:")
-        expect(solr_parameters["q_2"]).to eq("\\:foo \\:\\:\\: bar")
+      it "substitue colons in the addtional query values: q_1, q_2, q_3" do
+        expect(solr_parameters["q_1"]).to eq(" ")
+        expect(solr_parameters["q_2"]).to eq(" foo     bar")
       end
     end
   end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences the key value" do
         subject.begins_with_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\"")
       end
 
       it "sets a custom solr_parameter for q_1 field." do
@@ -82,7 +82,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences the key value" do
         subject.begins_with_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\"")
       end
 
       it "quotes the passed in value." do
@@ -97,13 +97,23 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences multiple key values" do
         subject.begins_with_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\"")
       end
 
       it "quotes the passed if used" do
         subject.begins_with_search(solr_parameters)
         expect(solr_parameters["q_1"]).to eq("\"#{begins_with_tag} Hello\"")
         expect(solr_parameters["q_2"]).to eq("World")
+      end
+    end
+
+    context "passing advanced subqueries where start query is qualified" do
+      let(:solr_parameters) { Blacklight::Solr::Request.new(q: "NOT _query_:\"{}Hello\" AND _query_:\"{}World\"") }
+      let(:params) { ActionController::Parameters.new("op_row" => ["begins_with", "contains", "contains"], "q_1" => "Hello", "q_2" => "World", search_field: "advanced") }
+
+      it "does not drop the first query qualifier" do
+        subject.begins_with_search(solr_parameters)
+        expect(solr_parameters["q"]).to eq("NOT _query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\"")
       end
     end
 
@@ -164,7 +174,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences the key value" do
         subject.exact_phrase_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\"")
       end
 
       it "sets a custom solr_parameter for q_1 field." do
@@ -179,7 +189,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences the key value" do
         subject.exact_phrase_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\"")
       end
 
       it "quotes the passed in value." do
@@ -194,7 +204,7 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "dereferences multiple key values" do
         subject.exact_phrase_search(solr_parameters)
-        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\" ")
+        expect(solr_parameters["q"]).to eq("_query_:\"{ v=$q_1}\" AND _query_:\"{ v=$q_2}\"")
       end
 
       it "quotes the passed if used" do


### PR DESCRIPTION
REF BL-267
 
 ## Description
 Normalizes &/and searches by substituting " & " occurances in queries with
 "and".

 ## Dependicies
 * Review and merge #204 before merging this PR.

 ## QA Steps
 * Build locally.
 * Run a search that has & in it.
 - [ ] Verify that the same search with "and" instead of & has the same results.