### PR TITLE
Add "More" bento box.

### DIFF
--- a/app/controllers/concerns/catalog_config_reinit.rb
+++ b/app/controllers/concerns/catalog_config_reinit.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Add this mixin to classes that inherit from CatalogController.
+module CatalogConfigReinit
+  extend ActiveSupport::Concern
+  included do
+    blacklight_config.configure do |config|
+      # Reinitialize blacklight field configurations
+      config.search_fields = ActiveSupport::OrderedHash.new
+      config.show_fields = ActiveSupport::OrderedHash.new
+      config.facet_fields = ActiveSupport::OrderedHash.new
+      config.index_fields = ActiveSupport::OrderedHash.new
+      config.sort_fields = ActiveSupport::OrderedHash.new
+    end
+  end
+end

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -2,15 +2,9 @@
 
 class PrimoCentralController < CatalogController
   include Blacklight::Catalog
+  include CatalogConfigReinit
 
   configure_blacklight do |config|
-    # Reinitialize field configruations.
-    config.search_fields = ActiveSupport::OrderedHash.new
-    config.show_fields = ActiveSupport::OrderedHash.new
-    config.facet_fields = ActiveSupport::OrderedHash.new
-    config.index_fields = ActiveSupport::OrderedHash.new
-    config.sort_fields = ActiveSupport::OrderedHash.new
-
     # Class for sending and receiving requests from a search index
     config.repository_class = Blacklight::PrimoCentral::Repository
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -10,7 +10,7 @@ class SearchController < CatalogController
     config.facet_fields = ActiveSupport::OrderedHash.new
     config.index_fields = ActiveSupport::OrderedHash.new
     config.sort_fields = ActiveSupport::OrderedHash.new
-    config.add_facet_field "format", label: "Resource Type", collapse: false, limit: false
+    config.add_facet_field "format", label: "Resource Type", url_method: :path_for_more_facet
   end
 
   @@per_page = 10

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -20,6 +20,7 @@ class SearchController < CatalogController
       searcher = BentoSearch::ConcurrentSearcher.new(*engines)
       searcher.search(params[:q], per_page: @@per_page, semantic_search_field: params[:field])
       @results = searcher.results
+      @response = @results["more"].first.custom_data
     end
   end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -48,11 +48,4 @@ class SearchController < CatalogController
       format.atom { render template: "bento_search/atom_results", locals: { atom_results: @results } }
     end
   end
-
-  protected
-    # Get controller to find templates in CatalogController too,
-    # so we can reuse facet templates.
-    def self.local_prefixes
-      @local_prefixes ||= super.push("catalog")
-    end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -11,7 +11,7 @@ class SearchController < CatalogController
   @@per_page = 10
   def index
     if params[:q]
-      engines = %i( blacklight journals books primo  more )
+      engines = %i( books journals primo  more )
       searcher = BentoSearch::ConcurrentSearcher.new(*engines)
       searcher.search(params[:q], per_page: @@per_page, semantic_search_field: params[:field])
       @results = searcher.results

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,14 +2,9 @@
 
 class SearchController < CatalogController
   include Blacklight::RequestBuilders
+  include CatalogConfigReinit
 
   blacklight_config.configure do |config|
-    # Reinitialize field configurations
-    config.search_fields = ActiveSupport::OrderedHash.new
-    config.show_fields = ActiveSupport::OrderedHash.new
-    config.facet_fields = ActiveSupport::OrderedHash.new
-    config.index_fields = ActiveSupport::OrderedHash.new
-    config.sort_fields = ActiveSupport::OrderedHash.new
     config.add_facet_field "format", label: "Resource Type", url_method: :path_for_more_facet
   end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,10 +1,22 @@
 # frozen_string_literal: true
 
