### PR TITLE
Refactor browse_creator for primo.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -13,7 +13,7 @@ class CatalogController < ApplicationController
 
   include Blacklight::Marc::Catalog
 
-  #helper BlacklightAlma::HelperBehavior
+  helper_method :browse_creator
 
   configure_blacklight do |config|
     # default advanced config values
@@ -443,7 +443,6 @@ class CatalogController < ApplicationController
       }
     end
 
-
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc
@@ -506,5 +505,21 @@ class CatalogController < ApplicationController
   def text_this_message_body(params)
     "#{params[:title]}\n" +
     "#{params[:location]}"
+  end
+
+  def browse_creator(args)
+    creator = args[:document][args[:field]]
+    creator.map do |name|
+      linked_subfields = name.split("|").first
+      facet_query = view_context.send(:url_encode, (linked_subfields))
+      newname = view_context.link_to(linked_subfields, base_path + "?f[creator_facet][]=#{facet_query}")
+      plain_text_subfields = name.split("|").second
+      creator = newname
+      if plain_text_subfields.present?
+        plain_text_subfields = plain_text_subfields
+        creator = newname + " " + plain_text_subfields
+      end
+      creator
+    end
   end
 end

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -4,6 +4,8 @@ class PrimoCentralController < CatalogController
   include Blacklight::Catalog
   include CatalogConfigReinit
 
+  helper_method :browse_creator
+
   configure_blacklight do |config|
     # Class for sending and receiving requests from a search index
     config.repository_class = Blacklight::PrimoCentral::Repository
@@ -75,5 +77,16 @@ class PrimoCentralController < CatalogController
   def render_sms_action?(_config, _options)
     # Render if the item can be found at a library
     false
+  end
+
+  def browse_creator(args)
+    creator = args[:document][args[:field]] || []
+    creator.map do |name|
+      linked_subfields = name.split("|").first
+
+      query = view_context.send(:url_encode, (linked_subfields))
+
+      view_context.link_to(linked_subfields, base_path + "?search_field=creator&q=#{query}")
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,21 +34,6 @@ module ApplicationHelper
     args[:document][args[:field]].map { |field| content_tag(:li,  fielded_search(field, args[:field]), class: "list_items") }.join("").html_safe
   end
 
-  def browse_creator(args)
-    creator = args[:document][args[:field]]
-    creator.map do |name|
-      linked_subfields = name.split("|").first
-      newname = link_to(linked_subfields, base_path + "?f[creator_facet][]=#{url_encode(linked_subfields)}").html_safe
-      plain_text_subfields = name.split("|").second
-      creator = newname
-      if plain_text_subfields.present?
-        plain_text_subfields = plain_text_subfields
-        creator = newname + " " + plain_text_subfields
-      end
-      creator
-    end
-  end
-
   def creator_index_separator(args)
     creator = args[:document][args[:field]]
     creator.map do |name|

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -65,4 +65,20 @@ module CatalogHelper
   def search_url_picker
     current_page?("/advanced") ? search_catalog_url : search_action_url
   end
+
+  def browse_creator(args)
+    creator = args[:document][args[:field]]
+    creator.map do |name|
+      linked_subfields = name.split("|").first
+      newname = link_to(linked_subfields, base_path + "?f[creator_facet][]=#{url_encode(linked_subfields)}").html_safe
+      plain_text_subfields = name.split("|").second
+      creator = newname
+      if plain_text_subfields.present?
+        plain_text_subfields = plain_text_subfields
+        creator = newname + " " + plain_text_subfields
+      end
+      creator
+    end
+  end
+
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -24,7 +24,6 @@ module CatalogHelper
     "data-lccn=#{value.first.gsub(/\D/, '')}" if value
   end
 
-
   def default_cover_image(document)
     formats = document.fetch(:format, ["unknown"])
     format = formats.first.to_s.parameterize.underscore
@@ -65,20 +64,4 @@ module CatalogHelper
   def search_url_picker
     current_page?("/advanced") ? search_catalog_url : search_action_url
   end
-
-  def browse_creator(args)
-    creator = args[:document][args[:field]]
-    creator.map do |name|
-      linked_subfields = name.split("|").first
-      newname = link_to(linked_subfields, base_path + "?f[creator_facet][]=#{url_encode(linked_subfields)}").html_safe
-      plain_text_subfields = name.split("|").second
-      creator = newname
-      if plain_text_subfields.present?
-        plain_text_subfields = plain_text_subfields
-        creator = newname + " " + plain_text_subfields
-      end
-      creator
-    end
-  end
-
 end

