### PR TITLE
Filter out query values equal to [""].

### DIFF
--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -42,7 +42,8 @@ module Blacklight::PrimoCentral::Document
     def url_query
       query = URI.parse(@url).query
       if (query)
-        CGI.parse(query)
+        q = CGI.parse(query) || {}
+        q.select { |k, v| v && !v.empty? && v != [""] }
       else
         {}
       end

--- a/spec/models/primo_central_document_spec.rb
+++ b/spec/models/primo_central_document_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PrimoCentralDocument, type: :model do
     let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
       delivery: {
         GetIt1: [{
-          "links" => [{ "link" => "http://foobar.com?rft.isbn=''" }],
+          "links" => [{ "link" => "http://foobar.com?rft.isbn=" }],
         }] }) }
     it "sets @doc['isbn'] to nil" do
       expect(subject["isbn"]).to be_nil

--- a/spec/models/primo_central_document_spec.rb
+++ b/spec/models/primo_central_document_spec.rb
@@ -5,11 +5,11 @@ require "rails_helper"
 RSpec.describe PrimoCentralDocument, type: :model do
   let (:subject) { PrimoCentralDocument.new(doc, nil) }
 
-  context "document direct_link contains rtf.isbn = ''" do
+  context "document direct_link contains rft.isbn = ''" do
     let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
       delivery: {
         GetIt1: [{
-          "links" => [{ "link" => "http://foobar.com?rtf.isbn=''" }],
+          "links" => [{ "link" => "http://foobar.com?rft.isbn=''" }],
         }] }) }
     it "sets @doc['isbn'] to nil" do
       expect(subject["isbn"]).to be_nil
@@ -20,7 +20,7 @@ RSpec.describe PrimoCentralDocument, type: :model do
     let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
       delivery: {
         GetIt1: [{
-          "links" => [{ "link" => "http://foobar.com?rtf.isbn=a" }],
+          "links" => [{ "link" => "http://foobar.com?rft.isbn=a" }],
         }] }) }
     it "sets @doc['isbn'] to [a]" do
       expect(subject["isbn"]).to eq(["a"])

--- a/spec/models/primo_central_document_spec.rb
+++ b/spec/models/primo_central_document_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PrimoCentralDocument, type: :model do
+  let (:subject) { PrimoCentralDocument.new(doc, nil) }
+
+  context "document direct_link contains rtf.isbn = ''" do
+    let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
+      delivery: {
+        GetIt1: [{
+          "links" => [{ "link" => "http://foobar.com?rtf.isbn=''" }],
+        }] }) }
+    it "sets @doc['isbn'] to nil" do
+      expect(subject["isbn"]).to be_nil
+    end
+  end
+
+  context "document direc_link contains a regular value" do
+    let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
+      delivery: {
+        GetIt1: [{
+          "links" => [{ "link" => "http://foobar.com?rtf.isbn=a" }],
+        }] }) }
+    it "sets @doc['isbn'] to [a]" do
+      expect(subject["isbn"]).to eq(["a"])
+    end
+  end
+end


### PR DESCRIPTION
REF BL-407

Sometimes we grab values from the query strings of the document link.
Some query values end up being [""].  These need to be filtered out or
they end up making field values appear with blank values.