-class SearchController < ApplicationController
+class SearchController < CatalogController
+  include Blacklight::RequestBuilders
+
+  blacklight_config.configure do |config|
+    # Reinitialize field configurations
+    config.search_fields = ActiveSupport::OrderedHash.new
+    config.show_fields = ActiveSupport::OrderedHash.new
+    config.facet_fields = ActiveSupport::OrderedHash.new
+    config.index_fields = ActiveSupport::OrderedHash.new
+    config.sort_fields = ActiveSupport::OrderedHash.new
+    config.add_facet_field "format", label: "Resource Type", collapse: false, limit: false
+  end
+
   @@per_page = 10
   def index
     if params[:q]
-      engines = %i( blacklight journals books primo )
+      engines = %i( blacklight journals books primo  more )
       searcher = BentoSearch::ConcurrentSearcher.new(*engines)
       searcher.search(params[:q], per_page: @@per_page, semantic_search_field: params[:field])
       @results = searcher.results
@@ -36,4 +48,11 @@ class SearchController < ApplicationController
       format.atom { render template: "bento_search/atom_results", locals: { atom_results: @results } }
     end
   end
+
+  protected
+    # Get controller to find templates in CatalogController too,
+    # so we can reuse facet templates.
+    def self.local_prefixes
+      @local_prefixes ||= super.push("catalog")
+    end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -172,6 +172,8 @@ module ApplicationHelper
       link_to "See all #{number_with_delimiter(results.total_items)} results.", search_catalog_path(q: params[:q], f: { format: ["Journal/Periodical"] }), class: "full-results"
     when "books"
       link_to "See all #{number_with_delimiter(results.total_items)} results.", search_catalog_path(q: params[:q], f: { format: ["Book"] }), class: "full-results"
+    when "more"
+      ""
     else
       content_tag(:p, "Total records from #{bento_engine_nice_name(results.engine_id)}: #{results.count}" || "?", class: "record-count")
     end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SearchHelper
+  ##
+  # Links More bento block facet back to catalog.
+  # @param [Blacklight::Solr::Response::Facets::FacetField] facet_field
+  # @param [String] item
+  # @return [String]
+  def path_for_more_facet(facet_field, item)
+    search_catalog_url(search_state.add_facet_params_and_redirect(facet_field, item))
+  end
+end

--- a/app/models/bento_search_builder_behavior.rb
+++ b/app/models/bento_search_builder_behavior.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module BentoSearchBuilderBehavior
+  extend ActiveSupport::Concern
+
+  def remove_facets(solr_params)
+    # Remove all field faceting for efficiency, we won't be using it.
+    solr_params.delete("facet.field")
+    solr_params.delete("facet.field".to_sym)
+    solr_params["stats"] = false
+    solr_params["facets"] = false
+  end
+
+  def format_facet_only(solr_params)
+    # Facet on one field and return no result rows.
+    solr_params["facet.field"] = "format"
+    solr_params["facets"] = true
+    solr_params["rows"] = 0;
+  end
+end

--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -5,13 +5,13 @@ module Blacklight::PrimoCentral
     extend ActiveSupport::Concern
 
     included do
-        self.default_processor_chain = [
-            :add_query_to_primo_central,
-            :set_query_field,
-            :set_query_sort_order,
-            :add_query_facets,
-        ]
-      end
+      self.default_processor_chain = [
+        :add_query_to_primo_central,
+        :set_query_field,
+        :set_query_sort_order,
+        :add_query_facets,
+      ]
+    end
 
     def add_query_to_primo_central(primo_central_parameters)
       per_page = (blacklight_params["per_page"] || blacklight_config.default_per_page).to_i

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -4,6 +4,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
   include BlacklightRangeLimit::RangeLimitBuilder
+  include BentoSearchBuilderBehavior
 
   BEGINS_WITH_TAG = "matchbeginswith"
   ENDS_WITH_TAG = "matchendswith"

--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -3,12 +3,16 @@
 module BentoSearch
   class BlacklightEngine
     include BentoSearch::SearchEngine
