### PR TITLE
Basic search

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -23,7 +23,14 @@
 <% end %>
 
 
+<% unless current_page?("/advanced") %>
+  <div class="navbar-form">
+    <%= link_to 'Advanced Search', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), class: 'advanced_search'%>
+  </div>
+<% end %>
 
-<div class="navbar-form">
-  <%= link_to 'Advanced Search', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), class: 'advanced_search'%>
-</div>
+<% if current_page?("/advanced") %>
+  <div class="navbar-form">
+    <%= link_to 'Basic Search', root_path, class: 'advanced_search'%>
+  </div>
+<% end %>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag search_action_url, method: :get, class: 'search-query-form clearfix navbar-form', role: 'search' do %>
+<%= form_tag search_catalog_url, method: :get, class: 'search-query-form clearfix navbar-form', role: 'search' do %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <div class="input-group">
     <% if search_fields.length > 1 %>

--- a/spec/features/indices_spec.rb
+++ b/spec/features/indices_spec.rb
@@ -22,7 +22,6 @@ RSpec.feature "Indices" do
           expect(page).to have_text "Resource Type"
         end
       end
-
     end
   end
 
@@ -53,7 +52,7 @@ RSpec.feature "Indices" do
 
   feature "Catalog" do
     let (:title) { "Academic freedom in an age of conformity" }
-    let (:results_url) { "http://www.example.com/?utf8=%E2%9C%93&search_field=all_fields&q=Academic+freedom+in+an+age+of+conformity" }
+    let (:results_url) { "http://www.example.com/catalog?utf8=%E2%9C%93&search_field=all_fields&q=Academic+freedom+in+an+age+of+conformity" }
     scenario "Search" do
       visit "/"
       fill_in "q", with: title

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -8,7 +8,7 @@ simple_search:
   physical_description: "vi, 217 pages ; 23 cm."
   series_title: "Palgrave critical university studies"
   status_location: "Paley Stacks"
-  url: "http://www.example.com/?utf8=%E2%9C%93&search_field=all_fields&q=Academic+freedom+in+an+age+of+conformity"
+  url: "http://www.example.com/catalog?utf8=%E2%9C%93&search_field=all_fields&q=Academic+freedom+in+an+age+of+conformity"
   HLD: "AMBLER"
 title_statement:
   doc_id: "991012172649703811"


### PR DESCRIPTION
BL-283 Fixes two bugs related to basic search in the advanced view.
- Replaces the advanced search link with a Basic Search link back to the home page
- Uses the search_catalog_url which allows you to use basic or advanced search in the advanced view
- Updates specs because the search_catalog_url adds /catalog to the search results url