### PR TITLE
Suppress holdings

### DIFF
--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -52,10 +52,15 @@ module AlmaDataHelper
     end
   end
 
+  def missing_or_lost?(item)
+    item["item_data"]["process_type"].has_value?("MISSING") || item["item_data"]["process_type"].has_value?("LOST")
+  end
+
   def library_name(items)
-    items.select { |item| item unless item["item_data"]["process_type"].has_value?("MISSING") || item["item_data"]["process_type"].has_value?("LOST") }.group_by do |lib|
-      (lib["holding_data"]["temp_library"]["value"] if lib["holding_data"]["in_temp_location"] == true) || (lib["item_data"]["library"]["value"])
-    end
+    items.select { |item| item unless missing_or_lost?(item) }
+      .group_by do |lib|
+        (lib["holding_data"]["temp_library"]["value"] if lib["holding_data"]["in_temp_location"] == true) || (lib["item_data"]["library"]["value"])
+      end
   end
 
   def library_name_from_short_code(short_code)

--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -53,7 +53,7 @@ module AlmaDataHelper
   end
 
   def library_name(items)
-    items.group_by do |lib|
+    items.select { |item| item unless item["item_data"]["process_type"].has_value?("MISSING") || item["item_data"]["process_type"].has_value?("LOST") }.group_by do |lib|
       (lib["holding_data"]["temp_library"]["value"] if lib["holding_data"]["in_temp_location"] == true) || (lib["item_data"]["library"]["value"])
     end
   end

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -26160,4 +26160,44 @@
       <subfield code="u">https://www.archive-it.org/collections/4280</subfield>
     </datafield>
   </record>
+  <record>
+    <leader>03545cgm a2200757Ia 4500</leader>
+    <controlfield tag="005">20170825173006.0</controlfield>
+    <controlfield tag="007">vd cvaizq</controlfield>
+    <controlfield tag="008">081016p20081982nyu090 g vleng d</controlfield>
+    <controlfield tag="001">991016705469703811</controlfield>
+    <datafield ind1="0" ind2="0" tag="245">
+      <subfield code="a">White dog</subfield>
+      <subfield code="h">[videorecording] /</subfield>
+      <subfield code="c">Paramount Pictures presents an Edgar J. Scherick production ; a Samuel Fuller film ; produced by Jon Davison ; screenplay by Samuel Fuller and Curtis Hanson ; directed by Samuel Fuller.</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="521">
+      <subfield code="a">MPAA rating: PG.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="520">
+      <subfield code="a">A German shepherd is adopted by an actress who learns that the dog has been trained to attack only African Americans. Now it's up to an animal trainer to try to change the dog.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocn262623833</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="b">0</subfield>
+      <subfield code="c">110825</subfield>
+      <subfield code="d">m</subfield>
+      <subfield code="e">g</subfield>
+      <subfield code="f">g</subfield>
+      <subfield code="g">0</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="a">08/25/11</subfield>
+      <subfield code="s">OCLC</subfield>
+      <subfield code="c">DH</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="HLD">
+      <subfield code="b">MEDIA</subfield>
+      <subfield code="c">media</subfield>
+      <subfield code="h">DVD 11 843</subfield>
+      <subfield code="8">22318756170003811</subfield>
+    </datafield>
+  </record>
 </collection>

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -170,19 +170,56 @@ RSpec.describe AlmaDataHelper, type: :helper do
   end
 
   describe "#library_name(item)" do
+    context "does not display items that are lost" do
+      let(:item) do
+        [{ "holding_data" =>
+           { "in_temp_location" => false,
+           },
+           "item_data" => {
+             "library" => { "value" => "MAIN" },
+             "process_type" => { "value" => "LOST" }
+           }
+         }]
+      end
+
+      it "does not display item" do
+        expect(library_name(item)).to eq({})
+      end
+    end
+
+    context "does not display items that are missing" do
+      let(:item) do
+        [{ "holding_data" =>
+           { "in_temp_location" => false,
+           },
+           "item_data" => {
+             "library" => { "value" => "MAIN" },
+             "process_type" => { "value" => "MISSING" }
+           }
+         }]
+      end
+
+      it "does not display item" do
+        expect(library_name(item)).to eq({})
+      end
+    end
+
+
     context "item is in a permanent library" do
       let(:item) do
         [{ "holding_data" =>
            { "in_temp_location" => false,
            },
            "item_data" => {
-             "library" => { "value" => "MAIN" }
+             "library" => { "value" => "MAIN" },
+             "process_type" => { "value" => "" }
            }
          }]
       end
 
       it "displays library code" do
-        expect(library_name(item)).to eq "MAIN" => [{ "holding_data" => { "in_temp_location" => false }, "item_data" => { "library" => { "value" => "MAIN" } } }]
+        expect(library_name(item)).to eq "MAIN" => [{ "holding_data" => { "in_temp_location" => false }, "item_data" => { "library" => { "value" => "MAIN" },              "process_type" => { "value" => "" }
+ } }]
       end
     end
 
@@ -193,13 +230,15 @@ RSpec.describe AlmaDataHelper, type: :helper do
              "temp_library" => { "value" => "RES-SHARE" },
            },
            "item_data" => {
-             "library" => { "value" => "MAIN" }
+             "library" => { "value" => "MAIN" },
+             "process_type" => { "value" => "" }
            }
          }]
       end
 
       it "displays temporary library code" do
-        expect(library_name(item)).to eq "RES-SHARE" => [{ "holding_data" => { "in_temp_location" => true, "temp_library" => { "value" => "RES-SHARE" } }, "item_data" => { "library" => { "value" => "MAIN" } } }]
+        expect(library_name(item)).to eq "RES-SHARE" => [{ "holding_data" => { "in_temp_location" => true, "temp_library" => { "value" => "RES-SHARE" } }, "item_data" => { "library" => { "value" => "MAIN" },              "process_type" => { "value" => "" }
+ } }]
       end
     end
   end

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
          }]
       end
 
-      it "does not display item" do
+      it "does not display lost item" do
         expect(library_name(item)).to eq({})
       end
     end
@@ -199,7 +199,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
          }]
       end
 
-      it "does not display item" do
+      it "does not display missing item" do
         expect(library_name(item)).to eq({})
       end
     end


### PR DESCRIPTION
BL-373 Items with a process type of missing or lost should not display in the availability data. 
- Alma mms_id 991016705469703811 in the spec/fixtures/marc_fixture.xml file should display the copy that it available, but not the copy that is missing
![screen shot 2018-04-20 at 2 46 32 pm](https://user-images.githubusercontent.com/15167238/39068248-a8466f1a-44a9-11e8-85e3-d45376061ff4.png)
