### PR TITLE
#BL-297 Update layout/styling for Advanced Search

### DIFF
--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -16,6 +16,10 @@ h1[itemprop="name"] {
 #search-navbar .container {
   padding-left: 0;
 }
+
+h1.advanced.page-header a {
+  display:none;
+}
 /* === AEON REQUESTS === */
 
 .aeon-wrapper {


### PR DESCRIPTION
Hide the top start over button on the advanced search results page.