### PR TITLE
Updated glyphicons on facets for color contrast.

### DIFF
--- a/app/assets/stylesheets/partials/_facets.scss
+++ b/app/assets/stylesheets/partials/_facets.scss
@@ -54,27 +54,14 @@ a.catalog_startOverLink {
 	color: $red;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+.facet_limit-active {
+	.panel-heading.collapse-toggle.collapsed .panel-title:after {
+		color: white;
+	}
+	.panel-heading.collapse-toggle .panel-title:after {
+		color: white;
+	}
+	.panel-heading.collapse-toggle.collapsed .panel-title:after {
+		color: white;
+	}
+}


### PR DESCRIPTION
left sidebar, white when active