### PR TITLE
Constraints

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -3,14 +3,6 @@
 module AdvancedHelper
   include BlacklightAdvancedSearch::AdvancedHelperBehavior
 
-  def label_tag_default_for(key)
-    if params[key].present?
-      params[key]
-    elsif params['search_field'] == key
-      params['q']
-    end
-  end
-
   def advanced_key_value
     key_value = []
     search_fields_for_advanced_search.each do |field|

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -155,7 +155,7 @@ module BlacklightAdvancedSearch
         field = search_field_def_for_key(my_params[:f_2]).to_h
         label = field[:label].to_s
         query = my_params[:q_2]
-        query = 'NOT ' + my_params[:q_2] if my_params[:op_1] == 'NOT'
+        query = "NOT " + my_params[:q_2] if my_params[:op_1] == "NOT"
         constraints << render_constraint_element(
           label, query,
           remove: search_catalog_path(remove_guided_keyword_query(%i[f_2 q_2 op_2], my_params))
@@ -165,7 +165,7 @@ module BlacklightAdvancedSearch
         field = search_field_def_for_key(my_params[:f_3]).to_h
         label = field[:label].to_s
         query = my_params[:q_3]
-        query = 'NOT ' + my_params[:q_3] if my_params[:op_2] == 'NOT'
+        query = "NOT " + my_params[:q_3] if my_params[:op_2] == "NOT"
         constraints << render_constraint_element(
           label, query,
           remove: search_catalog_path(remove_guided_keyword_query(%i[f_3 q_3 op_3], my_params))

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Advanced Search" do
 
       expect(page).to have_selector(results_selector, count: 1)
       expect(page).to have_text("Title full")
-      expect(page).to have_text("Title exercises")
+      expect(page).to have_text("Title AND exercises")
       expect(first(results_selector).text).to eq("1. Everyday Activities to Help Your Young Child with Autism Live Life to the Full Simple Exercises to Boost Functional Skills, Sensory Processing, Coordination and Self-Care")
     end
 
@@ -55,10 +55,9 @@ RSpec.feature "Advanced Search" do
         f_2: "title", q_2: "exercises",
         search_field: "advanced",
       }.to_query}"
-
       expect(page).to have_selector(results_selector, count: 10)
       expect(page).to have_text("Title full")
-      expect(page).to have_text("Title exercises")
+      expect(page).to have_text("Title OR exercises")
     end
 
     scenario "searching title for x NOT y" do

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -41,7 +41,10 @@ RSpec.feature "Advanced Search" do
         f_2: "title", q_2: "exercises",
         search_field: "advanced",
       }.to_query}"
+
       expect(page).to have_selector(results_selector, count: 1)
+      expect(page).to have_text("Title full")
+      expect(page).to have_text("Title exercises")
       expect(first(results_selector).text).to eq("1. Everyday Activities to Help Your Young Child with Autism Live Life to the Full Simple Exercises to Boost Functional Skills, Sensory Processing, Coordination and Self-Care")
     end
 
@@ -54,7 +57,22 @@ RSpec.feature "Advanced Search" do
       }.to_query}"
 
       expect(page).to have_selector(results_selector, count: 10)
+      expect(page).to have_text("Title full")
+      expect(page).to have_text("Title exercises")
     end
+
+    scenario "searching title for x NOT y" do
+      visit "catalog?#{{
+        op_row: ["contains", "contains"],
+        f_1: "title", q_1: "full", op_1: "NOT",
+        f_2: "title", q_2: "exercises",
+        search_field: "advanced",
+      }.to_query}"
+
+      expect(page).to have_text("Title full")
+      expect(page).to have_text("Title NOT exercises")
+    end
+
 
     scenario "searching with begins_with" do
       visit "catalog?#{{
@@ -75,7 +93,7 @@ RSpec.feature "Advanced Search" do
         search_field: "advanced",
       }.to_query}"
 
-      expect(page).to have_selector(results_selector, count: 2)
+      expect(page).to have_selector(results_selector)
       expect(first(results_selector).text).to match(/^1. Silencio roto/)
     end
 

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -4,10 +4,9 @@ require "rails_helper"
 
 RSpec.describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helper do
   describe "#guided_search" do