+    include Blacklight::SearchHelper
+
+    delegate :blacklight_config, to: CatalogController
 
     def search_implementation(args)
       query = args.fetch(:query, "")
 
       results = BentoSearch::Results.new
-      solr_result = search_results(q: query)
+      solr_result = search_results(q: query, &proc_remove_facets).first.response
+
       results.total_items = solr_result["numFound"]
 
       solr_result["docs"].each do |item|
@@ -18,27 +22,19 @@ module BentoSearch
       results
     end
 
+    def proc_remove_facets
+      Proc.new { |builder|
+        processor_chain = [ :add_query_to_solr, :remove_facets ]
+        builder.except(builder.default_processor_chain)
+          .append(*processor_chain)
+      }
+    end
+
     def conform_to_bento_result(item)
       BentoSearch::ResultItem.new(title: item.fetch("title_statement_display", []).first,
         authors: item.fetch("creator_display", []).map { |author| BentoSearch::Author.new(display: author) },
         publisher: item.fetch("imprint_display", []).join(" "),
         link: Rails.application.routes.url_helpers.solr_document_url(item["id"], only_path: true))
     end
-
-    def search_results(args)
-      SearchHelperWrapper.search_results(args).first["response"]
-    end
-  end
-end
-
-class SearchHelperWrapper
-  include Blacklight::SearchHelper
-
-  def blacklight_config
-    CatalogController.blacklight_config
-  end
-
-  def self.search_results(args)
-    self.new.search_results(args)
   end
 end

--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -24,9 +24,7 @@ module BentoSearch
 
     def proc_remove_facets
       Proc.new { |builder|
-        processor_chain = [ :add_query_to_solr, :remove_facets ]
-        builder.except(builder.default_processor_chain)
-          .append(*processor_chain)
+        builder.append(:remove_facets)
       }
     end
 

--- a/app/search_engines/bento_search/books_engine.rb
+++ b/app/search_engines/bento_search/books_engine.rb
@@ -4,9 +4,11 @@ module BentoSearch
   class BooksEngine < BlacklightEngine
     def search_implementation(args)
       query = args.fetch(:query, "")
+      query = { q: query, f: { format: ["Book"] } }
 
       results = BentoSearch::Results.new
-      solr_result = search_results(q: query, f: { format: ["Book"] })
+
+      solr_result = search_results(query, &proc_remove_facets).first.response
       results.total_items = solr_result["numFound"]
 
       solr_result["docs"].each do |item|

--- a/app/search_engines/bento_search/journals_engine.rb
+++ b/app/search_engines/bento_search/journals_engine.rb
@@ -4,9 +4,11 @@ module BentoSearch
   class JournalsEngine < BlacklightEngine
     def search_implementation(args)
       query = args.fetch(:query, "")
+      query = { q: query, f: { format: ["Journal/Periodical"] } }
 
       results = BentoSearch::Results.new
-      solr_result = search_results(q: query, f: { format: ["Journal/Periodical"] })
+
+      solr_result = search_results(query, &proc_remove_facets).first.response
       results.total_items = solr_result["numFound"]
 
       solr_result["docs"].each do |item|

--- a/app/search_engines/bento_search/more_engine.rb
+++ b/app/search_engines/bento_search/more_engine.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module BentoSearch
+  class MoreEngine < BlacklightEngine
+    def search_implementation(args)
+      query = args.fetch(:query, "")
+      query = { q: query }
+
+      response = search_results(query, &proc_format_facet_only).first
+
+      formats = filtered_format_facets(response)
+      response.facet_counts["facet_fields"]["format"] = formats
+
+      item = BentoSearch::ResultItem.new(custom_data: response)
+
+      BentoSearch::Results.new << item
+    end
+
+    def filtered_format_facets(response)
+      response.facet_counts["facet_fields"]["format"]
+        .each_slice(2).to_h
+        .select { |k, v| k != "Book" && k != "Journal/Periodical" }
+        .to_a.flatten
+    end
+
+    def proc_format_facet_only
+      Proc.new { |builder|
+        processor_chain = [ :format_facet_only ]
+        builder.except(builder.default_processor_chain)
+          .append(*processor_chain)
+      }
+    end
+  end
+end

