### PR TITLE
Add default message for records with no item data

### DIFF
--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -1,31 +1,39 @@
 <table class="table table-responsive borderless">
-  <% library_name(@items["item"]).each do |key,items| %>
-    <thead>
-      <tr>
-        <th scope="col">
-          <%= library_name_from_short_code(key) %>
-        </th>
-        <th scope="col">Availability</th>
-      </tr>
-    </thead>
-    <tbody >
-      <% items.each do |item| %>
+  <% unless @items["item"].nil? %>
+    <% library_name(@items["item"]).each do |key,items| %>
+      <thead>
         <tr>
-          <td scope="row"><%= location_status(item) %> <%= alternative_call_number(item) %></td>
-          <td scope="row"><%= availability_status(item) %></td>
-          <td scope="row"></td>
+          <th scope="col">
+            <%= library_name_from_short_code(key) %>
+          </th>
+          <th scope="col">Availability</th>
         </tr>
+      </thead>
+      <tbody >
+        <% items.each do |item| %>
+          <tr>
+            <td scope="row"><%= location_status(item) %> <%= alternative_call_number(item) %></td>
+            <td scope="row"><%= availability_status(item) %></td>
+            <td scope="row"></td>
+          </tr>
 
-        <tr>
-          <td scope="row"><%= description(item) %></td>
-        </tr>
-        <tr>
-          <td scope="row"><%= public_note(item) %></td>
-        </tr>
-        <!-- <tr>
-          <td scope="row"><strong>Request Options: </strong> <%= select_tag "requests", options_for_select([ "option1", "option2" ]) %></td>
-        </tr> -->
-      <% end %>
-    </tbody>
+          <tr>
+            <td scope="row"><%= description(item) %></td>
+          </tr>
+          <tr>
+            <td scope="row"><%= public_note(item) %></td>
+          </tr>
+          <!-- <tr>
+            <td scope="row"><strong>Request Options: </strong> <%= select_tag "requests", options_for_select([ "option1", "option2" ]) %></td>
+          </tr> -->
+        <% end %>
+      </tbody>
+    <% end %>
+    <% else %>
+    <tr>
+      <td>
+        We are unable to find availability information for this record. Please contact the library for more information.
+      </td>
+    </tr>
   <% end %>
 </table>


### PR DESCRIPTION
BL-375 and BL-221 Include default message on record pages for records that do not have any item data
- 991004349569703811 Should display the default message 
![screen shot 2018-04-16 at 1 46 53 pm](https://user-images.githubusercontent.com/15167238/38826050-a590fa7c-417c-11e8-8062-e34f91e2a880.png)
