### PR TITLE
BL-298 Suppress endnotes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -467,6 +467,9 @@ class CatalogController < ApplicationController
     # Do not show library_view link
     config.show.document_actions.delete(:librarian_view)
 
+    # Do not show endnotes for beta release
+    config.show.document_actions.delete(:endnote)
+
     # Configuration for text to phone_number
     config.show.document_actions.delete(:sms)
     config.add_show_tools_partial(:message, callback: :message_action)


### PR DESCRIPTION
Deletes the "Export to Endnote" link for now since it won't be ready for the beta launch.