### PR TITLE
URL encode author/creator label in links.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,7 +36,7 @@ module ApplicationHelper
     creator = args[:document][args[:field]]
     creator.map do |name|
       linked_subfields = name.split("|").first
-      newname = link_to(linked_subfields, root_url + "/?f[creator_facet][]=#{linked_subfields}").html_safe
+      newname = link_to(linked_subfields, root_url + "/?f[creator_facet][]=#{url_encode(linked_subfields)}").html_safe
       plain_text_subfields = name.split("|").second
       creator = newname
       if plain_text_subfields.present?


### PR DESCRIPTION
REF BL-304

URLs with & are failing for author/creator links because they are not
being URL encoded.

This commit makes sure to properly encode those fields so that links do
not fail.