### PR TITLE
Make sure to close file after write.

### DIFF
--- a/lib/oai/alma.rb
+++ b/lib/oai/alma.rb
@@ -97,6 +97,7 @@ module Oai
       FileUtils::mkdir_p File.dirname(filename)
       marc_file = File.new(filename, "w")
       marc_file.write(marc_doc.to_xml)
+      marc_file.close()
       marc_file.path
     end
   end


### PR DESCRIPTION
It seems that if the file remains open, then it cannot be used in the
purging process.