### PR TITLE
Bl 333 subject topic facet

### DIFF
--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -148,10 +148,7 @@ to_field "note_local_display", extract_marc("590a")
 # Subject fields
 to_field "subject_facet", extract_marc("600abcdefghklmnopqrstuxyz:610abcdefghklmnoprstuvxy:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz", separator: " — ", trim_punctuation: true)
 to_field "subject_display", extract_marc("600abcdefghklmnopqrstuvxyz:610abcdefghklmnoprstuvxyz:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz", separator: " — ", trim_punctuation: true)
-to_field "subject_topic_facet" do |record, accumulator|
-  subjects = process_subject_topic_facet(record)
-  accumulator.replace(subjects)
-end
+to_field "subject_topic_facet", extract_subject_topic_facet
 to_field "subject_era_facet", extract_marc("648a:650y:651y:654y:655y:690y:647y", trim_punctuation: true)
 to_field "subject_region_facet", marc_geo_facet
 to_field "genre_facet", extract_genre

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -148,7 +148,10 @@ to_field "note_local_display", extract_marc("590a")
 # Subject fields
 to_field "subject_facet", extract_marc("600abcdefghklmnopqrstuxyz:610abcdefghklmnoprstuvxy:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz", separator: " — ", trim_punctuation: true)
 to_field "subject_display", extract_marc("600abcdefghklmnopqrstuvxyz:610abcdefghklmnoprstuvxyz:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz", separator: " — ", trim_punctuation: true)
-to_field "subject_topic_facet", extract_marc("600abcdq:610ab:611a:630a:650a:653a:654ab:647acdg", trim_punctuation: true)
+to_field "subject_topic_facet" do |record, accumulator|
+  subjects = process_subject_topic_facet(record)
+  accumulator.replace(subjects)
+end
 to_field "subject_era_facet", extract_marc("648a:650y:651y:654y:655y:690y:647y", trim_punctuation: true)
 to_field "subject_region_facet", marc_geo_facet
 to_field "genre_facet", extract_genre

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -8,7 +8,7 @@ module Traject
     module Custom
       NOT_FULL_TEXT = /book review|publisher description|sample text|table of contents/i
       GENRE_STOP_WORDS = /CD-ROM|CD-ROMs|Compact discs|Computer network resources|Databases|Electronic book|Electronic books|Electronic government information|Electronic journal|Electronic journals|Electronic newspapers|Electronic reference sources|Electronic resource|Full text|Internet resource|Internet resources|Internet videos|Online databases|Online resources|Periodical|Periodicals|Sound recordings|Streaming audio|Streaming video|Video recording|Videorecording|Web site|Web sites|Périodiques|Congrès|Ressource Internet|Périodqiue électronique/i
-      SEPARATOR = '--'
+      SEPARATOR = "--"
 
       def get_xml
         lambda do |rec, acc|
@@ -130,7 +130,7 @@ module Traject
             subject = extractor.collect_subfields(field, spec).first
             unless subject.nil?
               field.subfields.each do |s_field|
-                if (s_field.code == 'x')
+                if (s_field.code == "x")
                   subject = subject.gsub(" #{s_field.value}", "#{SEPARATOR}#{s_field.value}")
                 end
               end


### PR DESCRIPTION
BL-333 Adds the x subfield to 650 and adds a separator between the a and x fields. It also returns only uniq values because sometimes cataloguers write the x subfield information inside the a subfield.  When looking at an A-Z sort of subject topic facets for a search on "adoption", you should see only one instance of "Abbasids--Early works to 1800" and "Adoption--Fees" should display with a separator between the words.
![screen shot 2018-03-15 at 11 33 10 am](https://user-images.githubusercontent.com/15167238/37473439-abfe6710-2844-11e8-9ad1-2e41442b0fd5.png)
 