--- a/app/search_engines/bento_search/more_engine.rb
+++ b/app/search_engines/bento_search/more_engine.rb
@@ -17,16 +17,21 @@ module BentoSearch
     end
 
     def filtered_format_facets(response)
-      response.facet_counts["facet_fields"]["format"]
-        .each_slice(2).to_h
-        .select { |k, v| k != "Book" && k != "Journal/Periodical" }
-        .to_a.flatten
+      if response.facet_fields["format"]
+        response.facet_counts["facet_fields"]["format"]
+          .each_slice(2).to_h
+          .select { |k, v| k != "Book" && k != "Journal/Periodical" }
+          .to_a.flatten
+      else
+        []
+      end
     end
 
+    # Overrides the search builder process chain with [:format_facet_only].
     def proc_format_facet_only
       Proc.new { |builder|
-        processor_chain = [ :format_facet_only ]
-        builder.except(builder.default_processor_chain)
+        processor_chain = [ :add_query_to_solr, :format_facet_only ]
+        builder.except(*builder.default_processor_chain)
           .append(*processor_chain)
       }
     end

--- a/app/views/bento_search/_more.html.erb
+++ b/app/views/bento_search/_more.html.erb
@@ -1,0 +1,3 @@
+
+<% @response = item.custom_data %>
+<%= render_facet_partials ["format"] %>

--- a/app/views/bento_search/_more.html.erb
+++ b/app/views/bento_search/_more.html.erb
@@ -1,3 +1,2 @@
 
-<% @response = item.custom_data %>
 <%= render_facet_partials ["format"] %>

--- a/app/views/search/_facet_layout.html.erb
+++ b/app/views/search/_facet_layout.html.erb
@@ -1,0 +1,3 @@
+    <div class="panel-body">
+      <%= yield %>
+    </div>

--- a/config/initializers/bento_search.rb
+++ b/config/initializers/bento_search.rb
@@ -23,6 +23,13 @@ BentoSearch.register_engine("books") do |conf|
   end
 end
 
+BentoSearch.register_engine("more") do |conf|
+  conf.engine = "BentoSearch::MoreEngine"
+  conf.for_display do |display|
+    display.item_partial = "bento_search/more"
+  end
+end
+
 BentoSearch.register_engine("primo") do |conf|
   conf.engine = "BentoSearch::PrimoEngine"
   conf.api_base_url = Rails.configuration.bento[:primo][:api_base_url]

