### PR TITLE
Bl 366 library display

### DIFF
--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -43,8 +43,8 @@ module AlmaDataHelper
     end
   end
 
-  def library_name(item)
-    libraries = item.group_by do |lib|
+  def library_name(items)
+    items.group_by do |lib|
       (lib["holding_data"]["temp_library"]["value"] if lib["holding_data"]["in_temp_location"] == true) || (lib["item_data"]["library"]["value"])
     end
   end

--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -44,11 +44,9 @@ module AlmaDataHelper
   end
 
   def library_name(item)
-    libraries = item.group_by { |lib| lib["item_data"]["library"]["value"] }
-  end
-
-  def temp_library(item)
-    libraries = item.map { |lib| lib["holding_data"]["temp_library"]["value"] if lib["holding_data"]["in_temp_location"] == true }
+    libraries = item.group_by do |lib|
+      (lib["holding_data"]["temp_library"]["value"] if lib["holding_data"]["in_temp_location"] == true) || (lib["item_data"]["library"]["value"])
+    end
   end
 
   def library_name_from_short_code(short_code)

--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -43,12 +43,16 @@ module AlmaDataHelper
     end
   end
 
-  def library_status(item)
-    if item["holding_data"]["in_temp_location"] == true
-      Rails.configuration.libraries[item["holding_data"]["temp_library"]["value"]]
-    else
-      Rails.configuration.libraries[item["item_data"]["library"]["value"]]
-    end
+  def library_name(item)
+    libraries = item.group_by { |lib| lib["item_data"]["library"]["value"] }
+  end
+
+  def temp_library(item)
+    libraries = item.map { |lib| lib["holding_data"]["temp_library"]["value"] if lib["holding_data"]["in_temp_location"] == true }
+  end
+
+  def library_name_from_short_code(short_code)
+    Rails.configuration.libraries[short_code]
   end
 
   def alternative_call_number(item)

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -3,13 +3,7 @@
     <thead>
       <tr>
         <th scope="col">
-          <% temp_library(items).each do |temp| %>
-            <% if temp.present? %>
-              <%= library_name_from_short_code(temp) %>
-            <% else %>
-              <%= library_name_from_short_code(key) %>
-            <% end %>
-          <% end %>
+          <%= library_name_from_short_code(key) %>
         </th>
         <th scope="col">Availability</th>
       </tr>

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -1,12 +1,21 @@
 <table class="table table-responsive borderless">
-  <% @items["item"].each do |item| %>
+  <% library_name(@items["item"]).each do |key,items| %>
     <thead>
       <tr>
-        <th scope="col"><%= library_status(item) %></th>
+        <th scope="col">
+          <% temp_library(items).each do |temp| %>
+            <% if temp.present? %>
+              <%= library_name_from_short_code(temp) %>
+            <% else %>
+              <%= library_name_from_short_code(key) %>
+            <% end %>
+          <% end %>
+        </th>
         <th scope="col">Availability</th>
       </tr>
     </thead>
     <tbody >
+      <% items.each do |item| %>
         <tr>
           <td scope="row"><%= location_status(item) %> <%= alternative_call_number(item) %></td>
           <td scope="row"><%= availability_status(item) %></td>
@@ -22,6 +31,7 @@
         <!-- <tr>
           <td scope="row"><strong>Request Options: </strong> <%= select_tag "requests", options_for_select([ "option1", "option2" ]) %></td>
         </tr> -->
+      <% end %>
     </tbody>
   <% end %>
 </table>

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -150,18 +150,42 @@ RSpec.describe AlmaDataHelper, type: :helper do
     end
   end
 
-  describe "#library_status(item)" do
-    context "item is in temporary library" do
+  describe "#temp_library(item)" do
+    context "item is in a temporary location" do
       let(:item) do
-        { "holding_data" =>
+        [{ "holding_data" =>
            { "in_temp_location" => true,
              "temp_library" => { "value" => "KARDON" }
             }
-         }
+        }]
       end
 
