### PR TITLE
Bl 369 library use only

### DIFF
--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -5,7 +5,11 @@ module AlmaDataHelper
 
   def availability_status(item)
     if item["item_data"]["base_status"]["value"] == "1"
-      "Available"
+      if item["item_data"]["policy"]["desc"].include?("Non-circulating")
+        "Library Use Only"
+      else
+        "Available"
+      end
     elsif item["item_data"]["base_status"]["value"] == "0"
       unavailable_items(item)
     end

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AlmaDataHelper type: :helper do
+RSpec.describe AlmaDataHelper, type: :helper do
   describe "#availability_status(item)" do
     context "item base_status is 1 and policy is Non-circulating" do
       let(:item) do

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -2,13 +2,31 @@
 
 require "rails_helper"
 
-RSpec.describe AlmaDataHelper, type: :helper do
+RSpec.describe AlmaDataHelper type: :helper do
   describe "#availability_status(item)" do
+    context "item base_status is 1 and policy is Non-circulating" do
+      let(:item) do
+        { "item_data" =>
+           { "base_status" =>
+             { "value" => "1" },
+             "policy" =>
+             { "desc" => "Non-circulating" }
+           }
+         }
+      end
+
+      it "displays library use only" do
+        expect(availability_status(item)).to eq "Library Use Only"
+      end
+    end
+
     context "item base_status is 1" do
       let(:item) do
         { "item_data" =>
            { "base_status" =>
-             { "value" => "1" }
+             { "value" => "1" },
+             "policy" =>
+             { "desc" => "" }
            }
          }
       end


### PR DESCRIPTION
BL-369 Display "library use only" for availability of non-circulating items.
- Sample data record 991012599009703811 should have the text "library use only" under availability
![screen shot 2018-04-10 at 4 26 26 pm](https://user-images.githubusercontent.com/15167238/38581835-eed06344-3cdb-11e8-8cd7-87330fa85343.png)
