### PR TITLE
Update articles bento box.

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -11,7 +11,7 @@ class SearchController < CatalogController
   @@per_page = 10
   def index
     if params[:q]
-      engines = %i( books journals primo  more )
+      engines = %i( books articles journals more )
       searcher = BentoSearch::ConcurrentSearcher.new(*engines)
       searcher.search(params[:q], per_page: @@per_page, semantic_search_field: params[:field])
       @results = searcher.results

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -174,6 +174,8 @@ module ApplicationHelper
       link_to "See all #{number_with_delimiter(results.total_items)} results.", search_catalog_path(q: params[:q], f: { format: ["Book"] }), class: "full-results"
     when "more"
       ""
+    when "articles"
+      link_to "See all #{number_with_delimiter(results.total_items)} articles", url_for(action: :index, controller: :primo_central, q: params[:q])
     else
       content_tag(:p, "Total records from #{bento_engine_nice_name(results.engine_id)}: #{results.count}" || "?", class: "record-count")
     end

--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -11,11 +11,11 @@ module BentoSearch
       query = args.fetch(:query, "")
 
       results = BentoSearch::Results.new
-      solr_result = search_results(q: query, &proc_remove_facets).first.response
+      response = search_results(q: query, &proc_remove_facets).first.response
 
-      results.total_items = solr_result["numFound"]
+      results.total_items = response["numFound"]
 
-      solr_result["docs"].each do |item|
+      response["docs"].each do |item|
         results << conform_to_bento_result(item)
       end
 
@@ -26,6 +26,17 @@ module BentoSearch
       Proc.new { |builder|
         builder.append(:remove_facets)
       }
+    end
+
+    def results(response)
+      results = BentoSearch::Results.new
+
+      results.total_items = response["numFound"]
+      response["docs"].each do |doc|
+        results << conform_to_bento_result(doc)
+      end
+
+      results
     end
 
     def conform_to_bento_result(item)

--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -12,14 +12,7 @@ module BentoSearch
 
       results = BentoSearch::Results.new
       response = search_results(q: query, &proc_remove_facets).first.response
-
-      results.total_items = response["numFound"]
-
-      response["docs"].each do |item|
-        results << conform_to_bento_result(item)
-      end
-
-      results
+      results(response)
     end
 
     def proc_remove_facets

--- a/app/search_engines/bento_search/books_engine.rb
+++ b/app/search_engines/bento_search/books_engine.rb
@@ -6,16 +6,8 @@ module BentoSearch
       query = args.fetch(:query, "")
       query = { q: query, f: { format: ["Book"] } }
 
-      results = BentoSearch::Results.new
-
-      solr_result = search_results(query, &proc_remove_facets).first.response
-      results.total_items = solr_result["numFound"]
-
-      solr_result["docs"].each do |item|
-        results << conform_to_bento_result(item)
-      end
-
-      results
+      response = search_results(query, &proc_remove_facets).first.response
+      results(response)
     end
   end
 end

--- a/app/search_engines/bento_search/journals_engine.rb
+++ b/app/search_engines/bento_search/journals_engine.rb
@@ -6,16 +6,8 @@ module BentoSearch
       query = args.fetch(:query, "")
       query = { q: query, f: { format: ["Journal/Periodical"] } }
 
-      results = BentoSearch::Results.new
-
-      solr_result = search_results(query, &proc_remove_facets).first.response
-      results.total_items = solr_result["numFound"]
-
-      solr_result["docs"].each do |item|
-        results << conform_to_bento_result(item)
-      end
-
-      results
+      response = search_results(query, &proc_remove_facets).first.response
+      results(response)
     end
   end
 end

--- a/app/search_engines/bento_search/primo_engine.rb
+++ b/app/search_engines/bento_search/primo_engine.rb
@@ -1,63 +1,28 @@
 # frozen_string_literal: true
 
-require "open-uri"
+module BentoSearch
+  class PrimoEngine < BlacklightEngine
+    delegate :blacklight_config, to: PrimoCentralController
 
