### PR TITLE
Update classes for online buttons

### DIFF
--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -3,11 +3,11 @@
 <% @response["response"][:docs].each_with_index do |field, i| %>
   <% if document.fetch("availability_facet", [])[i] == "Online" %>
     <% if document["electronic_resource_display"].length == 1 %>
-      <%= button_to "Online", single_link_builder(document["electronic_resource_display"][i]), class:"collapse-button btn btn-sm btn-info online" %>
+      <%= button_to "Online", single_link_builder(document["electronic_resource_display"][i]), class:"collapse-button btn btn-sm btn-info" %>
     <% else %>
     <div class="row button-break"></div>
-      <button class="btn-block btn btn-sm btn-info collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document_counter %>">
-      <span class="btn-drop-down online">Online</span>
+      <button class="btn-block btn btn-sm btn-info collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document_counter %>">
+      <span class="avail-label" aria-expanded="false">Online</span>
     </button>
       <div id="online-document-<%= document_counter %>" class="collapse online_resources">
         <ul>


### PR DESCRIPTION
The online dropdown button styling for  was overridden by a previous pull request.  This changes  the styling back to what it was before.