### PR TITLE
Refactor harvest timing code.

### DIFF
--- a/lib/oai/alma.rb
+++ b/lib/oai/alma.rb
@@ -18,7 +18,10 @@ module Oai
       to_time = time_range.fetch(:to) { "" }
       oai_from = from_time.empty? ? from_time : "&from=#{from_time}"
       oai_to = to_time.empty? ? to_time : "&until=#{to_time}"
-      oai_url = "https://temple.alma.exlibrisgroup.com/view/oai/01TULI_INST/request?verb=ListRecords&set=blacklight&metadataPrefix=marc21" + oai_from + oai_to
+      oai_url_base = "https://temple.alma.exlibrisgroup.com/view/oai/01TULI_INST/request?"
+      oai_url = oai_url_base +
+        "verb=ListRecords&set=blacklight&metadataPrefix=marc21" +
+        oai_from + oai_to
 
       harvest_files = []
 
@@ -35,7 +38,8 @@ module Oai
           harvest_files << harvest_file.path
           resumptionToken = oai.xpath("//oai:resumptionToken", "oai" => "http://www.openarchives.org/OAI/2.0/", "marc21" => "http://www.loc.gov/MARC21/slim")
           break if resumptionToken.empty?
-          oai_url = "https://sandbox02-na.alma.exlibrisgroup.com/view/oai/01TULI_INST/request?verb=ListRecords&resumptionToken=#{resumptionToken.text}"
+          oai_url = oai_url_base +
+            "verb=ListRecords&resumptionToken=#{resumptionToken.text}"
         end
       rescue => e
         logger.fatal("Fatal Error")

--- a/lib/oai/alma.rb
+++ b/lib/oai/alma.rb
@@ -12,7 +12,7 @@ module Oai
     # +time_range+:: Optinoal hash containing +:from+ (start) and +:to+ (end) time in ISO8601.
     def self.harvest(time_range)
       log_path = File.join(Rails.root, "log/fortytu.log")
-      logger = Logger.new(log_path, 10, 1024000)
+      logger = Logger.new("| tee #{log_path}", 10, 1024000)
 
       from_time = time_range.fetch(:from) { "" }
       to_time = time_range.fetch(:to) { "" }
@@ -50,7 +50,7 @@ module Oai
 
     def self.conform(harvest_filename)
       log_path = File.join(Rails.root, "log/fortytu.log")
-      logger = Logger.new(log_path, 10, 1024000)
+      logger = Logger.new("| tee #{log_path}", 10, 1024000)
       begin
         oai = Nokogiri::XML(File.open(harvest_filename))
         updated_records = oai.xpath("//oai:record/oai:metadata/marc21:record",

--- a/lib/tasks/jenkins.rake
+++ b/lib/tasks/jenkins.rake
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "time"
+
+module Jenkins
+  def self.last_build
+    if ENV["JOB_URL"]
+      url = "#{ENV["JOB_URL"]}lastBuild/api/json"
+      user_name = ENV["JENKINS_USER_NAME"]
+      api_token = ENV["JENKINS_USER_API_TOKEN"]
+      auth = { username: user_name, password: api_token }
+      HTTParty.get(url, verify: false, basic_auth: auth).parsed_response
+    else
+      {}
+    end
+  end
+
+  def self.last_build_time
+    job = last_build
+    # Jenkins timestamps are in milliseconds.
+    milliseconds_per_second = 1000
+    timestamp = job["timestamp"] || 0
+    Time.at(timestamp / milliseconds_per_second)
+  end
+end
+
+namespace :jenkins do
+  desc "Get time of the last build for jenkins job"
+  task :last_build_time do
+    puts Jenkins.last_build_time
+  end
+end

--- a/lib/tasks/oaiharvest.rake
+++ b/lib/tasks/oaiharvest.rake
@@ -41,8 +41,8 @@ namespace :fortytu do
 
       # Run the harvester.
       Rake::Task["fortytu:oai:harvest"].invoke(from, to)
-      Rake::Task["fortytu:oai:conform_all"]
-      Rake::Task["fortytu:oai:ingest_all"]
+      Rake::Task["fortytu:oai:conform_all"].invoke()
+      Rake::Task["fortytu:oai:ingest_all"].invoke()
 
       # Check the build for errors.
       if File.file? "log/fortytu.log.error"

--- a/lib/tasks/oaiharvest.rake
+++ b/lib/tasks/oaiharvest.rake
@@ -48,7 +48,11 @@ namespace :fortytu do
       if File.file? "log/fortytu.log.error"
 
         # Print and archive the Error logs
-        error_log = "log/fortytu.log.error"
+        # TODO: DRY up log file determination
+        main_logdir = File.join(Rails.root, "log/")
+        main_log = File.join(main_logdir, "fortytu.log")
+        error_log = "#{main_log}.error"
+
         puts "Errors:"
         File.open(error_log) do |file|
           file.each_line { |line| puts line }

--- a/lib/tasks/oaiharvest.rake
+++ b/lib/tasks/oaiharvest.rake
@@ -37,7 +37,7 @@ namespace :fortytu do
       from, to = [from, to].map { |t| t.to_time.utc.iso8601 }
 
       # Delete the previous build's marc_xml_files.
-      Dir.glob("tmp/alma/oai/**/*.xml").each { |file| File.delete file }
+      Dir.glob("tmp/alma/**/*.xml").each { |file| File.delete file }
 
       # Run the harvester.
       Rake::Task["fortytu:oai:harvest"].invoke(from, to)

--- a/lib/tasks/oaiharvest.rake
+++ b/lib/tasks/oaiharvest.rake
@@ -75,7 +75,7 @@ namespace :fortytu do
     desc "Conforms all raw OAI MARC records to traject readable MARC records"
     task conform_all: :environment do
       log_path = File.join(Rails.root, "log/fortytu.log")
-      logger = Logger.new(log_path, 10, 4096000)
+      logger = Logger.new("| tee #{log_path}", 10, 4096000)
       begin
         oai_path = File.join(Rails.root, "tmp", "alma", "oai", "*.xml")
         harvest_files = Dir.glob(oai_path).select { |fn| File.file?(fn) }
@@ -93,7 +93,7 @@ namespace :fortytu do
     task ingest_all: :environment do
       main_logdir = File.join(Rails.root, "log/")
       main_log = File.join(main_logdir, "fortytu.log")
-      logger = Logger.new(main_log, 10, 1024000)
+      logger = Logger.new("| tee #{main_log}", 10, 1024000)
 
       ingest_logdir = File.join(main_logdir, "ingest/")
       FileUtils::mkdir_p ingest_logdir


### PR DESCRIPTION
REF BL-329
REF BL-330

Once we broke up the harvest to happen for two different solr instances
we needed a way to run both jobs using the same parameters.  That means
we have to parameterize along the from and to options as well as the
solr URL.  Otherwise two consecutive calls to the job results in two
different sets of parameters.

This PR updates the task to allow us to parameterize the job as well as
adds a new task to allow us to capture the last build time in a way that
we can apply it to multiple Jenkins builds.

This PR also fixes a bug where we are using the wrong URL for the next records to fetch, as well as adds more logging to the standard output so that we see more info in the console.log for the jenkins job that ultimately uses this task.

Finally, this PR fixes a bug were not all the files created by the harvesting process were being deleted after they were no longer required, thus causing unnecessary strain on the machine.