### PR TITLE
Use default label for direct link.

### DIFF
--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -45,9 +45,7 @@ module Blacklight::PrimoCentral::Document
     end
 
     def link_label(doc)
-      get_it(doc).fetch("displayText", "Direct Link")
-        .gsub("$$E", "")
-        .gsub("_", " ")
+      I18n.t("primo_central.link_to_resource")
     end
 
     def get_it(doc)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,8 @@ en:
       modify_words: "Try different keywords"
       ask_librarian: "Ask a Librarian"
       for_help: "for help"
+  primo_central:
+    link_to_resource: "Link to Resource"
   availability_code:
     online_resources: "Online"
     peer_reviewed: "Peer Reviewed"

--- a/spec/helpers/primo_central_helper_spec.rb
+++ b/spec/helpers/primo_central_helper_spec.rb
@@ -30,18 +30,7 @@ RSpec.describe PrimoCentralHelper, type: :helper do
   describe "#document_link_label" do
     context "no link label found" do
       it "returns a default value when no direct link label is found" do
-        expect(document_link_label).to eq("Direct Link")
-      end
-    end
-
-    context "link label available" do
-      let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
-        delivery: {
-          GetIt1: [{
-            "links" => [{ "displayText" => "$$EView_full_text_via_AgEcon" }],
-          }] }) }
-      it "correctly normalized label if found" do
-        expect(document_link_label).to eq("View full text via AgEcon")
+        expect(document_link_label).to eq("Link to Resource")
       end
     end
   end


### PR DESCRIPTION
REF BL-395

Followup on BL-395. Do not attempt to get direct link label from
response.