### PR TITLE
Library info search results

### DIFF
--- a/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
+++ b/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
@@ -48,7 +48,7 @@ var BlacklightAlma = function (options) {
          }).join(" ");
    }
    else if(holding['availability'] == 'check_holdings') {
-    return ["Check holdings for", libraryAndLocation, holding['call_number']]
+    return ["Check holdings for", library]
         .filter(function (item) {
             return item != null && item.length > 0;
         }).join(" ");

--- a/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
+++ b/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
@@ -40,26 +40,16 @@ var BlacklightAlma = function (options) {
 
  availabilityInfo = function (holding) {
    var library = [holding['library']];
-   var capitalAvail = holding['availability'].charAt(0).toUpperCase() + holding['availability'].slice(1);
    if(holding['availability'] == 'available') {
-     return [capitalAvail, 'at', library]
-         .filter(function (item) {
-             return item != null && item.length > 0;
-         }).join(" ");
+     return "Available at " + library;
    }
    else if(holding['availability'] == 'check_holdings') {
-    return ["Check holdings for", library]
-        .filter(function (item) {
-            return item != null && item.length > 0;
-        }).join(" ");
+    return "Check holdings for " + library;
   }
   else {
-    return ["Checked out or temporarily unavailable at ", holding['library']]
-        .filter(function (item) {
-            return item != null && item.length > 0;
-        }).join(" ");
+    return "Checked out or temporarily unavailable at " + library
   }
-}
+ }
 
  BlacklightAlma.prototype.formatHolding = function (mms_id, holding) {
      if(holding['inventory_type'] == 'physical') {
@@ -73,7 +63,14 @@ var BlacklightAlma = function (options) {
   * @returns {string}
   */
  BlacklightAlma.prototype.formatHoldings = function (holdings) {
-     return holdings.join("<br/>");
+   if (holdings.indexOf('Available at Paley Library') > 0) {
+       holdings.splice(holdings.indexOf('Available at Paley Library'), 1);
+       holdings.unshift('Available at Paley Library');
+   }
+   list = holdings.filter(function (x, i, a) {
+    return a.indexOf(x) == i;
+   });
+   return list.join("<br/>");
  };
 
  /**

--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -53,7 +53,7 @@ module AlmaDataHelper
   end
 
   def missing_or_lost?(item)
-    item["item_data"]["process_type"].has_value?("MISSING") || item["item_data"]["process_type"].has_value?("LOST")
+    item["item_data"]["process_type"].has_value?("MISSING") || item["item_data"]["process_type"].has_value?("LOST_LOAN")
   end
 
   def group_and_order_items(items)

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
            },
            "item_data" => {
              "library" => { "value" => "MAIN" },
-             "process_type" => { "value" => "LOST" }
+             "process_type" => { "value" => "LOST_LOAN" }
            }
          }]
       end


### PR DESCRIPTION
BL-417 Sorts the availability by library in the search results view.
- "Available at Paley Library" should come first when the item is at multiple locations
- only unique library names should be displayed
![screen shot 2018-05-02 at 9 30 49 am](https://user-images.githubusercontent.com/15167238/39525988-872c9502-4deb-11e8-911f-eb88a8123b09.png)
