### PR TITLE
Fixes tracking links for articles.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
+  post 'articles/:id/track' => 'primo_central#track', as: :track_primo_central
+
   resources :users, only: [:index] do
     post :impersonate, on: :member
     post :stop_impersonating, on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
-  post 'articles/:id/track' => 'primo_central#track', as: :track_primo_central
+  post "articles/:id/track" => "primo_central#track", as: :track_primo_central
 
   resources :users, only: [:index] do
     post :impersonate, on: :member


### PR DESCRIPTION
Blacklight does some metaprogramming to add a data-attribute to the results links.
https://github.com/projectblacklight/blacklight/blob/v6.15.0/app/helpers/blacklight/url_helper_behavior.rb#L62-L87

Which is then used by BL js to track the search and redirect to the result page.

We needed a route in the form "track_#{controller_name}_path" or else BL uses the default,
in the form of  `/catalog/:id?track=....`

Results links for articles should now work as expected.

Fixes BL-420