### PR TITLE
Bl 357 process type

### DIFF
--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -12,7 +12,7 @@ module AlmaDataHelper
   end
 
   def unavailable_items(item)
-    if item["item_data"]["process_type"]["value"].present?
+    if item["item_data"]["process_type"].present?
       Rails.configuration.process_types[item["item_data"]["process_type"]["value"]]
     else
       "Checked out or currently unavailable"

--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -7,6 +7,14 @@ module AlmaDataHelper
     if item["item_data"]["base_status"]["value"] == "1"
       "Available"
     elsif item["item_data"]["base_status"]["value"] == "0"
+      unavailable_items(item)
+    end
+  end
+
+  def unavailable_items(item)
+    if item["item_data"]["process_type"]["value"].present?
+      Rails.configuration.process_types[item["item_data"]["process_type"]["value"]]
+    else
       "Checked out or currently unavailable"
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module Tulcob
     # here. Application configuration should go into files in
     # config/initializers: All .rb files in that directory are automatically
     # loaded.
+    config.process_types = config_for(:process_types).with_indifferent_access
     config.libraries = config_for(:libraries).with_indifferent_access
     config.locations = config_for(:locations).with_indifferent_access
     config.alma = config_for(:alma).with_indifferent_access

--- a/config/process_types.yml
+++ b/config/process_types.yml
@@ -1,0 +1,22 @@
+default: &default
+  ACQ: On order
+  CLAIM_RETURNED_LOAN: Claimed returned
+  HOLDSHELF: On hold shelf
+  ILL: At another institution
+  LOAN: Checked out
+  LOST_LOAN: Lost
+  MISSING: Missing
+  NOPROCESS: On shelf
+  OVERDUE: Checked out - overdue
+  REQUESTED: Requested
+  TECHNICAL: Unavailable - technical issue
+  TRANSIT: In transit
+
+test:
+  <<: *default
+
+development:
+  <<: *default
+
+production:
+  <<: *default

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -22,13 +22,43 @@ RSpec.describe AlmaDataHelper, type: :helper do
       let(:item) do
         { "item_data" =>
            { "base_status" =>
-             { "value" => "0" }
+             { "value" => "0" },
+             "process_type" => { "value" => "ILL" }
            }
          }
       end
 
-      it "displays available" do
-        expect(availability_status(item)).to eq "Checked out or currently unavailable"
+      it "displays unavailable" do
+        expect(availability_status(item)).to eq "At another institution"
+      end
+    end
+  end
+
+  describe "#unavailable_items(item)" do
+    context "item includes process_type" do
+      let(:item) do
+        { "item_data" =>
+           { "base_status" =>
+             { "value" => "0" },
+             "process_type" => { "value" => "ILL" }
+           }
+         }
+      end
+      it "displays process type" do
+        expect(unavailable_items(item)).to eq "At another institution"
+      end
+    end
+
+    context "item has no process_type" do
+      let(:item) do
+        { "item_data" =>
+           { "base_status" =>
+             { "value" => "0" }
+           }
+         }
+      end
+      it "displays default message" do
+        expect(unavailable_items(item)).to eq "Checked out or currently unavailable"
       end
     end
   end


### PR DESCRIPTION
BL-357 Adds additional logic into unavailable items according to their process type.
- created a new translation map to convert process_type values into the necessary messages
- On record 991022252979703811, Availability should display as "Checked out" at Paley and "Available" at Ambler
- record 991026548529703811 should display as "At another institution" for Resource Sharing Library
![screen shot 2018-04-05 at 2 08 28 pm](https://user-images.githubusercontent.com/15167238/38383558-d6c89f8c-38da-11e8-9c3b-58fa3f0b82d5.png)
![screen shot 2018-04-05 at 2 07 39 pm](https://user-images.githubusercontent.com/15167238/38383562-d872f472-38da-11e8-8d3c-798354f20ab7.png)

