### PR TITLE
Finding spec problem

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -330,6 +330,7 @@ class CatalogController < ApplicationController
     config.add_show_field "lccn_display", label: "LCCN"
     config.add_show_field "alma_mms_display", label: "Catalog Record ID"
     config.add_show_field "language_display", label: "Language"
+    config.add_show_field "url_finding_aid_display", label: "Finding Aid", helper_method: :check_for_full_http_link
     config.add_show_field "url_more_links_display", label: "Other Links", helper_method: :check_for_full_http_link
     config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :check_for_full_http_link
 

--- a/app/models/traject_indexer.rb
+++ b/app/models/traject_indexer.rb
@@ -179,6 +179,7 @@ to_field "lc_b4cutter_facet", extract_marc("050a", first: true)
 # URL Fields
 to_field "url_more_links_display", extract_url_more_links
 to_field("electronic_resource_display", extract_electronic_resource, &sort_electronic_resource!)
+to_field "url_finding_aid_display", extract_url_finding_aid
 
 # Availability
 to_field "availability_facet", extract_availability

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -190,7 +190,7 @@ module Traject
             if f.indicator1 == "4" && f.indicator2 == "2"
               unless f["u"].nil?
                 if f["u"].include?("http://library.temple.edu") && f["u"].include?("scrc")
-                acc << [label, f["u"]].compact.join("|")
+                  acc << [label, f["u"]].compact.join("|")
                 end
               end
             end

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -6,6 +6,7 @@ require "library_stdnums"
 module Traject
   module Macros
     module Custom
+      ARCHIVE_IT_LINKS = "https://archive-it.org/collections/"
       NOT_FULL_TEXT = /book review|publisher description|sample text|table of contents/i
       GENRE_STOP_WORDS = /CD-ROM|CD-ROMs|Compact discs|Computer network resources|Databases|Electronic book|Electronic books|Electronic government information|Electronic journal|Electronic journals|Electronic newspapers|Electronic reference sources|Electronic resource|Full text|Internet resource|Internet resources|Internet videos|Online databases|Online resources|Periodical|Periodicals|Sound recordings|Streaming audio|Streaming video|Video recording|Videorecording|Web site|Web sites|Périodiques|Congrès|Ressource Internet|Périodqiue électronique/i
       def get_xml
@@ -169,8 +170,27 @@ module Traject
         lambda { |rec, acc|
           rec.fields("856").each do |f|
             label = url_label(f["z"], f["3"], f["y"])
-            if f.indicator2 == "2" || NOT_FULL_TEXT.match(label) || !rec.fields("PRT").empty?
-              acc << [label, f["u"]].compact.join("|")
+            unless f["u"].nil?
+              if f.indicator2 == "2" || NOT_FULL_TEXT.match(label) || !rec.fields("PRT").empty? || f["u"].include?(ARCHIVE_IT_LINKS)
+                unless f["u"].include?("http://library.temple.edu") && f["u"].include?("scrc")
+                  acc << [label, f["u"]].compact.join("|")
+                end
+              end
+            end
+          end
+        }
+      end
+
+      def extract_url_finding_aid
+        lambda { |rec, acc|
+          rec.fields("856").each do |f|
+            label = url_label(f["z"], f["3"], f["y"])
+            if f.indicator1 == "4" && f.indicator2 == "2"
+              unless f["u"].nil?
+                if f["u"].include?("http://library.temple.edu") && f["u"].include?("scrc")
+                acc << [label, f["u"]].compact.join("|")
+                end
+              end
             end
           end
         }

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -130,8 +130,10 @@ module Traject
           rec.fields("856").each do |f|
             if f.indicator2 != "2"
               label = url_label(f["z"], f["3"], f["y"])
-              unless NOT_FULL_TEXT.match(label)
-                acc << [label, f["u"]].compact.join("|")
+              unless f["u"].nil?
+                unless NOT_FULL_TEXT.match(label) || f["u"].include?(ARCHIVE_IT_LINKS)
+                  acc << [label, f["u"]].compact.join("|")
+                end
               end
             end
           end

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -1157,6 +1157,17 @@ RSpec.feature "RecordPageFields" do
     end
   end
 
+  feature "MARC Finding Aid Field" do
+    let (:item_856_4) { fixtures.fetch("url_856_4") }
+    scenario "User visits a document with url indicator1 value 4 indicator2 value2 and subfield u includes both http://library.temple.edu and scrc" do
+      visit "catalog/#{item_856_4['doc_id']}"
+      within "dd.blacklight-url_finding_aid_display" do
+        expect(page).to have_text(item_856_4["url"])
+        expect(page).to have_link("#{item_856_4['url']}", href: "#{item_856_4['url_href']}")
+      end
+    end
+  end
+
   feature "MARC URL Fields" do
     let (:item_856_2) { fixtures.fetch("url_856_2") }
     scenario "User visits a document with url indicator2 value2" do
@@ -1173,6 +1184,15 @@ RSpec.feature "RecordPageFields" do
       within "dd.blacklight-url_more_links_display" do
         expect(page).to have_text(item_856_more_1["url"])
         expect(page).to have_link("#{item_856_more_1['url']}", href: "#{item_856_more_1['url_href']}")
+      end
+    end
+
+    let (:item_856_more_3) { fixtures.fetch("url_856_more_3") }
+    scenario "User visits a document with url indicator2 value2 with archive-it url in subfield u" do
+      visit "catalog/#{item_856_more_3['doc_id']}"
+      within "dd.blacklight-url_more_links_display" do
+        expect(page).to have_text(item_856_more_3["url"])
+        expect(page).to have_link("#{item_856_more_3['url']}", href: "#{item_856_more_3['url_href']}")
       end
     end
   end

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -405,6 +405,14 @@ url_856_more_1:
   doc_id: "991012132499760729"
   url: "table of contents"
   url_href: "http://www.loc.gov/catdir/toc/ecip0413/2004001291.html"
+url_856_more_3:
+  doc_id: "991034281219703811"
+  url: "View preserved website versions on Archive-It"
+  url_href: "https://archive-it.org/collections/4487"
+url_856_4:
+  doc_id: "991034281219703811"
+  url: "View a description and list of collection contents in the online finding aid"
+  url_href: "http://library.temple.edu/scrc/occupy-philadelphia-records"
 rarestacks:
   doc_id: "991012036369703811"
   library: "Special Collections Research Center"

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -26118,4 +26118,20 @@
       <subfield code="f">SCRC</subfield>
     </datafield>
   </record>
+  <record>
+    <controlfield tag="001">991034281219703811</controlfield>
+    <datafield tag="245" ind1="1" ind2="0">
+      <subfield code="a">Occupy Philadelphia records</subfield>
+      <subfield code="f">2006-2014 /</subfield>
+      <subfield code="g">(bulk 2011-2012).</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="2">
+      <subfield code="3">View a description and list of collection contents in the online finding aid.</subfield>
+      <subfield code="u">http://library.temple.edu/scrc/occupy-philadelphia-records</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="2">
+      <subfield code="3">View preserved website versions on Archive-It.</subfield>
+      <subfield code="u">https://archive-it.org/collections/4487</subfield>
+    </datafield>
+  </record>
 </collection>


### PR DESCRIPTION
BL-266 Modify and add fields for special collection links
- Add new finding_aid_field for links that include both "http://library.temple.edu" and "scrc"
- Links that include archive-it should display under the "Other Links" label.
<img width="804" alt="screen shot 2018-03-16 at 10 36 55 am" src="https://user-images.githubusercontent.com/15167238/37526523-fd326ebc-2905-11e8-99cb-49ff188717d6.png">

