### PR TITLE
Add online button to index result.

### DIFF
--- a/app/helpers/primo_central_helper.rb
+++ b/app/helpers/primo_central_helper.rb
@@ -57,6 +57,8 @@ module PrimoCentralHelper
   end
 
   def document_id
-    @document["pnxId"]
+    # This just needs to be unique.
+    # Hashing because () characters mess with javacript.
+    @document["pnxId"].hash
   end
 end

--- a/app/helpers/primo_central_helper.rb
+++ b/app/helpers/primo_central_helper.rb
@@ -44,11 +44,19 @@ module PrimoCentralHelper
     partials
   end
 
+  def index_buttons_partials
+    availability_link_partials.map { |p| "#{p}_button" }
+  end
+
   def document_link
     @document["link"]
   end
 
   def document_link_label
     @document["link_label"]
+  end
+
+  def document_id
+    @document["pnxId"]
   end
 end

--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -50,8 +50,9 @@ module Blacklight::PrimoCentral::Document
         .gsub("_", " ")
     end
 
-    def get_it(doc)
-      doc.to_h.dig("delivery", "GetIt1", 0, "links", 0) || {}
+    def get_it(doc = nil)
+      doc = (doc || @_source || {})
+      doc.dig("delivery", "GetIt1", 0, "links", 0) || {}
     end
 
 

--- a/app/views/primo_central/_direct_link_button.html.erb
+++ b/app/views/primo_central/_direct_link_button.html.erb
@@ -1,0 +1,2 @@
+
+<%= link_to "Online", single_link_builder(document_link), class:"collapse-button btn btn-sm btn-info", title:"This link opens the resource in a new tab.", target:"_blank" %>

--- a/app/views/primo_central/_index_availability_section.html.erb
+++ b/app/views/primo_central/_index_availability_section.html.erb
@@ -1,0 +1,6 @@
+<% @document = document %>
+
+<% index_buttons_partials.each do |partial| %>
+  <%= render(partial) %>
+<% end %>
+

--- a/app/views/primo_central/_online_button.html.erb
+++ b/app/views/primo_central/_online_button.html.erb
@@ -1,0 +1,8 @@
+<button class="btn-block btn btn-sm btn-info collapsed collapse-button" data-toggle="collapse" data-target="#<%=  document_id %>" >
+  <span class="avail-label" aria-expanded="false">Online</span>
+</button>
+<div id="<%= document_id %>" class="collapse online_resources">
+  <ul>
+    <%= render("online") %>
+  </ul>
+</div>

--- a/app/views/primo_central/_online_button.html.erb
+++ b/app/views/primo_central/_online_button.html.erb
@@ -1,6 +1,6 @@
 <button class="btn-block btn btn-sm btn-info collapsed collapse-button" data-toggle="collapse" data-target="#<%=  document_id %>" >
   <span class="avail-label" aria-expanded="false">Online</span>
 </button>
-<div id="<%= document_id %>" class="collapse online_resources">
+<div id="<%= document_id %>" class="collapse">
   <%= render("online") %>
 </div>

--- a/app/views/primo_central/_online_button.html.erb
+++ b/app/views/primo_central/_online_button.html.erb
@@ -2,7 +2,5 @@
   <span class="avail-label" aria-expanded="false">Online</span>
 </button>
 <div id="<%= document_id %>" class="collapse online_resources">
-  <ul>
-    <%= render("online") %>
-  </ul>
+  <%= render("online") %>
 </div>

--- a/spec/helpers/primo_central_helper_spec.rb
+++ b/spec/helpers/primo_central_helper_spec.rb
@@ -27,6 +27,24 @@ RSpec.describe PrimoCentralHelper, type: :helper do
     end
   end
 
+  describe "#index_buttons_partials" do
+    context "document does not have a direct link" do
+      it "returns only the online button partial" do
+        expect(index_buttons_partials).to eq(["online_button"])
+      end
+    end
+
+    context "document does have a direct link" do
+      let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
+        delivery: { availability: ["fulltext_linktorsrc"] }
+      )}
+
+      it "returns only the direc_link button partial" do
+        expect(index_buttons_partials).to eq(["direct_link_button"])
+      end
+    end
+  end
+
   describe "#document_link_label" do
     context "no link label found" do
       it "returns a default value when no direct link label is found" do


### PR DESCRIPTION
REF Bl-397

Adds either a direct link or iframe button to the result index items for
article searches (primo central)