### PR TITLE
Disable spellcheck feature.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -163,7 +163,7 @@ class CatalogController < ApplicationController
         subject_addl_t^10
       ].join(" "),
       facet: "true",
-      spellcheck: "true",
+      spellcheck: "false",
     }
 
     # solr path which will be added to solr base url before the other solr params.


### PR DESCRIPTION
REF BL-234

Suggestions coming back are strange.  We need to disable this feature
until we can figure out a better way to configure for both "phrase
suggestions" (not sure that's possible).  And also better suggestions
overall (Maybe a smarter dictionary?)