--- a/spec/fixtures/vcr_cassettes/bento_search_more.yml
+++ b/spec/fixtures/vcr_cassettes/bento_search_more.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://solr:8983/solr/blacklight/select?author_pf=creator_unstem_search%5E2000%20creator_t%5E200&author_qf=creator_unstem_search%5E200%20creator_t%5E20&defType=dismax&echoParams=explicit&f.creator_facet.facet.limit=11&f.format.facet.limit=11&f.genre_facet.facet.limit=11&f.language_facet.facet.limit=11&f.library_facet.facet.limit=11&f.subject_era_facet.facet.limit=11&f.subject_facet.facet.limit=11&f.subject_region_facet.facet.limit=11&f.subject_topic_facet.facet.limit=11&facet=true&facet.field=format&facets=true&fl=id%20score%20availability_facet%20creator_display%20contributor_display%20electronic_resource_display%20format%20imprint_display%20pub_date%20title_series_display%20title_statement_display%20title_uniform_display%20isbn_display%20lccn_display&mm=6%253C90%2525&pf=title_unstem_search%5E1000000%20subtitle_unstem_search%5E500000%20title_t%5E250000%20subtitle_t%5E100000%20title_uniform_unstem_search%5E75000%20title_uniform_t%5E50000%20title_addl_unstem_search%5E50000%20title_addl_t%5E25000%20title_added_entry_unstem_search%5E15000%20title_added_entry_t%5E12500%20subject_topic_unstem_search%5E10000%20subject_unstem_search%5E7500%20subject_topic_facet%5E6250%20subject_t%5E5000%20creator_unstem_search%5E2500%20creator_t%5E1000%20subject_addl_unstem_search%5E2500%20subject_addl_t%5E500%20title_series_unstem_search%5E250%20title_series_t%5E100%20text%5E10&ps=3&q=food&qf=title_unstem_search%5E100000%20subtitle_unstem_search%5E50000%20title_t%5E25000%20subtitle_t%5E10000%20title_uniform_unstem_search%5E5000%20title_uniform_t%5E2500%20title_addl_unstem_search%5E5000%20title_addl_t%5E2500%20title_added_entry_unstem_search%5E1500%20title_added_entry_t%5E1250%20subject_topic_unstem_search%5E1000%20subject_unstem_search%5E750%20subject_topic_facet%5E625%20subject_t%5E500%20creator_unstem_search%5E250%20creator_t%5E100%20subject_addl_unstem_search%5E250%20subject_addl_t%5E50%20title_series_unstem_search%5E25%20title_series_t%5E10%20isbn_t%20text&rows=0&sort=score%20desc,%20pub_date_sort%20desc,%20title_sort%20asc&spellcheck=false&stats=true&stats.field=pub_date_sort&subject_pf=subject_topic_unstem_search%5E2000%20subject_unstem_search%5E1250%20subject_t%5E1000%20subject_topic_facet%5E500%20subject_addl_unstem_search%5E100%20subject_addl_t%5E10&subject_qf=subject_topic_unstem_search%5E200%20subject_unstem_search%5E125%20subject_topic_facet%5E100%20subject_t%5E50%20subject_addl_unstem_search%5E10%20subject_addl_t&tie=0.01&title_pf=title_unstem_search%5E500000%20subtitle_unstem_search%5E250000%20title_uniform_unstem_search%5E150000%20title_addl_unstem_search%5E100000%20title_t%5E50000%20subtitle_t%5E25000%20title_uniform_t%5E1500%20title_addl_t%5E1000%20title_added_entry_unstem_search%5E500%20title_added_entry_t%5E100%20title_series_t%5E50%20title_series_unstem_search%5E10&title_qf=title_unstem_search%5E50000%20subtitle_unstem_search%5E25000%20title_uniform_unstem_search%5E15000%20title_addl_unstem_search%5E10000%20title_t%5E5000%20subtitle_t%5E2500%20title_uniform_t%5E150%20title_addl_t%5E100%20title_added_entry_unstem_search%5E50%20title_added_entry_t%5E10%20title_series_unstem_search%5E5%20title_series_t&wt=json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Last-Modified:
+      - Fri, 20 Apr 2018 18:58:30 GMT
+      Etag:
+      - '"MzAwMDAwMDAwMDAwMDAwMFNvbHI="'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '3453'
+    body:
+      encoding: UTF-8
+      string: '{"responseHeader":{"status":0,"QTime":11,"params":{"f.subject_facet.facet.limit":"11","ps":"3","echoParams":"explicit","fl":"id
+        score availability_facet creator_display contributor_display electronic_resource_display
+        format imprint_display pub_date title_series_display title_statement_display
+        title_uniform_display isbn_display lccn_display","subject_qf":"subject_topic_unstem_search^200
+        subject_unstem_search^125 subject_topic_facet^100 subject_t^50 subject_addl_unstem_search^10
+        subject_addl_t","facets":"true","tie":"0.01","defType":"dismax","qf":"title_unstem_search^100000
+        subtitle_unstem_search^50000 title_t^25000 subtitle_t^10000 title_uniform_unstem_search^5000
+        title_uniform_t^2500 title_addl_unstem_search^5000 title_addl_t^2500 title_added_entry_unstem_search^1500
+        title_added_entry_t^1250 subject_topic_unstem_search^1000 subject_unstem_search^750
+        subject_topic_facet^625 subject_t^500 creator_unstem_search^250 creator_t^100
+        subject_addl_unstem_search^250 subject_addl_t^50 title_series_unstem_search^25
+        title_series_t^10 isbn_t text","stats":"true","title_qf":"title_unstem_search^50000
+        subtitle_unstem_search^25000 title_uniform_unstem_search^15000 title_addl_unstem_search^10000
+        title_t^5000 subtitle_t^2500 title_uniform_t^150 title_addl_t^100 title_added_entry_unstem_search^50
+        title_added_entry_t^10 title_series_unstem_search^5 title_series_t","author_pf":"creator_unstem_search^2000
+        creator_t^200","wt":"json","f.format.facet.limit":"11","stats.field":"pub_date_sort","mm":["2<-1","5<-2","6%3C90%25"],"facet.field":"format","f.subject_era_facet.facet.limit":"11","f.library_facet.facet.limit":"11","subject_pf":"subject_topic_unstem_search^2000
+        subject_unstem_search^1250 subject_t^1000 subject_topic_facet^500 subject_addl_unstem_search^100
+        subject_addl_t^10","sort":"score desc, pub_date_sort desc, title_sort asc","rows":"0","f.creator_facet.facet.limit":"11","q":"food","f.subject_topic_facet.facet.limit":"11","spellcheck":"false","pf":"title_unstem_search^1000000
+        subtitle_unstem_search^500000 title_t^250000 subtitle_t^100000 title_uniform_unstem_search^75000
+        title_uniform_t^50000 title_addl_unstem_search^50000 title_addl_t^25000 title_added_entry_unstem_search^15000
+        title_added_entry_t^12500 subject_topic_unstem_search^10000 subject_unstem_search^7500
+        subject_topic_facet^6250 subject_t^5000 creator_unstem_search^2500 creator_t^1000
+        subject_addl_unstem_search^2500 subject_addl_t^500 title_series_unstem_search^250
+        title_series_t^100 text^10","title_pf":"title_unstem_search^500000 subtitle_unstem_search^250000
+        title_uniform_unstem_search^150000 title_addl_unstem_search^100000 title_t^50000
+        subtitle_t^25000 title_uniform_t^1500 title_addl_t^1000 title_added_entry_unstem_search^500
+        title_added_entry_t^100 title_series_t^50 title_series_unstem_search^10","author_qf":"creator_unstem_search^200
+        creator_t^20","f.genre_facet.facet.limit":"11","facet":"true","f.subject_region_facet.facet.limit":"11","f.language_facet.facet.limit":"11"}},"response":{"numFound":126,"start":0,"maxScore":3.7970283,"docs":[]},"facet_counts":{"facet_queries":{},"facet_fields":{"format":["Book",119,"Conference
+        Proceeding",6,"Journal/Periodical",4,"Image",2,"Dissertation/Thesis",1]},"facet_ranges":{},"facet_intervals":{},"facet_heatmaps":{}},"stats":{"stats_fields":{"pub_date_sort":{"min":1948.0,"max":2016.0,"count":124,"missing":2,"sum":248375.0,"sumOfSquares":4.97518971E8,"mean":2003.024193548387,"stddev":12.042245225706692}}}}
+
+'
+    http_version: 
+  recorded_at: Fri, 20 Apr 2018 19:26:34 GMT
+recorded_with: VCR 3.0.3

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -213,4 +213,7 @@ RSpec.describe SearchBuilder , type: :model do
         ["bazz", ["q_3", "World"]]])
     end
   end