--- a/app/helpers/primo_central_helper.rb
+++ b/app/helpers/primo_central_helper.rb
@@ -61,4 +61,12 @@ module PrimoCentralHelper
     # Hashing because () characters mess with javacript.
     @document["pnxId"].hash
   end
+
+  def browse_creator(args)
+    creator = args[:document][args[:field]] || []
+    creator.map do |name|
+      linked_subfields = name.split("|").first
+      link_to(linked_subfields, base_path + "?search_field=creator&q=#{url_encode(linked_subfields)}")
+    end
+  end
 end

--- a/app/helpers/primo_central_helper.rb
+++ b/app/helpers/primo_central_helper.rb
@@ -61,12 +61,4 @@ module PrimoCentralHelper
     # Hashing because () characters mess with javacript.
     @document["pnxId"].hash
   end
-
-  def browse_creator(args)
-    creator = args[:document][args[:field]] || []
-    creator.map do |name|
-      linked_subfields = name.split("|").first
-      link_to(linked_subfields, base_path + "?search_field=creator&q=#{url_encode(linked_subfields)}")
-    end
-  end
 end

--- a/spec/helpers/primo_central_helper_spec.rb
+++ b/spec/helpers/primo_central_helper_spec.rb
@@ -5,10 +5,8 @@ require "rails_helper"
 RSpec.describe PrimoCentralHelper, type: :helper do
   let(:doc) { Hash.new }
   let(:document) { PrimoCentralDocument.new(doc) }
-  let(:base_path) { "" }
 
   before(:example) do
-    allow(helper).to receive(:base_path).and_return("")
     @document = document
   end
 

--- a/spec/helpers/primo_central_helper_spec.rb
+++ b/spec/helpers/primo_central_helper_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-include ERB::Util
 
 RSpec.describe PrimoCentralHelper, type: :helper do
   let(:doc) { Hash.new }
@@ -55,27 +54,5 @@ RSpec.describe PrimoCentralHelper, type: :helper do
         expect(document_link_label).to eq("Link to Resource")
       end
     end
-  end
-
-  describe "#browse_creator" do
-    context "no creator" do
-      let(:presenter) { { document: document, field: "creator" } }
-      it "returns an empty list if nos creators are available" do
-        expect(browse_creator(presenter)).to eq([])
-      end
-    end
-
-    context "a creator" do
-      let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
-        creator: ["Hello, World"],
-      )}
-      let(:presenter) { { document: document, field: "creator" } }
-      it "returns a list of links to creator search for each creator" do
-        expect(browse_creator(presenter)).to eq([
-          "<a href=\"?search_field=creator&amp;q=Hello%2C%20World\">Hello, World</a>",
-        ])
-      end
-    end
-
   end
 end

--- a/spec/helpers/primo_central_helper_spec.rb
+++ b/spec/helpers/primo_central_helper_spec.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+include ERB::Util
 
 RSpec.describe PrimoCentralHelper, type: :helper do
   let(:doc) { Hash.new }
   let(:document) { PrimoCentralDocument.new(doc) }
+  let(:base_path) { "" }
+
   before(:example) do
+    allow(helper).to receive(:base_path).and_return("")
     @document = document
   end
 
@@ -51,5 +55,27 @@ RSpec.describe PrimoCentralHelper, type: :helper do
         expect(document_link_label).to eq("Link to Resource")
       end
     end
+  end
+
+  describe "#browse_creator" do
+    context "no creator" do
+      let(:presenter) { { document: document, field: "creator" } }
+      it "returns an empty list if nos creators are available" do
+        expect(browse_creator(presenter)).to eq([])
+      end
+    end
+
+    context "a creator" do
+      let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
+        creator: ["Hello, World"],
+      )}
+      let(:presenter) { { document: document, field: "creator" } }
+      it "returns a list of links to creator search for each creator" do
+        expect(browse_creator(presenter)).to eq([
+          "<a href=\"?search_field=creator&amp;q=Hello%2C%20World\">Hello, World</a>",
+        ])
+      end
+    end
+
   end
 end


### PR DESCRIPTION
REF BL-409

Add a primo specific `browser_creator` helper method so that links creator values to primo creator queries vs faceted query.

To do this we need to move `browser_creator` method to be a helper_method so that we can selectivly override it in the `PrimoCentralController`