### PR TITLE
Grab Shibboleth attributes properly from omniauth hash

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,10 +33,10 @@ class User < ApplicationRecord
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.uid        = auth.uid
       user.provider   = auth.provider
-      user.email      = auth.mail
-      user.name       = auth.cn
-      user.last_name  = auth.sn
-      user.first_name = auth.givenName
+      user.email      = auth.info.email
+      user.name       = auth.info.name
+      user.last_name  = auth.info.last_name
+      user.first_name = auth.info.first_name
     end
   end
 


### PR DESCRIPTION
We were not using the proper path to shibboleth attributes 
in the omniauth hash. This corrects that issue