+
+  describe BentoSearchBuilderBehavior do
+  end
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -215,5 +215,54 @@ RSpec.describe SearchBuilder , type: :model do
   end
 
   describe BentoSearchBuilderBehavior do
+    let(:solr_parameters) {
+      sp = Blacklight::Solr::Request.new
+      sp["facet.field"] = [ "foo", "bar", "bizz", "buzz" ]
+      sp["facets"] = true
+      sp["rows"] = 10
+      sp["stats"] = true
+      sp
+    }
+
+    describe "#remove_facets" do
+      before(:example) do
+        subject.remove_facets(solr_parameters)
+      end
+
+      it "sets facets param to false" do
+        expect(solr_parameters["facets"]).to be(false)
+      end
+
+      it "removes the facet.field params" do
+        expect(solr_parameters["facet.field"]).to be_nil
+      end
+
+      it "sets stats to false" do
+        expect(solr_parameters["stats"]).to be(false)
+      end
+
+      it "does not touch rows" do
+        expect(solr_parameters["rows"]).to eq(10)
+      end
+    end
+
+    describe "#format_facet_only" do
+      before(:example) do
+        subject.format_facet_only(solr_parameters)
+      end
+
+      it "sets the facet.field param to format" do
+        expect(solr_parameters["facet.field"]).to eq("format")
+      end
+
+      it "sets the rows param to 0" do
+        expect(solr_parameters["rows"]).to eq(0)
+      end
+
+      it "sets the facets param to true" do
+        expect(solr_parameters["facets"]).to be(true)
+      end
+    end
+
   end
 end

