### PR TITLE
Bl 385 link helper bug

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,6 +58,14 @@ module ApplicationHelper
     creator
   end
 
+  def has_one_electronic_resource?(document)
+    document.fetch("electronic_resource_display", []).length == 1
+  end
+
+  def has_many_electronic_resources?(document)
+    document.fetch("electronic_resource_display", []).length > 1
+  end
+
   def check_for_full_http_link(args)
     args[:document][args[:field]].map { |field|
       if field.include?("http")

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -2,9 +2,9 @@
 
 <% @response["response"][:docs].each_with_index do |field, i| %>
   <% if document.fetch("availability_facet", [])[i] == "Online" %>
-    <% if document.fetch("electronic_resource_display",[]).length == 1 %>
+    <% if has_one_electronic_resource?(document) %>
       <%= link_to "Online", single_link_builder(document["electronic_resource_display"][i]), class:"collapse-button btn btn-sm btn-info", title:"This link opens the resource in a new tab.", target:"_blank" %>
-    <% else %>
+    <% elsif has_many_electronic_resources?(document) %>
     <div class="row button-break"></div>
       <button class="btn-block btn btn-sm btn-info collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document_counter %>">
       <span class="avail-label" aria-expanded="false">Online</span>

--- a/spec/fixtures/marc_files/url_field_examples.xml
+++ b/spec/fixtures/marc_files/url_field_examples.xml
@@ -324,10 +324,24 @@
     </datafield>
   </record>
   <record>
-    <!-- 14. ARCHIVE_IT_LINKS aren't included in Online Availability  -->
+    <!-- 14. Indicator1= 4 and indicator2 = NOT 2 maps to Online  -->
     <datafield tag="856" ind1="4" ind2="0">
       <subfield code="z">Adobe Acrobat reader required to view</subfield>
       <subfield code="u">http://www.access.gpo.gov/congress/commissions/secrecy/index.html</subfield>
     </datafield>
   </record>
+  <record>
+  <!-- 15. Finding aid and more links test record  -->
+  <datafield tag="245" ind1="4" ind2="2">
+    <subfield code="a">Camp Kennebec Alumni Collection, 1910-2016</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="2">
+    <subfield code="3">View a description and list of collection contents in the online finding aid.</subfield>
+    <subfield code="u">http://library.temple.edu/collections/scrc/camp-kennebec-alumni</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="0">
+    <subfield code="3">View preserved website versions on Archive-It.</subfield>
+    <subfield code="u">https://www.archive-it.org/collections/4280</subfield>
+  </datafield>
+</record>
 </collection>

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -26146,4 +26146,18 @@
       <subfield code="u">https://archive-it.org/collections/4487</subfield>
     </datafield>
   </record>
+  <record>
+    <controlfield tag='001'>991036440439703811</controlfield>
+    <datafield tag="245" ind1="4" ind2="2">
+      <subfield code="a">Camp Kennebec Alumni Collection, 1910-2016</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="2">
+      <subfield code="3">View a description and list of collection contents in the online finding aid.</subfield>
+      <subfield code="u">http://library.temple.edu/collections/scrc/camp-kennebec-alumni</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="0">
+      <subfield code="3">View preserved website versions on Archive-It.</subfield>
+      <subfield code="u">https://www.archive-it.org/collections/4280</subfield>
+    </datafield>
+  </record>
 </collection>

--- a/spec/models/traject_indexer_spec.rb
+++ b/spec/models/traject_indexer_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe Traject::Macros::Custom do
 
         context "multiple 856 fields (ind1 = 4; ind2 = not 2) with exceptions" do
           it "does not map a field to electronic_resource_display" do
-            expect(subject.map_record(records[6])).to eq({})
+            expect(subject.map_record(records[15])).to eq({})
           end
         end
       end


### PR DESCRIPTION
BL-385 Update the logic for electronic_resource_display to try to fix libQA issue with records that have no electronic_resource field
- Add data for specs
- Move logic out of view and into helper methods