### PR TITLE
Add back :previous_and_next_document to pc.

### DIFF
--- a/app/models/blacklight/primo_central/search_builder.rb
+++ b/app/models/blacklight/primo_central/search_builder.rb
@@ -9,6 +9,7 @@ module Blacklight::PrimoCentral
       :add_query_to_primo_central,
       :set_query_field,
       :set_query_sort_order,
+      :previous_and_next_document,
       :add_query_facets,
     ]
   end


### PR DESCRIPTION
BL-REF 386

When I did the merge conflict resolution for the bento concurrency lock
fix, I managed to not add the query processor that fixes the next-previous
button fix.  This commit adds that back.