### PR TITLE
Remove redundant search bar.

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,72 +1,18 @@
-<div class="megasearch">
-
-  <div class="row">
-    <div class="span12">
-      <div class="hero-unit">
-        <h1> Search Results </h1>
-
-        <p></p>
-
-        <%= form_tag({}, :method=> "get", :class => "well form-search") do %>
-
-            Search: <%= search_field_tag 'q', params[:q], :class => "search-query" %>
-
-            <%= select_tag "field",
-                           options_for_select({"in any field" => nil, "as Title" => "title", "as Author" => "author", "as Subject" => "subject"}, params[:field]) %>
-
-            <%= button_tag 'search', :type=> 'submit', :class => 'btn btn-primary'  %>
-
-        <% end %>
-
-      </div>
-    </div>
-  </div>
-
-  <div class="bento_box row">
-
-
-    <% if params[:q] && @ajax_bg_engines %>
-        <% @ajax_bg_engines.each do |engine| %>
-            <div class="span4">
-              <div class="bento_compartment <%= engine %>">
-                <h2><%= engine %></h2>
-                <%= bento_search engine, :query => params[:q], :load => :ajax_auto %>
-              </div>
-            </div>
-        <% end %>
-    <% end %>
-
 
     <% if @results %>
+      <div class="row">
 
         <% @results.each_pair do |key, result| %>
-            <div class="span4">
 
-              <div class="bento_compartment <%= key %>">
+              <div class="col-xl-2 col-md-3 col-sm-6  bento_compartment <%= key %>">
                 <h2><%= key.titleize %> </h2>
                 <%= render :layout => "layouts/bento_box_wrapper", :locals => {:results => result } do %>
                     <%= bento_search result %>
                 <% end %>
               </div>
-            </div>
 
         <% end %>
-
+      </div>
+    <% else %>
+      <%= render("home_text") %>
     <% end %>
-
-
-
-    <% if params[:q] && @ajax_triggered_engines %>
-        <% @ajax_triggered_engines.each do |engine| %>
-            <div class="span4">
-              <div class="bento_compartment <%= engine %>">
-                <h2><%= engine %></h2>
-                <%= link_to "Load Results", single_search_path(engine, :q => params[:q], :field => params[:field]), :class => "ajax_load_trigger" %>
-                <%= bento_search engine, :query => params[:q], :load => :ajax_triggered %>
-              </div>
-            </div>
-        <% end %>
-    <% end %>
-
-  </div>
-</div>

--- a/spec/features/bento_search_spec.rb
+++ b/spec/features/bento_search_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Bento Searches" do
     let (:item) { fixtures.fetch("book_search") }
     scenario "Search Title" do
       visit "/bento"
-      within("div.hero-unit") do
+      within("div.input-group") do
         fill_in "q", with: item["title"]
         click_button
       end
@@ -25,7 +25,7 @@ RSpec.feature "Bento Searches" do
     let (:item) { fixtures.fetch("book_search") }
     scenario "Blacklight results display link to full results " do
       visit "/bento"
-      within("div.hero-unit") do
+      within("div.input-group") do
         fill_in "q", with: item["title"]
         click_button
       end


### PR DESCRIPTION
REF BL-400

This PR removes the redundant bento search bar once #344 (BL-378) gets
merged. It also removes the advanced_search link from that page because
it causes issues with search.