### PR TITLE
BL-374 Add sort order for holdings

### DIFF
--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -56,7 +56,7 @@ module AlmaDataHelper
     item["item_data"]["process_type"].has_value?("MISSING") || item["item_data"]["process_type"].has_value?("LOST")
   end
 
-  def library_name(items)
+  def group_and_order_items(items)
     showable_items = items.select { |item| item unless missing_or_lost?(item) }
     grouped_items = showable_items.group_by do |lib|
       (lib["holding_data"]["temp_library"]["value"] if lib["holding_data"]["in_temp_location"] == true) || (lib["item_data"]["library"]["value"])

--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -57,19 +57,53 @@ module AlmaDataHelper
   end
 
   def library_name(items)
-    items.select { |item| item unless missing_or_lost?(item) }
-      .group_by do |lib|
-        (lib["holding_data"]["temp_library"]["value"] if lib["holding_data"]["in_temp_location"] == true) || (lib["item_data"]["library"]["value"])
-      end
+    showable_items = items.select { |item| item unless missing_or_lost?(item) }
+    grouped_items = showable_items.group_by do |lib|
+      (lib["holding_data"]["temp_library"]["value"] if lib["holding_data"]["in_temp_location"] == true) || (lib["item_data"]["library"]["value"])
+    end
+    sort_order_for_holdings(grouped_items)
   end
 
   def library_name_from_short_code(short_code)
     Rails.configuration.libraries[short_code]
   end
 
+  def location_name_from_short_code(item)
+    if item["holding_data"]["in_temp_location"] == true
+      temp_library = item["holding_data"]["temp_library"]["value"]
+      temp_location = item["holding_data"]["temp_location"]["value"]
+      Rails.configuration.locations[temp_library][temp_location]
+    else
+      library = item["item_data"]["library"]["value"]
+      location = item["item_data"]["location"]["value"]
+      Rails.configuration.locations[library][location]
+    end
+  end
+
   def alternative_call_number(item)
     if item["item_data"]["alternative_call_number"].present?
       "(Also found under #{item["item_data"]["alternative_call_number"]})"
     end
+  end
+
+  def call_number_for_sort(item)
+    if item["item_data"]["alternative_call_number"].present?
+      item["item_data"]["alternative_call_number"]
+    else
+      item["holding_data"]["call_number"]
+    end
+  end
+
+  def sort_order_for_holdings(items)
+    sorted_library_hash = {}
+    sorted_library_hash.merge!("MAIN" => items.delete("MAIN")) if items.has_key?("MAIN")
+    items_hash = items.sort_by { |k, v| library_name_from_short_code(k) }.to_h
+    sorted_library_hash = sorted_library_hash.merge!(items_hash)
+    sorted_library_hash.each do |lib, items|
+      unless items.empty?
+        items.sort_by! { |item| [location_name_from_short_code(item), call_number_for_sort(item), item["item_data"]["description"]] }
+      end
+    end
+    sorted_library_hash
   end
 end

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -1,6 +1,6 @@
 <table class="table table-responsive borderless">
   <% unless @items["item"].nil? %>
-    <% library_name(@items["item"]).each do |key,items| %>
+    <% group_and_order_items(@items["item"]).each do |key,items| %>
       <thead>
         <tr>
           <th scope="col">

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
     end
   end
 