-
-    example "empty search fields" do
-      expect(helper.guided_search).to be_empty
-    end
+     example "empty search fields" do
+       expect(helper.guided_search).to be_empty
+     end
    end
 
   describe ".op_row_default" do

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-module BlacklightAdvancedSearch
-  module RenderConstraintsOverride
-  end
-end
 
 RSpec.describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helper do
   describe "#guided_search" do
@@ -12,46 +8,7 @@ RSpec.describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helpe
     example "empty search fields" do
       expect(helper.guided_search).to be_empty
     end
-
-    example "one search field" do
-      params = ActionController::Parameters.new(
-        f1: "all_fields",
-        search_field: "advanced",
-        q1: "james"
-      )
-      expect(helper.guided_search(params).count).to eq(1)
-    end
-
-    example "two search fields" do
-      params = ActionController::Parameters.new(
-        f1: "all_fields",
-        search_field: "advanced",
-        q1: "james",
-        f2: "all_fields",
-        q2: "james",
-        op2: "OR"
-      )
-      expect(helper.guided_search(params).count).to eq(2)
-    end
-
-    it "can handle more than the number of fields defined (current is 3)" do
-      params = ActionController::Parameters.new(
-        f1: "all_fields",
-        search_field: "advanced",
-        q1: "james",
-        f2: "all_fields",
-        q2: "john",
-        op2: "OR",
-        f3: "all_fields",
-        q3: "david",
-        op3: "OR",
-        f4: "all_fields",
-        q4: "summer",
-        op4: "OR"
-      )
-      expect(helper.guided_search(params).count).to eq(4)
-    end
-  end
+   end
 
   describe ".op_row_default" do
     example "default" do

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -3,11 +3,33 @@
 require "rails_helper"
 
 RSpec.describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helper do
-  describe "#guided_search" do
+  describe "#guided_search"
+   do
      example "empty search fields" do
        expect(helper.guided_search).to be_empty
      end
    end
+
+   example "one search field" do
+      params = ActionController::Parameters.new(
+        f1: "all_fields",
+        search_field: "advanced",
+        q1: "james"
+      )
+      expect(helper.guided_search(params).count).to eq(1)
+    end
+
+    example "two search fields" do
+      params = ActionController::Parameters.new(
+        f1: "all_fields",
+        search_field: "advanced",
+        q1: "james",
+        f2: "all_fields",
+        q2: "james",
+        op2: "OR"
+      )
+      expect(helper.guided_search(params).count).to eq(2)
+    end
 
   describe ".op_row_default" do
     example "default" do

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -3,33 +3,12 @@
 require "rails_helper"
 
 RSpec.describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helper do
-  describe "#guided_search"
-   do
-     example "empty search fields" do
-       expect(helper.guided_search).to be_empty
-     end
-   end
+  describe "#guided_search" do
 
-   example "one search field" do
-      params = ActionController::Parameters.new(
-        f1: "all_fields",
-        search_field: "advanced",
-        q1: "james"
-      )
-      expect(helper.guided_search(params).count).to eq(1)
+    example "empty search fields" do
+      expect(helper.guided_search).to be_empty
     end
-
-    example "two search fields" do
-      params = ActionController::Parameters.new(
-        f1: "all_fields",
-        search_field: "advanced",
-        q1: "james",
-        f2: "all_fields",
-        q2: "james",
-        op2: "OR"
-      )
-      expect(helper.guided_search(params).count).to eq(2)
-    end
+  end
 
   describe ".op_row_default" do
     example "default" do

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -3,9 +3,6 @@
 require "rails_helper"
 module BlacklightAdvancedSearch
   module RenderConstraintsOverride
-    def search_field_def_for_key(key)
-      nil
-    end
   end
 end
 


### PR DESCRIPTION
BL-319 Restores the field labels to constraints for advanced search
- The results for an advanced search should display the field name and search query term
- If and, or was used then there should be a constraint shown for each query term
- When not was selected, the "NOT" keyword should be displayed in the constraint as well
<img width="466" alt="screen shot 2018-03-29 at 4 42 26 pm" src="https://user-images.githubusercontent.com/15167238/38112585-6e0ceb2a-3370-11e8-90e5-19453decb3d7.png">