-      it "displays temporary library" do
-        expect(library_status(item)).to eq "Remote Storage"
+      it "displays temporary library code" do
+        expect(temp_library(item)).to have_text "KARDON"
+      end
+    end
+  end
+
+  describe "#library_name(item)" do
+    context "item is in a library" do
+      let(:item) do
+        [{ "item_data" => {
+          "library" => { "value" => "MAIN" }
+          }
+        }]
+      end
+
+      it "displays library code" do
+        expect(library_name(item)).to have_text "MAIN"
+      end
+    end
+  end
+
+  describe "#library_name_from_short_code(short_code)" do
+    context "library codes are converted to names using translation map" do
+      let(:short_code) { "MAIN" }
+      it "displays library name" do
+        expect(library_name_from_short_code(short_code)).to eq "Paley Library"
       end
     end
   end
@@ -171,7 +195,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
       let(:item) do
         { "item_data" =>
            { "alternative_call_number" => "alternate" }
-         }
+        }
       end
 
       it "displays alternate call number" do

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
       end
 
       it "displays library code" do
-        expect(library_name(item)).to eq "MAIN" => [{"holding_data"=>{"in_temp_location"=>false}, "item_data"=>{"library"=>{"value"=>"MAIN"}}}]
+        expect(library_name(item)).to eq "MAIN" => [{ "holding_data" => { "in_temp_location" => false }, "item_data" => { "library" => { "value" => "MAIN" } } }]
       end
     end
 
@@ -180,7 +180,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
       end
 
       it "displays temporary library code" do
-        expect(library_name(item)).to eq "RES-SHARE" => [{"holding_data"=>{"in_temp_location"=>true, "temp_library"=>{"value"=>"RES-SHARE"}}, "item_data"=>{"library"=>{"value"=>"MAIN"}}}]
+        expect(library_name(item)).to eq "RES-SHARE" => [{ "holding_data" => { "in_temp_location" => true, "temp_library" => { "value" => "RES-SHARE" } }, "item_data" => { "library" => { "value" => "MAIN" } } }]
       end
     end
   end

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -150,33 +150,37 @@ RSpec.describe AlmaDataHelper, type: :helper do
     end
   end
 
-  describe "#temp_library(item)" do
-    context "item is in a temporary location" do
+  describe "#library_name(item)" do
+    context "item is in a permanent library" do
       let(:item) do
         [{ "holding_data" =>
-           { "in_temp_location" => true,
-             "temp_library" => { "value" => "KARDON" }
-            }
-        }]
-      end
-
-      it "displays temporary library code" do
-        expect(temp_library(item)).to have_text "KARDON"
-      end
-    end
-  end
-
-  describe "#library_name(item)" do
-    context "item is in a library" do
-      let(:item) do
-        [{ "item_data" => {
-          "library" => { "value" => "MAIN" }
-          }
-        }]
+           { "in_temp_location" => false,
+           },
+           "item_data" => {
+             "library" => { "value" => "MAIN" }
+           }
+         }]
       end
 
       it "displays library code" do
-        expect(library_name(item)).to have_text "MAIN"
+        expect(library_name(item)).to eq "MAIN" => [{"holding_data"=>{"in_temp_location"=>false}, "item_data"=>{"library"=>{"value"=>"MAIN"}}}]
+      end
+    end
+
+    context "item is in a temporary library" do
+      let(:item) do
+        [{ "holding_data" =>
+           { "in_temp_location" => true,
+             "temp_library" => { "value" => "RES-SHARE" },
+           },
+           "item_data" => {
+             "library" => { "value" => "MAIN" }
+           }
+         }]
+      end
+
+      it "displays temporary library code" do
+        expect(library_name(item)).to eq "RES-SHARE" => [{"holding_data"=>{"in_temp_location"=>true, "temp_library"=>{"value"=>"RES-SHARE"}}, "item_data"=>{"library"=>{"value"=>"MAIN"}}}]
       end
     end
   end


### PR DESCRIPTION

![screen shot 2018-04-10 at 3 35 57 pm](https://user-images.githubusercontent.com/15167238/38579454-11533970-3cd5-11e8-9ff8-b1dc99d31316.png)
![screen shot 2018-04-10 at 3 34 21 pm](https://user-images.githubusercontent.com/15167238/38579462-1740eda0-3cd5-11e8-94dd-80ae3c8db3d9.png)

BL-366 Library names should only display once, regardless of how many copies there are at that library
- Record 991025629919703811 should display "Paley Library" once
- Temporary libraries should display instead of library name if item is in a temporary library
- Record 991026548529703811 should display "Resource Sharing Library" NOT "Paley Library"