-  describe "#library_name(item)" do
+  describe "#group_and_order_items(item)" do
     context "does not display items that are lost" do
       let(:item) do
         [{ "holding_data" =>
@@ -183,7 +183,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
       end
 
       it "does not display lost item" do
-        expect(library_name(item)).to eq({})
+        expect(group_and_order_items(item)).to eq({})
       end
     end
 
@@ -200,7 +200,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
       end
 
       it "does not display missing item" do
-        expect(library_name(item)).to eq({})
+        expect(group_and_order_items(item)).to eq({})
       end
     end
 
@@ -219,7 +219,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
       end
 
       it "displays library code" do
-        expect(library_name(item)).to eq "MAIN" => [{ "holding_data" => { "in_temp_location" => false }, "item_data" => { "library" => { "value" => "MAIN" }, "location" => { "value" => "" }, "process_type" => { "value" => "" }
+        expect(group_and_order_items(item)).to eq "MAIN" => [{ "holding_data" => { "in_temp_location" => false }, "item_data" => { "library" => { "value" => "MAIN" }, "location" => { "value" => "" }, "process_type" => { "value" => "" }
  } }]
       end
     end
@@ -239,7 +239,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
       end
 
       it "displays temporary library code" do
-        expect(library_name(item).keys).to have_text "RES_SHARE"
+        expect(group_and_order_items(item).keys).to have_text "RES_SHARE"
       end
     end
   end

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -212,13 +212,14 @@ RSpec.describe AlmaDataHelper, type: :helper do
            },
            "item_data" => {
              "library" => { "value" => "MAIN" },
+             "location" => { "value" => "" },
              "process_type" => { "value" => "" }
            }
          }]
       end
 
       it "displays library code" do
-        expect(library_name(item)).to eq "MAIN" => [{ "holding_data" => { "in_temp_location" => false }, "item_data" => { "library" => { "value" => "MAIN" },              "process_type" => { "value" => "" }
+        expect(library_name(item)).to eq "MAIN" => [{ "holding_data" => { "in_temp_location" => false }, "item_data" => { "library" => { "value" => "MAIN" }, "location" => { "value" => "" }, "process_type" => { "value" => "" }
  } }]
       end
     end
@@ -227,7 +228,8 @@ RSpec.describe AlmaDataHelper, type: :helper do
       let(:item) do
         [{ "holding_data" =>
            { "in_temp_location" => true,
-             "temp_library" => { "value" => "RES-SHARE" },
+             "temp_library" => { "value" => "RES_SHARE" },
+             "temp_location" => { "value" => "IN_RS_REQ" }
            },
            "item_data" => {
              "library" => { "value" => "MAIN" },
@@ -237,8 +239,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
       end
 
       it "displays temporary library code" do
-        expect(library_name(item)).to eq "RES-SHARE" => [{ "holding_data" => { "in_temp_location" => true, "temp_library" => { "value" => "RES-SHARE" } }, "item_data" => { "library" => { "value" => "MAIN" },              "process_type" => { "value" => "" }
- } }]
+        expect(library_name(item).keys).to have_text "RES_SHARE"
       end
     end
   end
@@ -262,6 +263,159 @@ RSpec.describe AlmaDataHelper, type: :helper do
 
       it "displays alternate call number" do
         expect(alternative_call_number(item)).to eq "(Also found under alternate)"
+      end
+    end
+  end
+
+  describe "#sort_order_for_holdings(items)" do
+    context "items are sorted by library name with Paley first" do
+      let(:items) do
+        {
+          "MAIN" => {},
+          "AMBLER" => {}
+        }
+      end
+
+      it "returns Paley first, then Ambler and Kardon" do
+        expect(sort_order_for_holdings(items).keys).to eq(["MAIN", "AMBLER"])
+      end
+    end
+
+    context "items in Kardon sort by Remote Storage, not KARDON" do
+      let(:items) do
+        {
+          "KARDON" => {},
+          "MEDIA" => {}
+        }
+      end
+
+      it "returns Media before Kardon" do
+        expect(sort_order_for_holdings(items).keys).to eq(["MEDIA", "KARDON"])
+      end
+    end
+
+    context "Items are ordered by location after library name" do
+      let(:items) do
+        { "MAIN" => [{
+          "holding_data" =>
+             { "in_temp_location" => false
+          },
+          "item_data" => {
+            "library" => { "value" => "MAIN" },
+            "location" => { "value" => "stacks" }
+          }
+        }, {
+          "holding_data" =>
+             { "in_temp_location" => false
+          },
+          "item_data" => {
+            "library" => { "value" => "MAIN" },
+            "location" => { "value" => "serials" }
+          }
+        }, {
+          "holding_data" =>
+             { "in_temp_location" => false
+          },
+          "item_data" => {
+            "library" => { "value" => "MAIN" },
+            "location" => { "value" => "reference" }
+            }
+          }]
+        }
+      end
+
+      it "returns copies for each library by location" do
+        sorted_locations = sort_order_for_holdings(items)["MAIN"].map do |item|
+          item["item_data"]["location"]["value"]
+        end
+        expect(sorted_locations).to eq(["serials", "reference", "stacks"])
+      end
+    end
+
+    context "Items are ordered by call number after location" do
+      let(:items) do
+        { "MAIN" => [{
+          "holding_data" =>
+             { "in_temp_location" => false,
+               "call_number" => "MT655.P45x"
+          },
+          "item_data" => {
+            "library" => { "value" => "MAIN" },
+            "location" => { "value" => "stacks" }
+          }
+        }, {
+          "holding_data" =>
+             { "in_temp_location" => false,
+               "call_number" => "AC1 .G72"
+
+          },
+          "item_data" => {
+            "library" => { "value" => "MAIN" },
+            "location" => { "value" => "stacks" }
+          }
+        }, {
+          "holding_data" =>
+             { "in_temp_location" => false,
+               "call_number" => "HF5006 .I614"
+          },
+          "item_data" => {
+            "library" => { "value" => "MAIN" },
+            "location" => { "value" => "stacks" }
+            }
+          }]
+        }
+      end
+
+      it "returns copies for each library by call number" do
+        sorted_call_numbers = sort_order_for_holdings(items)["MAIN"].map do |item|
+          item["holding_data"]["call_number"]
+        end
+        expect(sorted_call_numbers).to eq(["AC1 .G72", "HF5006 .I614", "MT655.P45x"])
+      end
+    end
+
+    context "Items are ordered by description after call number" do
+      let(:items) do
+        { "MAIN" => [{
+          "holding_data" =>
+             { "in_temp_location" => false,
+               "call_number" => "MT655.P45x"
+          },
+          "item_data" => {
+            "library" => { "value" => "MAIN" },
+            "location" => { "value" => "stacks" },
+            "description" => "v.55, no.5 (Nov. 2017)"
+          }
+        }, {
+          "holding_data" =>
+             { "in_temp_location" => false,
+               "call_number" => "MT655.P45x"
+
+          },
+          "item_data" => {
+            "library" => { "value" => "MAIN" },
+            "location" => { "value" => "stacks" },
+            "description" => "v.42 (2004)"
+          }
+        }, {
+          "holding_data" =>
+             { "in_temp_location" => false,
+               "call_number" => "MT655.P45x"
+          },
+          "item_data" => {
+            "library" => { "value" => "MAIN" },
+            "location" => { "value" => "stacks" },
+            "description" => "v.53 (2016)"
+            }
+          }]
+        }
+      end
+
+      it "returns copies for each library by description" do
+        sorted_descriptions = sort_order_for_holdings(items)["MAIN"].map do |item|
+          item["item_data"]["description"]
+        end
+        expect(sorted_descriptions).to eq(["v.42 (2004)", "v.53 (2016)", "v.55, no.5 (Nov. 2017)"])
       end
     end
   end


### PR DESCRIPTION
BL-374 Physical items should be sorted first by library name, then location, call number, and description
