### PR TITLE
Bl 226 show unable to renew indicator

### DIFF
--- a/app/views/users/_user_loans.html.erb
+++ b/app/views/users/_user_loans.html.erb
@@ -37,7 +37,11 @@
                 </label>
               </div>
             </td>
-            <td id="<%= loan.loan_id %>" class="overdue"><%= is_overdue(loan.loan_status) %></td>
+            <td id="<%= loan.loan_id %>" class="overdue"><%= is_overdue(loan.loan_status) %>
+              <% unless loan.renewable %>
+                <span class="glyphicon glyphicon-exclamation-sign"></span>
+              <% end %>
+            </td>
           </tr>
         <% end %>
           <tr>

--- a/app/views/users/_user_loans.html.erb
+++ b/app/views/users/_user_loans.html.erb
@@ -37,11 +37,7 @@
                 </label>
               </div>
             </td>
-            <td id="<%= loan.loan_id %>" class="overdue"><%= is_overdue(loan.loan_status) %>
-              <% unless loan.renewable %>
-                <span class="glyphicon glyphicon-exclamation-sign"></span>
-              <% end %>
-            </td>
+            <td id="<%= loan.loan_id %>" class="overdue"><%= is_overdue(loan.loan_status) %></td>
           </tr>
         <% end %>
           <tr>
@@ -49,7 +45,7 @@
             <div class="col col-md-10 text-left">Items marked with the unable to renew <span class="glyphicon glyphicon-exclamation-sign"></span> icon are not eligible for renewal at this time and are disabled.  Please visit your library's Circulation Desk for more information visit your library's Circulation Desk or <a href='http://library.temple.edu/asktulibraries'>Ask a Librarian</a>.</div>
             <div class="col col-md-2"><%= submit_tag "Renew Selected", class: "btn btn-white", id: "renew_selected" %></div></td>
             </tr>
-            
+
       <% end %>
     </tbody>
   </table>

--- a/spec/views/users/_user_loans.html.erb_spec.rb
+++ b/spec/views/users/_user_loans.html.erb_spec.rb
@@ -4,8 +4,12 @@ require "rails_helper"
 require "time"
 
 RSpec.describe "users/_user_loans.html.erb", type: :view do
+  before :each do
+    @loans = Alma::LoanSet.new({})
+  end
 
   let(:one_day) { 24 * 3600 }
+  
   context "Renewable" do
     let(:renewable_loan) {
       OpenStruct.new(
@@ -18,10 +22,27 @@ RSpec.describe "users/_user_loans.html.erb", type: :view do
         loan_status: "Active"
       )
     }
-
+    
+    let(:renewable_loan_without_flag) {
+      OpenStruct.new(
+        loan_id: "12345",
+        title: "History",
+        due_date: (Time.now + one_day).iso8601, # tomorrow
+        item_barcode: "000237055710000121",
+        call_number: "AA123",
+        loan_status: "Active"
+      )
+    }
+    
     it "doesn't show exclamation point in renewal column" do
-      @loans = Alma::LoanSet.new({})
       allow(@loans).to receive(:list).and_return([renewable_loan])
+
+      render partial: "users/user_loans"
+      expect(rendered).to_not have_css('td.renewal-check span.glyphicon-exclamation-sign[title="unable to renew"]')
+    end
+    
+    it "doesn't show exclamation point in renewal column" do
+      allow(@loans).to receive(:list).and_return([renewable_loan_without_flag])
 
       render partial: "users/user_loans"
       expect(rendered).to_not have_css('td.renewal-check span.glyphicon-exclamation-sign[title="unable to renew"]')
@@ -42,7 +63,6 @@ RSpec.describe "users/_user_loans.html.erb", type: :view do
     }
 
     it "shows exclamation point in renewal column" do
-      @loans = Alma::LoanSet.new({})
       allow(@loans).to receive(:list).and_return([nonrenewable_loan])
 
       render partial: "users/user_loans"

--- a/spec/views/users/_user_loans.html.erb_spec.rb
+++ b/spec/views/users/_user_loans.html.erb_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "time"
+
+RSpec.describe "users/_user_loans.html.erb", type: :view do
+
+  let(:one_day) { 24 * 3600 }
+  context "Renewable" do
+    let(:renewable_loan) {
+      OpenStruct.new(
+        loan_id: "12345",
+        title: "History",
+        due_date: (Time.now + one_day).iso8601, # tomorrow
+        item_barcode: "000237055710000121",
+        call_number: "AA123",
+        renewable: "true",
+        loan_status: "Active"
+      )
+    }
+
+    it "doesn't show exclamation point in renewal column" do
+      @loans = Alma::LoanSet.new({})
+      allow(@loans).to receive(:list).and_return([renewable_loan])
+
+      render partial: "users/user_loans"
+      expect(rendered).to_not have_css('td.renewal-check span.glyphicon-exclamation-sign[title="unable to renew"]')
+    end
+  end
+
+  context "Non-Renewable" do
+    let(:nonrenewable_loan) {
+      OpenStruct.new(
+        loan_id: "12345",
+        title: "History",
+        due_date: (Time.now + one_day).iso8601, # tomorrow
+        item_barcode: "000237055710000121",
+        call_number: "AA123",
+        renewable: "false",
+        loan_status: "Active"
+      )
+    }
+
+    it "shows exclamation point in renewal column" do
+      @loans = Alma::LoanSet.new({})
+      allow(@loans).to receive(:list).and_return([nonrenewable_loan])
+
+      render partial: "users/user_loans"
+      expect(rendered).to have_css('td.renewal-check span.glyphicon-exclamation-sign[title="unable to renew"]')
+    end
+  end
+end

--- a/spec/views/users/_user_loans.html.erb_spec.rb
+++ b/spec/views/users/_user_loans.html.erb_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "users/_user_loans.html.erb", type: :view do
   end
 
   let(:one_day) { 24 * 3600 }
-  
+
   context "Renewable" do
     let(:renewable_loan) {
       OpenStruct.new(
@@ -22,7 +22,7 @@ RSpec.describe "users/_user_loans.html.erb", type: :view do
         loan_status: "Active"
       )
     }
-    
+
     let(:renewable_loan_without_flag) {
       OpenStruct.new(
         loan_id: "12345",
@@ -33,14 +33,14 @@ RSpec.describe "users/_user_loans.html.erb", type: :view do
         loan_status: "Active"
       )
     }
-    
+
     it "doesn't show exclamation point in renewal column" do
       allow(@loans).to receive(:list).and_return([renewable_loan])
 
       render partial: "users/user_loans"
       expect(rendered).to_not have_css('td.renewal-check span.glyphicon-exclamation-sign[title="unable to renew"]')
     end
-    
+
     it "doesn't show exclamation point in renewal column" do
       allow(@loans).to receive(:list).and_return([renewable_loan_without_flag])
 


### PR DESCRIPTION
The data viewed had no items that were not renewable. Run test against user with uid: "20180130" to see one item that is not renewable.

Spec for view partial added to verify logic non-renewable indicator logic.