### PR TITLE
Fix query tests fail on travis not locally.

### DIFF
--- a/lib/tasks/tulsearch.rake
+++ b/lib/tasks/tulsearch.rake
@@ -7,7 +7,7 @@ namespace :fortytu do
 
     desc "Posts fixtures to Solr"
     task :load_fixtures do
-      Dir.glob("spec/fixtures/*.xml").each do |file|
+      Dir.glob("spec/fixtures/*.xml").sort.each do |file|
         `traject -c app/models/traject_indexer.rb #{file}`
       end
 
@@ -28,7 +28,7 @@ task :ingest, [:filepath] => [:environment] do |t, args|
   if args[:filepath]
     `traject -c app/models/traject_indexer.rb #{args[:filepath]}`
   else
-    Dir.glob("sample_data/**/*.xml").each do |file|
+    Dir.glob("sample_data/**/*.xml").sort.each do |file|
       `traject -c app/models/traject_indexer.rb #{file}`
     end
   end

--- a/spec/controllers/query_results_spec.rb
+++ b/spec/controllers/query_results_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe CatalogController, type: :controller do
@@ -5,14 +7,14 @@ RSpec.describe CatalogController, type: :controller do
   describe "Query results as JSON" do
     render_views
 
-    context 'to check that the search results' do
+    context "to check that the search results" do
       fixtures = YAML.load_file("#{fixture_path}/search_features.yml")
       test_queries = fixtures.fetch("results_queries")
       docs = []
       test_queries.each do |test_item|
         search_string = ""
 
-        test_item['query_type'].each do |query_field|
+        test_item["query_type"].each do |query_field|
           search_term = test_item[query_field]
           if search_term.kind_of?(Array) == true
             search_term = search_term.to_s
@@ -22,7 +24,7 @@ RSpec.describe CatalogController, type: :controller do
 
         it "for search #{search_string}" do
           for page in [1..2] do
-            get(:index, params: {q: search_string, page: page.to_s}, :format => :json)
+            get(:index, params: { q: search_string, page: page.to_s }, format: :json)
             docs += JSON.parse(response.body)["response"]["docs"]
           end
 

--- a/spec/features/searches_spec.rb
+++ b/spec/features/searches_spec.rb
@@ -14,36 +14,32 @@ RSpec.feature "Searches" do
       visit "/"
       fill_in "q", with: item["title"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(first(".document-position-0 h3", text: item["title"]))
+        .to have_text item["title"]
     end
 
     scenario "Search ID" do
       visit "/"
       fill_in "q", with: item["doc_id"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(first(".document-position-0 h3", text: item["title"]))
+        .to have_text item["title"]
     end
 
     scenario "Search book creator" do
       visit "/"
       fill_in "q", with: item["creator"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(first(".document-position-0 h3", text: item["title"]))
+        .to have_text item["title"]
     end
 
     scenario "Search imprint" do
       visit "/"
       fill_in "q", with: item["imprint"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(first(".document-position-0 h3", text: item["title"]))
+        .to have_text item["title"]
     end
 
     scenario "Search physical description" do
@@ -51,18 +47,16 @@ RSpec.feature "Searches" do
       visit "/"
       fill_in "q", with: item["physical_description"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(first(".document-position-0 h3", text: item["title"]))
+        .to have_text item["title"]
     end
 
     scenario "Search series title" do
       visit "/"
       fill_in "q", with: item["series_title"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(first(".document-position-0 h3", text: item["title"]))
+        .to have_text item["title"]
     end
 
     scenario "Search content" do
@@ -70,36 +64,32 @@ RSpec.feature "Searches" do
       visit "/"
       fill_in "q", with: item["content"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(first(".document-position-0 h3", text: item["title"]))
+        .to have_text item["title"]
     end
 
     scenario "Search subject" do
       visit "/"
       fill_in "q", with: item["subject"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(first(".document-position-0 h3", text: item["title"]))
+        .to have_text item["title"]
     end
 
     scenario "Search ISBN" do
       visit "/"
       fill_in "q", with: item["isbn"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(first(".document-position-0 h3", text: item["title"]))
+        .to have_text item["title"]
     end
 
     scenario "Search LCCN" do
       visit "/"
       fill_in "q", with: item["lccn"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(first(".document-position-0 h3", text: item["title"]))
+        .to have_text item["title"]
     end
   end
 
@@ -109,36 +99,28 @@ RSpec.feature "Searches" do
       visit "/"
       fill_in "q", with: item["title"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(page).to have_text item["title"]
     end
 
     scenario "Search ID" do
       visit "/"
       fill_in "q", with: item["doc_id"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(page).to have_text item["title"]
     end
 
     scenario "Search journal creator" do
       visit "/"
       fill_in "q", with: item["creator"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(page).to have_text item["title"]
     end
 
     scenario "Search imprint" do
       visit "/"
       fill_in "q", with: item["imprint"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(page).to have_text item["title"]
     end
 
     scenario "Search physical description" do
@@ -146,38 +128,28 @@ RSpec.feature "Searches" do
       visit "/"
       fill_in "q", with: item["physical_description"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(page).to have_text item["title"]
     end
 
     scenario "Search subject" do
       visit "/"
       fill_in "q", with: item["subject"]
       click_button "Search"
-      STDERR.puts "The search page HTML is..."
-      STDERR.puts page.html
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(page).to have_text item["title"]
     end
 
     scenario "Search ISSN" do
       visit "/"
       fill_in "q", with: item["issn"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(page).to have_text item["title"]
     end
 
     scenario "Search LCCN" do
       visit "/"
       fill_in "q", with: item["lccn"]
       click_button "Search"
-      within first(".document-position-0 h3", text: item["title"]) do
-        expect(page).to have_text item["title"]
-      end
+      expect(page).to have_text item["title"]
     end
   end
 
@@ -187,17 +159,13 @@ RSpec.feature "Searches" do
       visit "/"
       fill_in "q", with: item["title_statement"]
       click_button "Search"
-      within(".document-position-0 h3") do
-        expect(page).to have_text item["exact_title"]
-      end
+      expect(page).to have_text item["exact_title"]
     end
     scenario "using advanced serch" do
       visit "/advanced"
       fill_in "q_1", with: item["title_statement"]
       click_button "advanced-search-submit"
-      within(".document-position-0 h3") do
-        expect(page).to have_text item["exact_title"]
-      end
+      expect(page).to have_text item["exact_title"]
     end
   end
 end


### PR DESCRIPTION
* Apply sort to `Dir.glob` call to ensure order of files is the same locally and on travis.
* Updates order of ingested files so that specific records are not clobbered.
* Stop expect inside of within to avoid timing issues.