### PR TITLE
Genre facets

### DIFF
--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -151,7 +151,7 @@ to_field "subject_display", extract_marc("600abcdefghklmnopqrstuvxyz:610abcdefgh
 to_field "subject_topic_facet", extract_marc("600abcdq:610ab:611a:630a:650a:653a:654ab:647acdg")
 to_field "subject_era_facet", extract_marc("648a:650y:651y:654y:655y:690y:647y", trim_punctuation: true)
 to_field "subject_region_facet", marc_geo_facet
-to_field "genre_facet", extract_marc("600v:610v:611v:630v:648v:650v:651v:655av:647v", trim_punctuation: true)
+to_field "genre_facet", extract_genre
 
 to_field "subject_t", extract_marc_with_flank(%W(
   600#{ATOU}

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -189,7 +189,7 @@ module Traject
           MarcExtractor.cached("600v:610v:611v:630v:648v:650v:651v:655av:647v").collect_matching_lines(rec) do |field, spec, extractor|
             genre = extractor.collect_subfields(field, spec).first
             unless GENRE_STOP_WORDS.match(genre)
-              acc << genre.gsub(/[[:punct:]]?$/,'') unless genre.nil?
+              acc << genre.gsub(/[[:punct:]]?$/, "") unless genre.nil?
             end
             acc.uniq!
           end

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -7,7 +7,7 @@ module Traject
   module Macros
     module Custom
       NOT_FULL_TEXT = /book review|publisher description|sample text|table of contents/i
-
+      GENRE_STOP_WORDS = /CD-ROM|CD-ROMs|Compact discs|Computer network resources|Databases|Electronic book|Electronic books|Electronic government information|Electronic journal|Electronic journals|Electronic newspapers|Electronic reference sources|Electronic resource|Full text|Internet resource|Internet resources|Internet videos|Online databases|Online resources|Periodical|Periodicals|Sound recordings|Streaming audio|Streaming video|Video recording|Videorecording|Web site|Web sites/i
       def get_xml
         lambda do |rec, acc|
           acc << MARC::FastXMLWriter.encode(rec)
@@ -182,6 +182,18 @@ module Traject
           end
           acc.uniq!
         }
+      end
+
+      def extract_genre
+        lambda do |rec, acc|
+          MarcExtractor.cached("600v:610v:611v:630v:648v:650v:651v:655av:647v").collect_matching_lines(rec) do |field, spec, extractor|
+            genre = extractor.collect_subfields(field, spec).first
+            unless GENRE_STOP_WORDS.match(genre)
+              acc << genre.gsub(/[[:punct:]]?$/,'') unless genre.nil?
+            end
+            acc.uniq!
+          end
+        end
       end
 
       def normalize_lc_alpha

--- a/spec/fixtures/marc_files/genre_facet_examples.xml
+++ b/spec/fixtures/marc_files/genre_facet_examples.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
+  <record>
+    <datafield ind1=' ' ind2='0' tag='650'>
+      <subfield code='a'>Rock musicians</subfield>
+      <subfield code='z'>England</subfield>
+      <subfield code='v'>Drama</subfield>
+    </datafield>
+  </record>
+  <record>
+    <datafield ind1=' ' ind2='0' tag='650'>
+      <subfield code='a'>Rock musicians</subfield>
+      <subfield code='z'>England</subfield>
+      <subfield code='v'>Electronic book</subfield>
+    </datafield>
+  </record>
 </collection>
-<record>
-  <datafield ind1=' ' ind2='0' tag='650'>
-    <subfield code='a'>Rock musicians</subfield>
-    <subfield code='z'>England</subfield>
-    <subfield code='v'>Biography.</subfield>
-  </datafield>
-</record>

--- a/spec/fixtures/marc_files/genre_facet_examples.xml
+++ b/spec/fixtures/marc_files/genre_facet_examples.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
+</collection>
+<record>
+  <datafield ind1=' ' ind2='0' tag='650'>
+    <subfield code='a'>Rock musicians</subfield>
+    <subfield code='z'>England</subfield>
+    <subfield code='v'>Biography.</subfield>
+  </datafield>
+</record>

--- a/spec/models/traject_indexer_spec.rb
+++ b/spec/models/traject_indexer_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe Traject::Macros::Custom do
         settings do
           provide "marc_source.type", "xml"
         end
+        ex1 = Traject::MarcExtractor.cached("600v:610v:611v:630v:648v:650v:651v:655av:647v", :separator => nil)
       end
     end
 
@@ -152,6 +153,13 @@ RSpec.describe Traject::Macros::Custom do
         expect(subject.map_record(records[0])).to eq("genre_facet" => ["Drama"])
       end
     end
+
+    context "String found in GENRE_STOP_WORDS" do
+      it "does not map a field to genre_facet" do
+        expect(subject.map_record(records[1])).to eq({})
+      end
+    end
+
 
   end
 

--- a/spec/models/traject_indexer_spec.rb
+++ b/spec/models/traject_indexer_spec.rb
@@ -144,7 +144,6 @@ RSpec.describe Traject::Macros::Custom do
         settings do
           provide "marc_source.type", "xml"
         end
-        ex1 = Traject::MarcExtractor.cached("600v:610v:611v:630v:648v:650v:651v:655av:647v", :separator => nil)
       end
     end
 

--- a/spec/models/traject_indexer_spec.rb
+++ b/spec/models/traject_indexer_spec.rb
@@ -130,11 +130,32 @@ RSpec.describe Traject::Macros::Custom do
     c
   end
 
-  let(:file) { File.new("spec/fixtures/marc_files/url_field_examples.xml") }
   let(:records) { Traject::MarcReader.new(file, subject.settings).to_a }
 
 
   subject { test_class.new }
+
+  describe "#extract_genre" do
+    let(:file) { File.new("spec/fixtures/marc_files/genre_facet_examples.xml") }
+    before(:each) do
+      subject.instance_eval do
+        to_field "genre_facet", extract_genre
+
+        settings do
+          provide "marc_source.type", "xml"
+        end
+      end
+    end
+
+    context "String not found in GENRE_STOP_WORDS" do
+      it "does map a field to genre_facet" do
+        expect(subject.map_record(records[0])).to eq("genre_facet" => ["Drama"])
+      end
+    end
+
+  end
+
+  let(:file) { File.new("spec/fixtures/marc_files/url_field_examples.xml") }
 
   describe "#extract_electronic_resource" do
     before(:each) do


### PR DESCRIPTION
BL-257 Refine genre_facet to exclude certain values.  When viewing the genre facet list, none of the following should appear:  
- CD-ROM|CD-ROMs|Compact discs|Computer network resources|Databases|Electronic book|Electronic books|Electronic government information|Electronic journal|Electronic journals|Electronic newspapers|Electronic reference sources|Electronic resource|Full text|Internet resource|Internet resources|Internet videos|Online databases|Online resources|Periodical|Periodicals|Sound recordings|Streaming audio|Streaming video|Video recording|Videorecording|Web site|Web sites