### PR TITLE
Update label for availability status

### DIFF
--- a/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
+++ b/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
@@ -54,7 +54,10 @@ var BlacklightAlma = function (options) {
         }).join(" ");
   }
   else {
-    return "Checked out or temporarily unavailable"
+    return ["Checked out or temporarily unavailable at ", holding['library']]
+        .filter(function (item) {
+            return item != null && item.length > 0;
+        }).join(" ");
   }
 }
 


### PR DESCRIPTION
Updates status for checked out materials to include the library name.  
- A search for 991021718189703811 should display like this:
<img width="615" alt="screen shot 2018-02-02 at 2 59 40 pm" src="https://user-images.githubusercontent.com/15167238/35752424-ecebb3e4-0829-11e8-812a-32ffab4fff14.png">