--- a/spec/search_engines/bento_search_spec.rb
+++ b/spec/search_engines/bento_search_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe BentoSearch, type: :search_engine do
     it "uses TulStandardDecorator" do
       expect(item.decorator).to eq("TulDecorator")
     end
+  end
 
+  describe "#proc_remove_facets" do
+    let(:builder) { SearchBuilder.new(CatalogController.new) }
+
+    it "does not affect builder.proccessor_chain automatically" do
+      expect(builder.processor_chain).to_not include(:format_facet_only)
+    end
+
+    it "Overrides the builder processor_chain" do
+      _builder = blacklight_se.proc_remove_facets[builder]
+      expect(_builder.processor_chain.last).to eq(:remove_facets)
+    end
   end
 end

--- a/spec/search_engines/more_search_spec.rb
+++ b/spec/search_engines/more_search_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BentoSearch, type: :search_engine do
+  more_se = BentoSearch.get_engine("more")
+
+  more_search_results = VCR.use_cassette("bento_search_more") do
+    more_se.search("food")
+  end
+
+  let(:expected_fields) { RSpec.configuration.bento_expected_fields }
+
+  describe "Bento  More Search Engine" do
+    let (:item) { more_search_results[0] }
+
+    it "overrides the item display configuration" do
+      expect(item.display_configuration.item_partial).to eq("bento_search/more")
+    end
+
+    it "sets custom_data to a Blackligh::Solr::Response" do
+      expect(item.custom_data).to be_a(Blacklight::Solr::Response)
+    end
+
+    it "filters out the Books and Journal/Periodical facets from results" do
+      format_facets = item.custom_data.facet_counts["facet_fields"]["format"]
+      expect(format_facets).not_to include("Book")
+      expect(format_facets).not_to include("Journal/Periodical")
+    end
+
+  end
+
+end


### PR DESCRIPTION
REF BL-378

Adds a bento box that grabs the format facet from the catalog
search and filters out "Book" and "Journal/Periodical" facets if
included:

![image](https://user-images.githubusercontent.com/444215/39079086-fe9ad2a6-44e1-11e8-85e8-cbb96554351b.png)

Some other enhancements include.
* Does not search for facets in non facet bento searches
* Only searches for the facet.field = format for the more bento search.