-class BentoSearch::PrimoEngine
-  include BentoSearch::SearchEngine
+    def search_implementation(args)
+      query = args.fetch(:query, "")
 
-  @@per_page = 10
+      # Avoid making a costly call for no reason.
+      if query.empty?
+        response = { "docs" => [] }
+      else
+        response = search_results(q: query).first["response"]
+      end
 
-  attr_accessor :query
-
-  def search_implementation(args)
-    @query = args.fetch(:query, "")
-    results = BentoSearch::Results.new
-
-    if @query.empty?
-      primo_results = { "docs" => [] }
-    else
-      primo_results = search_primo
+      results(response)
     end
 
-    primo_results["docs"].each do |doc|
-      results << conform_to_bento_result(doc)
+    def conform_to_bento_result(item)
+      BentoSearch::ResultItem.new(
+        title: item["title"],
+        authors: item.fetch("creator", []).map { |author| BentoSearch::Author.new(display: author) },
+        publisher: item.fetch("isPartOf", "Non found"),
+        link: Rails.application.routes.url_helpers.primo_central_document_url(item["pnxId"], only_path: true))
     end
-    results
-  end
-
-  def search_primo
-    JSON.parse(open(api_url).read)
-  end
-
-  def api_url
-    params = {
-      q: "any,contains,#{@query}",
-      apikey: configuration.apikey,
-      limit: @@per_page,
-      scope: configuration.scope,
-      vid: configuration.vid
-    }
-    URI::HTTPS.build(host: configuration.api_base_url, path: "/primo/v1/pnxs", query: params.to_query).to_s
-  end
-
-  def conform_to_bento_result(item)
-    BentoSearch::ResultItem.new(title: item.fetch("title", ""),
-      authors: authors(item),
-      publisher: item.fetch("isPartOf", "None found"),
-      link: build_primo_url(item))
-  end
-
-
-  def authors(item)
-    item.values_at("creator", "contributor")
-      .flatten
-      .compact
-      .uniq
-      .map { |creator| BentoSearch::Author.new(display: creator) }
-  end
-
-
-  def build_primo_url(primo_doc)
-    "#{configuration.web_ui_base_url}#{primo_doc['pnxId']}&context=L&vid=#{configuration.vid}&search_scope=default_scope&tab=default_tab&lang=en_US"
   end
 end

--- a/config/initializers/bento_search.rb
+++ b/config/initializers/bento_search.rb
@@ -30,13 +30,8 @@ BentoSearch.register_engine("more") do |conf|
   end
 end
 
-BentoSearch.register_engine("primo") do |conf|
+BentoSearch.register_engine("articles") do |conf|
   conf.engine = "BentoSearch::PrimoEngine"
-  conf.api_base_url = Rails.configuration.bento[:primo][:api_base_url]
-  conf.apikey = Rails.configuration.bento[:primo][:apikey]
-  conf.scope = Rails.configuration.bento[:primo][:scope]
-  conf.vid = Rails.configuration.bento[:primo][:vid]
-  conf.web_ui_base_url = Rails.configuration.bento[:primo][:web_ui_base_url]
   conf.for_display do |display|
     display.decorator = "TulDecorator"
   end

--- a/config/locales/bento.en.yml
+++ b/config/locales/bento.en.yml
@@ -2,8 +2,8 @@ en:
   bento:
     blacklight:
       nice_name: 'Blacklight'
-    primo:
-      nice_name: "Primo"
+    articles:
+      nice_name: "Articles"
     journals:
       nice_name: "Journals"
     books:

--- a/spec/search_engines/primo_search_spec.rb
+++ b/spec/search_engines/primo_search_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe BentoSearch, type: :search_engine do
-  primo_se = BentoSearch.get_engine("primo")
+  primo_se = BentoSearch.get_engine("articles")
 
   primo_search_results = VCR.use_cassette("bento_search_primo") do
     primo_se.search("james")


### PR DESCRIPTION
REF BL-402

Refactor the primo search engine so that it uses PrimoCentralController

Additionally,
* Relabels the "Primo" box "Articles"
* Adds link to search results in Blacklight articles view
* Refactors out some common code to `results` method