### PR TITLE
BL-416 Adjust styles for availability panels

### DIFF
--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -36,6 +36,7 @@ div #facet-availability_facet .panel-body {
 .aeon-wrapper {
   display: table;
   margin-bottom: 20px;
+  padding-bottom: 20px;
   width: 100%;
 }
 
@@ -119,14 +120,14 @@ dd.blacklight-availability {
   vertical-align: middle;
 }
 
-#availability-heading {
-  margin: 0;
-  padding: 0;
+.availability-panel-heading {
+  background-color: #A30733 !important;
+  color: #fff !important;
+  padding: 5px;
 }
 
-.bl_alma_iframe {
-  border: 0;
-  width: 99.9%;
+#availability-heading {
+  margin-left: 5px;
 }
 
 div.online_resources {
@@ -155,7 +156,8 @@ div.online_resources {
 }
 
 div.physical-holding-panel {
-  padding-top: 0;
+  padding: 0 !important;
+  margin-bottom: -20px !important;
 }
 
 .show_page_records dd {
@@ -171,13 +173,14 @@ div.physical-holding-panel {
   margin-top: 10px;
 }
 
-.physical-holding-panel {
-  padding: 0 !important;
+.border-bottom td, .border-bottom th {
+  border-bottom: 1px solid #CFC7B0;
 }
 
-.borderless td, .borderless th {
-  border: none !important;
+table {
+  border: 1px solid #CFC7B0;
 }
+
 
 /* ALMA DATA TABLE */
 .table-heading {

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-responsive borderless">
+<table class="table table-responsive border-bottom">
   <% unless @items["item"].nil? %>
     <% group_and_order_items(@items["item"]).each do |key,items| %>
       <thead class="table-heading">

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -2,7 +2,7 @@
 <%# partial to display availability details in catalog show view -%>
 <div class="col-sm-12">
 <div id="record-view-iframe"  class="panel panel-default">
-  <div class="panel-heading">
+  <div class="availability-panel-heading panel-heading">
     <h4 id="availability-heading">Availability</h4>
   </div>
 
@@ -39,6 +39,8 @@
         </div>
       </div>
   <% end %>
-  <%= render "aeon_request", :document => document %>
+  <% if aeon_request_button(document) %>
+    <%= render "aeon_request", :document => document %>
+  <% end %>
 </div>
 </div>


### PR DESCRIPTION
BL-416 Tweaks to availability styles per Rachel
- add border
- record page availability panel has a Temple red header with white text
- record page availability has no extra padding at the bottom
- All text is aligned to the left, including the Availability header
<img width="835" alt="screen shot 2018-05-04 at 4 35 08 pm" src="https://user-images.githubusercontent.com/15167238/39651249-25888b24-4fb9-11e8-922b-1b2a61bfa9ed.png">
