### PR TITLE
Add configurable solr cache

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -17,11 +17,11 @@
 -->
 
 <!--
- This is a stripped down config file used for a simple example...  
- It is *not* a good example to work from. 
+ This is a stripped down config file used for a simple example...
+ It is *not* a good example to work from.
 -->
 <config>
-  
+
   <!-- Controls what version of Lucene various components of Solr
        adhere to.  Generally, you want to use the latest version to
        get all bug fixes and improvements. It is highly recommended
@@ -29,13 +29,13 @@
        affect both how text is indexed and queried.
   -->
   <luceneMatchVersion>5.0.0</luceneMatchVersion>
-  
+
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />
 
-  <directoryFactory name="DirectoryFactory" 
+  <directoryFactory name="DirectoryFactory"
                     class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}">
-  </directoryFactory> 
+  </directoryFactory>
 
   <codecFactory class="solr.SchemaCodecFactory"/>
 
@@ -43,14 +43,14 @@
 
 
   <dataDir>${solr.blacklight-core.data.dir:}</dataDir>
-  
+
   <requestDispatcher handleSelect="true" >
     <requestParsers enableRemoteStreaming="false" multipartUploadLimitInKB="2048" />
   </requestDispatcher>
-  
+
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
 
-  <!-- config for the admin interface --> 
+  <!-- config for the admin interface -->
   <admin>
     <defaultQuery>*:*</defaultQuery>
   </admin>
@@ -89,7 +89,7 @@
 
        <!-- this qf and pf are used by default, if not otherwise specified by
             client. The default blacklight_config will use these for the
-            "keywords" search. See the author_qf/author_pf, title_qf, etc 
+            "keywords" search. See the author_qf/author_pf, title_qf, etc
             below, which the default blacklight_config will specify for
             those searches. You may also be interested in:
             http://wiki.apache.org/solr/LocalParams
@@ -194,21 +194,21 @@
          subject_addl_unstem_search^100
          subject_addl_t^10
        </str>
-       
+
        <int name="ps">3</int>
        <float name="tie">0.01</float>
 
        <!-- NOT using marc_display because it is large and will slow things down for search results -->
        <str name="fl">
-         id, 
+         id,
          score,
          author_display,
-         author_vern_display, 
-         format, 
-         isbn_t, 
-         language_facet, 
+         author_vern_display,
+         format,
+         isbn_t,
+         language_facet,
          lc_callnum_display,
-         material_type_display, 
+         material_type_display,
          published_display,
          published_vern_display,
          pub_date,
@@ -277,7 +277,7 @@
        <str name="facet.field">subject_era_facet</str>
        <str name="facet.field">subject_geo_facet</str>
        <str name="facet.field">subject_topic_facet</str>
-       
+
        <str name="spellcheck">true</str>
        <str name="spellcheck.dictionary">default</str>
        <str name="spellcheck.onlyMorePopular">true</str>
@@ -341,7 +341,7 @@
     <arr name="last-components">
       <str>spellcheck</str>
     </arr>
-      
+
   </requestHandler>
 
   <!-- for requests to get a single document; use id=666 instead of q=id:666 -->
@@ -357,7 +357,7 @@
 <!-- Spell Check
 
         The spell check component can return a list of alternative spelling
-        suggestions.  
+        suggestions.
 
         http://wiki.apache.org/solr/SpellCheckComponent
      -->
@@ -412,7 +412,7 @@
        </lst>
      -->
 
-    <!-- a spellchecker that use an alternate comparator 
+    <!-- a spellchecker that use an alternate comparator
 
          comparatorClass be one of:
           1. score (default)
@@ -460,6 +460,25 @@
       <str>suggest</str>
     </arr>
   </requestHandler>
+  <query>
+    <filterCache class="solr.FastLRUCache"
+                 size="${filterCacheSize:2048}"
+                 initialSize="${filterCacheInitialSize:2048}"
+                 autowarmCount="256"/>
+
+    <queryResultCache class="solr.LRUCache"
+                      size="${queryResultCacheSize:2048}"
+                      initialSize="${queryResultCacheInitialSize:2048}"
+                      autowarmCount="128"/>
+
+    <documentCache class="solr.LRUCache"
+                   size="${documentCacheSize:2048}"
+                   initialSize="${documentCacheInitialSize:2048}"/>
+
+    <enableLazyFieldLoading>true</enableLazyFieldLoading>
+
+    <queryResultWindowSize>100</queryResultWindowSize>
+    <queryResultMaxDocsCached>500</queryResultMaxDocsCached>
+</query>
 
 </config>
-

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -479,6 +479,7 @@
 
     <queryResultWindowSize>100</queryResultWindowSize>
     <queryResultMaxDocsCached>500</queryResultMaxDocsCached>
+    <slowQueryThresholdMillis>500</slowQueryThresholdMillis>
 </query>
 
 </config>


### PR DESCRIPTION
Defaults to smaller caches, but make configurable to allow setting higher values on a machine with more memory, like production.

More reading is available at https://lucene.apache.org/solr/guide/6_6/query-settings-in-solrconfig.html#QuerySettingsinSolrConfig-queryResultCache

Additionally, adds a config to log slower queries, as per https://lucene.apache.org/solr/guide/6_6/configuring-logging.html