### PR TITLE
#BL-305   Re: Electronic resource links open with new tab

### DIFF
--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -16,6 +16,10 @@ h1[itemprop="name"] {
 #search-navbar .container {
   padding-left: 0;
 }
+
+h1.advanced.page-header a {
+  display:none;
+}
 /* === AEON REQUESTS === */
 
 .aeon-wrapper {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,7 +69,7 @@ module ApplicationHelper
   def electronic_access_links(field)
     link_text = field.split("|").first.sub(/ *[ ,.\/;:] *\Z/, "")
     link_url = field.split("|").last
-    new_link = content_tag(:li, link_to(link_text, link_url, {title: "Target opens in new window", target: "_blank"}), class: "list_items")
+    new_link = content_tag(:li, link_to(link_text, link_url, { title: "Target opens in new window", target: "_blank" }), class: "list_items")
     new_link
   end
 
@@ -85,7 +85,7 @@ module ApplicationHelper
   end
 
   def render_alma_eresource_link(portfolio_pid, db_name)
-    link_to(db_name, alma_electronic_resource_direct_link(portfolio_pid), {title: "Target opens in new window", target: "_blank"})
+    link_to(db_name, alma_electronic_resource_direct_link(portfolio_pid), { title: "Target opens in new window", target: "_blank" })
   end
 
   def alma_electronic_resource_direct_link(portfolio_pid)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,7 +69,7 @@ module ApplicationHelper
   def electronic_access_links(field)
     link_text = field.split("|").first.sub(/ *[ ,.\/;:] *\Z/, "")
     link_url = field.split("|").last
-    new_link = content_tag(:li, link_to(link_text, link_url), class: "list_items")
+    new_link = content_tag(:li, link_to(link_text, link_url, {title: "Target opens in new window", target: "_blank"}), class: "list_items")
     new_link
   end
 
@@ -85,7 +85,7 @@ module ApplicationHelper
   end
 
   def render_alma_eresource_link(portfolio_pid, db_name)
-    link_to(db_name, alma_electronic_resource_direct_link(portfolio_pid))
+    link_to(db_name, alma_electronic_resource_direct_link(portfolio_pid), {title: "Target opens in new window", target: "_blank"})
   end
 
   def alma_electronic_resource_direct_link(portfolio_pid)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,7 +69,7 @@ module ApplicationHelper
   def electronic_access_links(field)
     link_text = field.split("|").first.sub(/ *[ ,.\/;:] *\Z/, "")
     link_url = field.split("|").last
-    new_link = content_tag(:li, link_to(link_text, link_url, { title: "Target opens in new window", target: "_blank" }), class: "list_items")
+    new_link = content_tag(:li, link_to(link_text, link_url, title: "Target opens in new window", target: "_blank"), class: "list_items")
     new_link
   end
 
@@ -85,7 +85,7 @@ module ApplicationHelper
   end
 
   def render_alma_eresource_link(portfolio_pid, db_name)
-    link_to(db_name, alma_electronic_resource_direct_link(portfolio_pid), { title: "Target opens in new window", target: "_blank" })
+    link_to(db_name, alma_electronic_resource_direct_link(portfolio_pid), title: "Target opens in new window", target: "_blank")
   end
 
   def alma_electronic_resource_direct_link(portfolio_pid)


### PR DESCRIPTION
Added new tab targets to eresource links in the availabilty sections of the search results and record pages, with title text on the anchor tags for ADA purposes