### PR TITLE
Adds specs and updated logic for online availability

### DIFF
--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -235,7 +235,7 @@ module Traject
           unless acc.include?("Online")
             rec.fields(["856"]).each do |field|
               z3 = [field["z"], field["3"]].join(" ")
-              unless NOT_FULL_TEXT.match(z3) || rec.fields("856").empty?
+              unless NOT_FULL_TEXT.match(z3) || rec.fields("856").empty? || field["u"].include?(ARCHIVE_IT_LINKS)
                 acc << "Online" if field.indicator1 == "4" && field.indicator2 != "2"
               end
             end

--- a/spec/fixtures/marc_files/url_field_examples.xml
+++ b/spec/fixtures/marc_files/url_field_examples.xml
@@ -73,6 +73,10 @@
       <subfield code="z">tabLe of Contents</subfield>
       <subfield code="u">http://foobar.com</subfield>
     </datafield>
+    <datafield tag="856" ind1="4" ind2="1">
+     <subfield code="z">Archive</subfield>
+     <subfield code="u">http://archive-it.org/collections/4222</subfield>
+   </datafield>
   </record>
   <record>
     <!-- 7. PRT field and 856 field (with exception)  -->
@@ -92,6 +96,27 @@
     <datafield tag="856" ind1="4" ind2="1">
       <subfield code="z">bar</subfield>
       <subfield code="u">http://foobar.com</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 9. ARCHIVE_IT_LINKS aren't included in Online Availability  -->
+    <datafield tag="856" ind1="4" ind2="0">
+      <subfield code="z">archive</subfield>
+      <subfield code="u">https://archive-it.org/collections/4487</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 10. Only single 856 field (with archive-it exception) -->
+    <datafield tag="856" ind1="4" ind2="1">
+      <subfield code="z">Archive</subfield>
+      <subfield code="u">http://archive-it.org/collections/4222</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 11. Links with temple url and scrc map to url_finding_aid_display -->
+    <datafield tag="856" ind1="4" ind2="2">
+      <subfield code="z">Finding aid</subfield>
+      <subfield code="u">http://library.temple.edu/scrc</subfield>
     </datafield>
   </record>
 </collection>

--- a/spec/models/traject_indexer_spec.rb
+++ b/spec/models/traject_indexer_spec.rb
@@ -166,6 +166,25 @@ RSpec.describe Traject::Macros::Custom do
 
   context "electronic resource macros" do
     let(:path) { "url_field_examples.xml" }
+
+    describe "#extract_availability" do
+      before(:each) do
+        subject.instance_eval do
+          to_field "availability_facet", extract_availability
+
+          settings do
+            provide "marc_source.type", "xml"
+          end
+        end
+      end
+
+      context "Archive-it links are NOT Online" do
+        it "does not include ARCHIVE_IT_LINKS in Online records" do
+          expect(subject.map_record(records[9])).to_not eq("Online")
+        end
+      end
+    end
+
     describe "#extract_electronic_resource" do
       before(:each) do
         subject.instance_eval do
@@ -280,13 +299,25 @@ RSpec.describe Traject::Macros::Custom do
 
       context "Only 856 field is present" do
         context "single 856 field (ind1 = 4; ind2 = not 2) with no exceptions" do
-          it "maps a single 856 field to electronic_resource_display" do
+          it "maps a single 856 field to url_more_links_display" do
             expect(subject.map_record(records[3])).to eq({})
           end
         end
 
+        context "single 856 field (ind1 = 4; ind2 = not 2) with archive-it exception" do
+          it "maps a single 856 field to url_more_links_display" do
+            expect(subject.map_record(records[10])).to eq("url_more_links_display" => ["Archive|http://archive-it.org/collections/4222"])
+          end
+        end
+
+        context "single 856 field (ind1 = 4; ind2 = not 2) with temple and scrc should not map to more_links" do
+          it "does not include Temple SCRC resources in url_more_links_display" do
+            expect(subject.map_record(records[11])).to eq({})
+          end
+        end
+
         context "single 856 field (ind1 = 4; ind2 = not 2) with exceptions" do
-          it "maps a single 856 field to electronic_resource_display" do
+          it "maps a single 856 field to url_more_links_display" do
             expect(subject.map_record(records[5])).to eq(
               "url_more_links_display" => ["book review|http://foobar.com"],
             )
@@ -297,18 +328,37 @@ RSpec.describe Traject::Macros::Custom do
 
       context "Both PRT and 856 fields are present" do
         context "856 field has exception" do
-          it "only maps the PRT field to electronic_resource_display" do
+          it "only maps the PRT field to url_more_links_display" do
             expect(subject.map_record(records[7])).to eq(
               "url_more_links_display" => ["BOOK review|http://foobar.com"]
             )
           end
         end
         context "856 has no exception" do
-          it "only maps the PRT field to electronic_resource_display" do
+          it "only maps the PRT field to url_more_links_display" do
             expect(subject.map_record(records[8])).to eq(
               "url_more_links_display" => ["bar|http://foobar.com"]
             )
           end
+        end
+      end
+    end
+
+    describe "#extract_url_finding_aid" do
+      before(:each) do
+        subject.instance_eval do
+          to_field "url_finding_aid_display", extract_url_finding_aid
+
+          settings do
+            provide "marc_source.type", "xml"
+          end
+        end
+      end
+
+      context "856 field includes temple and scrc" do
+        it "it does not map to url_finding_aid_display " do
+          expect(subject.map_record(records[11])).to eq(
+            "url_finding_aid_display" => ["Finding aid|http://library.temple.edu/scrc"])
         end
       end
     end


### PR DESCRIPTION
The updated logic for electronic_resource_display excludes archive-it links, but these items were still being indexed into online availability.

I think this is what was causing the nil electronic_resource_display problem on libQA
Added specs for online availability, finding aid display, and added more specs for new logic in electronic_resource_display and url_more_links_display