### PR TITLE
Add arrows to collapse buttons

### DIFF
--- a/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
+++ b/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
@@ -19,21 +19,18 @@ var BlacklightAlma = function (options) {
 
  availabilityButton = function(id, holding) {
    var availButton = $("button[data-availability-ids='" + id + "']");
-   if (!$(availButton).hasClass("btn-success")) {
+   if (!$(availButton).hasClass("btn-success collapse-button")) {
      if(holding['availability'] == 'available') {
-       console.log("success");
-       $(availButton).html("<span class='btn-drop-down available'>Available</span>");
+       $(availButton).html("<span class='avail-label'>Available</span>");
        $(availButton).removeClass("btn-default");
-       $(availButton).addClass("btn-success");
+       $(availButton).addClass("btn-success collapsed");
        $(availButton).show();
      }
      else if(holding['availability'] == 'check_holdings') {
-       console.log("check");
        $(availButton).hide();
      }
      else {
-       console.log("nothing");
-       $(availButton).html("<span class='btn-drop-down not-available'>Not Available</span>");
+       $(availButton).html("<span class='btn-drop-down collapsed collapse-button not-available'>Not Available</span>");
        $(availButton).removeClass("btn-default");
        $(availButton).addClass("btn-warning");
        $(availButton).show();

--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -126,6 +126,19 @@ div.physical-holding-panel {
   padding-top: 0;
 }
 
+button.collapse-button .avail-label:after {
+    /* symbol for "opening" panels */
+    font-family: 'Glyphicons Halflings';  /* essential for enabling glyphicon */
+    content: "\e114";    /* adjust as needed, taken from bootstrap.css */
+    float: right;        /* adjust as needed */
+    color: white;         /* adjust as needed */
+}
+button.collapse-button.collapsed .avail-label:after {
+    /* symbol for "collapsed" panels */
+    content: "\e080";    /* adjust as needed, taken from bootstrap.css */
+}
+
+
 /* === MEDIA QUERIES === */
 @media (min-width: 768px) {
   .show_page_records dd {

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -5,7 +5,9 @@
     <% if document["electronic_resource_display"].length == 1 %>
       <%= button_to "Online", single_link_builder(document["electronic_resource_display"][i]), class:"collapse-button btn btn-sm btn-info" %>
     <% else %>
-      <button class="btn-block btn btn-sm btn-info collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document_counter %>">Online</button>
+      <button class="btn-block btn btn-sm btn-info collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document_counter %>">
+        <span class="avail-label" aria-expanded="false">Online</span>
+      </button>
       <div id="online-document-<%= document_counter %>" class="collapse online_resources">
         <ul>
           <%= check_for_full_http_link({document: document, field: "electronic_resource_display"}) %>
@@ -16,7 +18,10 @@
 
   <% if document.fetch("availability_facet", [])[i] == "At the Library" %>
     <div class="row button-break"></div>
-    <button data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" class="btn btn-sm btn-default availability-toggle-details collapse-button" data-toggle="collapse" data-target="#physical-document-<%=  document_counter %>">Loading...</button>
+    <button data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" class="btn btn-sm btn-default availability-toggle-details collapse-button" data-toggle="collapse" data-target="#physical-document-<%=  document_counter %>">
+      <span class="avail-label" aria-expanded="false">Loading...</span>
+    </button>
+
     <dd class="blacklight-availability availability-ajax-load" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" ></dd>
     <div id="physical-document-<%= document_counter %>" class="collapse">
     <div class="availability-details-container" data-availability-iframe-url="<%= alma_app_fulfillment_url(document) %>"></div>


### PR DESCRIPTION
Add arrows for the availability collapse buttons. The buttons should point to the right in initial state, and then toggle down when clicked open and closed.