### PR TITLE
Add direct link to availability if available.

### DIFF
--- a/app/helpers/primo_central_helper.rb
+++ b/app/helpers/primo_central_helper.rb
@@ -32,4 +32,23 @@ module PrimoCentralHelper
     presenter[:document][:format] = codes
     separate_formats(presenter)
   end
+
+  # Returns a list of partials to render in the availability section
+  def availability_link_partials
+    partials = []
+    if @document.has_direct_link?
+      partials.push("direct_link")
+    else
+      partials.push("online")
+    end
+    partials
+  end
+
+  def document_link
+    @document["link"]
+  end
+
+  def document_link_label
+    @document["link_label"]
+  end
 end

--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -28,8 +28,7 @@ module Blacklight::PrimoCentral::Document
   end
 
   def has_direct_link?
-    availability = @_source.fetch("delivery", {})
-      .fetch("availability", [])
+    availability = @_source.dig("delivery", "availability") || []
     availability == ["fulltext_linktorsrc"]
   end
 
@@ -52,10 +51,7 @@ module Blacklight::PrimoCentral::Document
     end
 
     def get_it(doc)
-      doc.to_h.fetch("delivery", {})
-        .fetch("GetIt1", [{}])
-        .first.fetch("links", [{}])
-        .first
+      doc.to_h.dig("delivery", "GetIt1", 0, "links", 0) || {}
     end
 
 

--- a/app/views/primo_central/_direct_link.html.erb
+++ b/app/views/primo_central/_direct_link.html.erb
@@ -1,0 +1,1 @@
+<%= link_to document_link_label, document_link  %>

--- a/app/views/primo_central/_online.html.erb
+++ b/app/views/primo_central/_online.html.erb
@@ -1,0 +1,1 @@
+<iframe class="bl_alma_iframe" src="<%= document_link + "&is_new_ui=true" %>"></iframe>

--- a/app/views/primo_central/_show_availability_section.html.erb
+++ b/app/views/primo_central/_show_availability_section.html.erb
@@ -5,12 +5,12 @@
     <h4 id="availability-heading">Availability</h4>
   </div>
 
-  <% if document["link"] %>
-    <div class="online-border"></div>
-    <div class="availability_iframe physical-holding-panel panel-body">
-      <h5>Online</h5>
-      <iframe class="bl_alma_iframe" src="<%= document["link"] %>"></iframe>
-    </div>
-  <% end %>
+  <div class="online-border"></div>
+  <div class="availability_iframe physical-holding-panel panel-body">
+    <h5>Online</h5>
+    <% availability_link_partials.each do |partial| %>
+      <%= render(partial) %>
+    <% end %>
+  </div>
 </div>
 </div>

--- a/spec/helpers/primo_central_helper_spec.rb
+++ b/spec/helpers/primo_central_helper_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PrimoCentralHelper, type: :helper do
+  let(:doc) { Hash.new }
+  let(:document) { PrimoCentralDocument.new(doc) }
+  before(:example) do
+    @document = document
+  end
+
+  describe "#availability_link_partials" do
+    context "document does not have a direct link" do
+      it "returns only the online partial" do
+        expect(availability_link_partials).to eq(["online"])
+      end
+    end
+
+    context "document does have a direct link" do
+      let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
+        delivery: { availability: ["fulltext_linktorsrc"] }
+      )}
+
+      it "returns only the direc_link partial" do
+        expect(availability_link_partials).to eq(["direct_link"])
+      end
+    end
+  end
+
+  describe "#document_link_label" do
+    context "no link label found" do
+      it "returns a default value when no direct link label is found" do
+        expect(document_link_label).to eq("Direct Link")
+      end
+    end
+
+    context "link label available" do
+      let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
+        delivery: {
+          GetIt1: [{
+            "links" => [{ "displayText" => "$$EView_full_text_via_AgEcon" }],
+          }] }) }
+      it "correctly normalized label if found" do
+        expect(document_link_label).to eq("View full text via AgEcon")
+      end
+    end
+  end
+end

--- a/spec/models/primo_central_document_spec.rb
+++ b/spec/models/primo_central_document_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PrimoCentralDocument, type: :model do
+  let (:subject) { PrimoCentralDocument.new(doc, nil) }
+
+  describe "#has_direct_link?" do
+    context "document is completely empty" do
+      let(:doc) { Hash.new }
+
+      it "verifies there is no direct_link" do
+        expect(subject.has_direct_link?).to be(false)
+      end
+    end
+
+    context "document has a direct_link" do
+      let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
+        delivery: { availability: ["fulltext_linktorsrc"] }
+      )}
+
+      it "verifies that document has a direct_link" do
+        expect(subject.has_direct_link?).to be(true)
+      end
+    end
+
+    context "document does not have a direct link" do
+      let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
+        delivery: { availability: ["foobar"] }
+      )}
+
+      it "should verifies there is no direct_link" do
+        expect(subject.has_direct_link?).to be(false)
+      end
+    end
+  end
+
+end

--- a/spec/views/primo_central/_online.html.erb._spec.rb
+++ b/spec/views/primo_central/_online.html.erb._spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "primo_central/_online.html.erb", type: :view do
+  it "Creates the expected tStaff View link" do
+    view.instance_variable_set("@document", "link" => "")
+    expect(view.render("online")).to match(/is_new_ui=true/)
+  end
+end

--- a/spec/views/primo_central/_online.html.erb._spec.rb
+++ b/spec/views/primo_central/_online.html.erb._spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "primo_central/_online.html.erb", type: :view do
-  it "Creates the expected tStaff View link" do
+  it "adds the expected parameter to the iframe link" do
     view.instance_variable_set("@document", "link" => "")
     expect(view.render("online")).to match(/is_new_ui=true/)
   end


### PR DESCRIPTION
REF BL-395
REF BL-396

Refactors availability rendering for primo_central and allows for
a switch between either the iframe view or a direct link to the
resource.