### PR TITLE
Encode dots in primo ids.

### DIFF
--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -13,6 +13,9 @@ module Blacklight::PrimoCentral::Document
       .first["links"]
       .first["link"]
 
+    # dots do not get URL encoded and break links to articles.
+    doc[:pnxId] = doc[:pnxId].gsub(".", "-dot-") if doc[:pnxId]
+
     doc["link"] = url
 
     solr_to_primo_keys.each do |solr_key, primo_key|

--- a/app/models/blacklight/primo_central/repository.rb
+++ b/app/models/blacklight/primo_central/repository.rb
@@ -5,6 +5,7 @@ require "primo"
 module Blacklight::PrimoCentral
   class Repository < Blacklight::AbstractRepository
     def find(id, params = {})
+      id = id.gsub("-dot-", ".")
       response = Primo.find(id: id)
       blacklight_config.document_model.new response.to_h
     end


### PR DESCRIPTION
REF BL-383

Dots in primo central record ids are causing links to full records pages
to get rerouted with routing errors.