### PR TITLE
Fix local dev container bundle install.

### DIFF
--- a/.docker/cli/Dockerfile
+++ b/.docker/cli/Dockerfile
@@ -5,7 +5,10 @@ RUN apt-get update -qq \
       && apt-get clean \
       && cd; wget -qO - https://raw.github.com/dkinzer/.vim/master/deploy.sh | bash
 
-WORKDIR /tul_cob
 
+ADD Gemfile .
+ADD Gemfile.lock .
 RUN bundle install
+
+WORKDIR /tul_cob
 CMD ["bash"]


### PR DESCRIPTION
Bundle instal fails on my local dev container becuase it needs the
Gemfile handy.