### PR TITLE
Fix sort breaks when title is nil.

### DIFF
--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -148,7 +148,7 @@ module Traject
               unless available
                 available = []
               end
-              [available[1] || "9999", available[2] || "9999", title, subtitle || ""]
+              [available[1] || "9999", available[2] || "9999", "#{title}", "#{subtitle}"]
             }.reverse!
           rescue
             logger.error("Failed `sort_electronic_resource!` on sorting #{rec}")


### PR DESCRIPTION
The code for sorting link elements does not properly handle the nil case
for a record title.  This commit resolves that issue.