### PR TITLE
Update logic to exclude archive-it links from Online availability

### DIFF
--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -235,7 +235,7 @@ module Traject
           unless acc.include?("Online")
             rec.fields(["856"]).each do |field|
               z3 = [field["z"], field["3"]].join(" ")
-              unless NOT_FULL_TEXT.match(z3) || rec.fields("856").empty?
+              unless NOT_FULL_TEXT.match(z3) || rec.fields("856").empty? || field["u"].include?(ARCHIVE_IT_LINKS)
                 acc << "Online" if field.indicator1 == "4" && field.indicator2 != "2"
               end
             end

--- a/spec/fixtures/marc_files/subject_topic_missing.xml
+++ b/spec/fixtures/marc_files/subject_topic_missing.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
+  <record>
+    <datafield ind1=' ' ind2='0' tag='650'>
+      <subfield code='z'>England</subfield>
+      <subfield code='v'>Drama</subfield>
+    </datafield>
+  </record>
+  </record>
+</collection>

--- a/spec/fixtures/marc_files/url_field_examples.xml
+++ b/spec/fixtures/marc_files/url_field_examples.xml
@@ -73,6 +73,10 @@
       <subfield code="z">tabLe of Contents</subfield>
       <subfield code="u">http://foobar.com</subfield>
     </datafield>
+    <datafield tag="856" ind1="4" ind2="1">
+      <subfield code="z">Archive</subfield>
+      <subfield code="u">http://archive-it.org/collections/4222</subfield>
+    </datafield>
   </record>
   <record>
     <!-- 7. PRT field and 856 field (with exception)  -->
@@ -92,6 +96,27 @@
     <datafield tag="856" ind1="4" ind2="1">
       <subfield code="z">bar</subfield>
       <subfield code="u">http://foobar.com</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 9. ARCHIVE_IT_LINKS aren't included in Online Availability  -->
+    <datafield tag="856" ind1="4" ind2="0">
+      <subfield code="z">archive</subfield>
+      <subfield code="u">https://archive-it.org/collections/4487</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 10. Only single 856 field (with archive-it exception) -->
+    <datafield tag="856" ind1="4" ind2="1">
+      <subfield code="z">Archive</subfield>
+      <subfield code="u">http://archive-it.org/collections/4222</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 11. Links with temple url and scrc map to url_finding_aid_display -->
+    <datafield tag="856" ind1="4" ind2="2">
+      <subfield code="z">Finding aid</subfield>
+      <subfield code="u">http://library.temple.edu/scrc</subfield>
     </datafield>
   </record>
 </collection>

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -26141,7 +26141,7 @@
       <subfield code="3">View a description and list of collection contents in the online finding aid.</subfield>
       <subfield code="u">http://library.temple.edu/scrc/occupy-philadelphia-records</subfield>
     </datafield>
-    <datafield tag="856" ind1="4" ind2="2">
+    <datafield tag="856" ind1="4" ind2="0">
       <subfield code="3">View preserved website versions on Archive-It.</subfield>
       <subfield code="u">https://archive-it.org/collections/4487</subfield>
     </datafield>


### PR DESCRIPTION
The updated logic for electronic_resource_display excludes archive-it links, but these items were still being indexed into online availability. 
- I think this is what was causing the nil electronic_resource_display problem on libQA
- Added specs for online availability, finding aid display, and added more specs for new logic in electronic_resource_display and url_more_links_display