### PR TITLE
Fix advanced_search_helper deprecation warning.

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -180,7 +180,7 @@ module BlacklightAdvancedSearch
           op = "op_#{position - 1}"
         end
 
-        field = search_field_def_for_key(my_params[f]).to_h
+        field = blacklight_config.search_fields[my_params[f]].to_h
         label = field[:label].to_s
         if position == 1
           query = my_params[q]


### PR DESCRIPTION
REF BL-391

Fixes warning:

```
DEPRECATION WARNING: search_field_def_for_key is deprecated and will be
removed from blacklight 7.x (Use blacklight_config.search_fields[key]).`
```