### PR TITLE
BL-323 Add labels to advanced search for accessibility

### DIFF
--- a/app/views/advanced/_advanced_search_facets.html.erb
+++ b/app/views/advanced/_advanced_search_facets.html.erb
@@ -31,13 +31,15 @@
     </div>
     <div class="col col-sm-8">
     <div class="col col-sm-3 pub-date">
+      <label for="range_pub_date_sort_begin" class="sr-only">Publication date range (starting year)</label>
       <%= render_range_input("pub_date_sort", :begin) %>
     </div>
-    <div class="col col-sm-1 pub-date-separator"> 
-     to 
+    <div class="col col-sm-1 pub-date-separator">
+     to
     </div>
     <div class="col col-sm-3 pub-date">
-       <%= render_range_input("pub_date_sort", :end) %>
+      <label for="range_pub_date_sort_end" class="sr-only">Publication date range (ending year)</label>
+      <%= render_range_input("pub_date_sort", :end) %>
     </div>
   </div>
 </div>

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -2,23 +2,26 @@
   <% (1..advanced_search_config[:fields_row_count]).each do |count| %>
   <div class="row">
     <div class="col-sm-2">
+      <label for=<%= "f_#{count}" %> class="sr-only">Options for advanced search</label>
       <%= select_tag("f_#{count}", options_for_select(advanced_key_value, label_tag_default_for("f_#{count}")), :class=>"form-control") %>
     </div>
 
     <div class="col-sm-2">
-      <%= select_tag("op_row[]", options_for_select({"contains"=> :contains, "is (exact)" => :is, "begins with" => :begins_with}.sort, op_row_default(count)), :class => "form-control" ) %>
+      <label for="op_row[]" class="sr-only">Operator</label>
+      <%= select_tag("op_row[]", options_for_select({"contains"=> :contains, "is (exact)" => :is, "begins with" => :begins_with}.sort, op_row_default(count)), :class => "form-control", :id =>"op_row[]") %>
     </div>
 
     <div class="col-sm-3">
+    <label for=<%= "q_#{count}" %> class="sr-only">Advanced search terms</label>
     <%= text_field_tag "q_#{count}", label_tag_default_for("q_#{count}"), :class => "form-control", autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
     </div>
   </div>
   <div class="row booleans">
   <% if count != advanced_search_config[:fields_row_count] %>
     <div class="col-sm-5 col-sm-offset-2">
-    <%= radio_button_tag("op_#{count}", "AND", booleans("op_#{count}", "AND")) %><label> AND</label>
-    <%= radio_button_tag("op_#{count}", "OR", booleans("op_#{count}", "OR")) %><label> OR</label>
-    <%= radio_button_tag("op_#{count}", "NOT", booleans("op_#{count}", "NOT")) %><label> NOT</label>
+    <label><%= radio_button_tag("op_#{count}", "AND", booleans("op_#{count}", "AND")) %> AND</label>
+    <label><%= radio_button_tag("op_#{count}", "OR", booleans("op_#{count}", "OR")) %> OR</label>
+    <label><%= radio_button_tag("op_#{count}", "NOT", booleans("op_#{count}", "NOT")) %> NOT</label>
     </div>
   <% end %>
   </div>


### PR DESCRIPTION
BL-323 Update advanced search form for greater accessibility
- add sr-only labels to form inputs
- chosen dropdown are not currently compliant, looks like they are working on it