### PR TITLE
Remove bottom-border from online only items

### DIFF
--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -130,7 +130,7 @@ div.online_resources {
   padding: 3px;
 }
 
-.online-panel {
+.online-border {
   border-bottom: 1px solid #ececec;
   padding-bottom: 10px;
   padding-top: 0;
@@ -229,7 +229,7 @@ div.navbar-form {
   margin-left: -42px;
   border: 0;
 }
-                   
+
 button.collapse-button .avail-label:after {
     /* symbol for "opening" panels */
     font-family: 'Glyphicons Halflings';  /* essential for enabling glyphicon */
@@ -250,7 +250,7 @@ ul.navbar-nav {
   margin: auto auto;
 }
 #tools-navbar {
-  
+
 }
 #tools-navbar li, #tools-navbar li a {
   display: inline-block;

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -28,6 +28,7 @@
   <% end %>
 
   <% if document.fetch("availability_facet", []).include?("At the Library") %>
+    <div class="online-border"></div>
     <div class="availability_iframe physical-holding-panel panel-body">
       <h5>In Library</h5>
       <iframe class="bl_alma_iframe" src="<%= alma_app_fulfillment_url(document) %>"></iframe>


### PR DESCRIPTION
Online only availability iframe on the record pages show no bottom-border
![screen shot 2018-02-05 at 9 30 29 am](https://user-images.githubusercontent.com/15167238/35809630-4d008348-0a57-11e8-9e70-d4ef7f40d358.png)
