### PR TITLE
Use default values in form

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -16,7 +16,11 @@ module AdvancedHelper
     if !params["op_row"]
       "contains"
     else
-      params["op_row"][count - 1]
+      # Always select from last rows count of total values in op_row[]
+      # @see BL-334
+      rows = params.select { |k| k.match(/^q_/) }
+      count_rows = rows.count
+      params["op_row"][-count_rows + count - 1]
     end
   end
 

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -11,6 +11,15 @@ module AdvancedHelper
     key_value
   end
 
+  # Get default value for op_row[] field in advanced_search form.
+  def op_row_default(count)
+    if !params["op_row"]
+      "contains"
+    else
+      params["op_row"][count - 1]
+    end
+  end
+
   def search_fields_for_advanced_search
     search_fields_for_advanced_search ||= begin
       hash = blacklight_config.search_fields.class.new

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -110,8 +110,19 @@ class SearchBuilder < Blacklight::SearchBuilder
     # @return [Array] A transformed set of search parameters OR and empty set.
     def params_field_ops(params)
       begin
-        fields = params.to_unsafe_h.compact.select { |k| k.match(/(^q$|^q_)/) }
-        ops = params.to_unsafe_h.fetch("op_row", ["default"])
+        p = params.to_unsafe_h.compact
+
+        fields = p.select { |k| k.match(/(^q$|^q_)/) }
+        ops = p.fetch("op_row", ["default"])
+
+        # Always use last rows count of total values in op_row[]
+        # @see BL-334
+        rows = p.select { |k| k.match(/^q_/) }
+        rows_count = rows.count
+        if ops.count > rows_count
+          ops = ops[-rows_count..-1]
+        end
+
         ops.zip(fields)
       rescue
         []

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -2,11 +2,11 @@
   <% (1..advanced_search_config[:fields_row_count]).each do |count| %>
   <div class="row">
     <div class="col-sm-2">
-    <%= select_tag("f_#{count}", options_for_select(advanced_key_value, search_fields_for_advanced_search), :class=>"form-control") %>
+      <%= select_tag("f_#{count}", options_for_select(advanced_key_value, label_tag_default_for("f_#{count}")), :class=>"form-control") %>
     </div>
 
     <div class="col-sm-2">
-      <%= select_tag("op_row[]", options_for_select({"contains"=> :contains, "is (exact)" => :is, "begins with" => :begins_with}.sort, "contains"), :class => "form-control" ) %>
+      <%= select_tag("op_row[]", options_for_select({"contains"=> :contains, "is (exact)" => :is, "begins with" => :begins_with}.sort, op_row_default(count)), :class => "form-control" ) %>
     </div>
 
     <div class="col-sm-3">

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -55,4 +55,24 @@ RSpec.describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helpe
       expect(helper.guided_search(params).count).to eq(4)
     end
   end
+
+  describe ".op_row_default" do
+    example "default" do
+      expect(helper.op_row_default(2)).to eq("contains")
+    end
+
+    # REF BL-334
+    example "two consecutive searches" do
+      params = ActionController::Parameters.new(
+        q_1: "james",
+        q_2: "john",
+        q_3: "david",
+        op_row: [ "fizz", "fizz", "fizz", "foo", "bar", "bum" ]
+      )
+      allow(helper).to receive(:params).and_return(params)
+
+      expect(helper.op_row_default(2)).to eq("bar")
+    end
+  end
+
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -198,5 +198,19 @@ RSpec.describe SearchBuilder , type: :model do
         ["default", ["q", "Hello"]]])
     end
 
+    # REF BL-334
+    it "uses the last 3 values in op_row not all of it" do
+      params = ActionController::Parameters.new(
+        "op_row" => ["foo", "foo", "foo", "bizz", "buzz", "bazz"],
+        "f_1" => "all_fields", "q_1" => "Hello",
+        "f_2" => "all_fields", "q_2" => "Beautiful",
+        "f_3" => "all_fields", "q_3" => "World",
+        search_field: "advanced")
+
+      expect(subject.send(:params_field_ops, params)).to eq([
+        ["bizz", ["q_1", "Hello"]],
+        ["buzz", ["q_2", "Beautiful"]],
+        ["bazz", ["q_3", "World"]]])
+    end
   end
 end


### PR DESCRIPTION
REF BL-291
REF BL-334

The advanced search form is not currently using the default values for
the operators which are available in the blacklight_params.

This PR also addresses an issue where the op_row field on multiple searches without hitting the "restart" button in between the searches, was appending new values to the op_row array in the params object and then we were not using the newer values.