### PR TITLE
Make spec less brittle to timing issues.

### DIFF
--- a/spec/features/home_facets_spec.rb
+++ b/spec/features/home_facets_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature "Advanced Search" do
 
       visit "/catalog?search_field=all_fields&q=test"
       expect(page).to have_current_path("/catalog?search_field=all_fields&q=test")
-      expect(page).to have_text("You searched for:")
 
       search_facets = page.all(".facet_limit").length
       expect(home_facets).to be < search_facets

--- a/spec/features/home_facets_spec.rb
+++ b/spec/features/home_facets_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature "Advanced Search" do
       home_facets = page.all(".facet_limit").length
 
       visit "/catalog?search_field=all_fields&q=test"
+      expect(page).to have_current_path("/catalog?search_field=all_fields&q=test")
       expect(page).to have_text("You searched for:")
 
       search_facets = page.all(".facet_limit").length

--- a/spec/features/home_facets_spec.rb
+++ b/spec/features/home_facets_spec.rb
@@ -8,7 +8,10 @@ RSpec.feature "Advanced Search" do
     it "Only a subset of all the facets render on the homepage" do
       visit "/catalog"
       home_facets = page.all(".facet_limit").length
-      visit "/catalog?search_field=all_fields"
+
+      visit "/catalog?search_field=all_fields&q=test"
+      expect(page).to have_text("You searched for:")
+
       search_facets = page.all(".facet_limit").length
       expect(home_facets).to be < search_facets
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,7 @@ require "capybara/rspec"
 require "capybara/rails"
 
 # Add additional requires below this line. Rails is not loaded until this point!
+Capybara.default_max_wait_time = 5
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
By adding a `have_text` expectation we force capybara to retry
for up to 2 seconds (by default).  This makes sure that we get the
number of facets on the rendered search page instead of potentially on
the front page where it will be 3 thus creating a false negative when
3 is not < 3.