### PR TITLE
Update mappings for creator/contributor subfield order

### DIFF
--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -82,7 +82,7 @@ to_field "title_sort", marc_sortable_title
 
 # Creator/contributor fields
 to_field "creator_t", extract_marc_with_flank("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejlmnopqrtu:710abcdelmnopt:711acdejlnopt", trim_punctuation: true)
-to_field "creator_facet", extract_marc("100abcdq:110abcd:111acdj:700abcdq:710abcd:711acdj", trim_punctuation: true)
+to_field "creator_facet", extract_marc("100abcdq:110abcd:111ancdj:700abcdq:710abcd:711ancdj", trim_punctuation: true)
 to_field "creator_display", extract_creator
 to_field "contributor_display", extract_contributor
 to_field "creator_vern_display", extract_creator_vern

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -38,18 +38,18 @@ module Traject
       def extract_creator
         lambda do |rec, acc|
           rec.fields("100").each do |f|
-            linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
+            linked_subfields = [f["a"], f["b"], f["c"], f["q"], f["d"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
             acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           rec.fields("110").each do |f|
-            linked_subfields = [f["a"], f["b"], f["c"], f["d"]].compact.join(" ")
+            linked_subfields = [f["a"], f["b"], f["d"], f["c"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["m"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
             acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           rec.fields("111").each do |f|
-            linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
-            plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
+            linked_subfields = [f["a"], f["n"], f["d"], f["c"], f["j"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["l"], f["o"], f["p"], f["t"]].compact.join(" ")
             acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
         end
@@ -58,18 +58,18 @@ module Traject
       def extract_creator_vern
         lambda do |rec, acc|
           MarcExtractor.cached("100abcdejlmnopqrtu", alternate_script: :only).collect_matching_lines(rec) do |f|
-            linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
+            linked_subfields = [f["a"], f["b"], f["c"], f["q"], f["d"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
             acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           MarcExtractor.cached("110abcdelmnopt", alternate_script: :only).collect_matching_lines(rec) do |f|
-            linked_subfields = [f["a"], f["b"], f["c"], f["d"]].compact.join(" ")
+            linked_subfields = [f["a"], f["b"], f["d"], f["c"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["m"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
             acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           MarcExtractor.cached("111acdejlnopt", alternate_script: :only).collect_matching_lines(rec) do |f|
-            linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
-            plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
+            linked_subfields = [f["a"], f["n"], f["d"], f["c"], f["j"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["l"], f["o"], f["p"], f["t"]].compact.join(" ")
             acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
         end
@@ -78,18 +78,18 @@ module Traject
       def extract_contributor
         lambda do |rec, acc|
           rec.fields("700").each do |f|
-            linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
+            linked_subfields = [f["a"], f["b"], f["c"], f["q"], f["d"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
             acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           rec.fields("710").each do |f|
-            linked_subfields = [f["a"], f["b"], f["c"], f["d"]].compact.join(" ")
+            linked_subfields = [f["a"], f["b"], f["d"], f["c"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["m"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
             acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           rec.fields("711").each do |f|
-            linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
-            plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
+            linked_subfields = [f["a"], f["n"], f["d"], f["c"], f["j"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["l"], f["o"], f["p"], f["t"]].compact.join(" ")
             acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
         end
@@ -98,18 +98,18 @@ module Traject
       def extract_contributor_vern
         lambda do |rec, acc|
           MarcExtractor.cached("700abcdejlmnopqrtu", alternate_script: :only).collect_matching_lines(rec) do |f|
-            linked_subfields = [f["a"], f["b"], f["c"], f["d"], f["q"]].compact.join(" ")
+            linked_subfields = [f["a"], f["b"], f["c"], f["q"], f["d"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["j"], f["l"], f["m"], f["n"], f["o"], f["p"], f["r"], f["t"], f["u"]].compact.join(" ")
             acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           MarcExtractor.cached("710abcdelmnopt", alternate_script: :only).collect_matching_lines(rec) do |f|
-            linked_subfields = [f["a"], f["b"], f["c"], f["d"]].compact.join(" ")
+            linked_subfields = [f["a"], f["b"], f["d"], f["c"]].compact.join(" ")
             plain_text_subfields = [f["e"], f["l"], f["m"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
             acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
           MarcExtractor.cached("711acdejlnopt", alternate_script: :only).collect_matching_lines(rec) do |f|
-            linked_subfields = [f["a"], f["c"], f["d"], f["j"]].compact.join(" ")
-            plain_text_subfields = [f["e"], f["l"], f["n"], f["o"], f["p"], f["t"]].compact.join(" ")
+            linked_subfields = [f["a"], f["n"], f["d"], f["c"], f["j"]].compact.join(" ")
+            plain_text_subfields = [f["e"], f["l"], f["o"], f["p"], f["t"]].compact.join(" ")
             acc << creator_name_trim_punctuation(linked_subfields) + "|" + creator_role_trim_punctuation(plain_text_subfields)
           end
         end

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -39,16 +39,16 @@ title_addl_740:
   title_addl: "Dictionary of American history: 740. Subfield N. Subfield P."
 creator_100:
   doc_id: "991012132499760617"
-  creator: "Giovanni, Nikki. Subfield B. Subfield C. Subfield D. Subfield Q. Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield R. Subfield T. Subfield U"
+  creator: "Giovanni, Nikki. Subfield B. Subfield C. Subfield Q. Subfield D. Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield R. Subfield T. Subfield U"
 creator_100_v:
   doc_id: "991012172649703811"
   creator_vern: "מעקלער, ד.ל"
 creator_110:
   doc_id: "991012132499760618"
-  creator: "Dictionary of American history: 110. Subfield B. Subfield C. Subfield D. Subfield E. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield T"
+  creator: "Dictionary of American history: 110. Subfield B. Subfield D. Subfield C. Subfield E. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield T"
 creator_111:
   doc_id: "991012132499760619"
-  creator: "Dictionary of American history: 111. Subfield C. Subfield D. Subfield J. Subfield E.  Subfield L. Subfield N. Subfield O. Subfield P. Subfield T"
+  creator: "Dictionary of American history: 111. Subfield N. Subfield D. Subfield C. Subfield J. Subfield E.  Subfield L. Subfield O. Subfield P. Subfield T"
 contributor_700:
   doc_id: "991012132499760620"
   creator: "Dictionary of American history: 700. Subfield B. Subfield C. Subfield D. Subfield E. Subfield J. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield T. Subfield U."


### PR DESCRIPTION
Changes the array order of the subfields so that it matches what the facet is returning. 
- this makes changes to traject, so you will need to clean your solr_wrapper and run bundle exec rake ingest.
-  In the record 991000673139703811, you should see Haggard, H. Rider (Henry Rider), 1856-1925 King Solomon's mines.  The data should be returned in that exact order and clicking on the link should take you to the search results page for author/creator Haggard, H. Rider (Henry Rider), 1856-1925.