### PR TITLE
Bl 422 brief libraries

### DIFF
--- a/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
+++ b/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
@@ -40,34 +40,26 @@ var BlacklightAlma = function (options) {
 
  availabilityInfo = function (holding) {
    var library = [holding['library']];
-   if(holding['availability'] == 'available') {
-     return "Available at " + library;
-   }
-   else if(holding['availability'] == 'check_holdings') {
-    return "Check holdings for " + library;
-  }
-  else {
-    return "Checked out or temporarily unavailable at " + library
-  }
+    return library;
  }
 
  BlacklightAlma.prototype.formatHolding = function (mms_id, holding) {
      if(holding['inventory_type'] == 'physical') {
-         return availabilityInfo(holding);
+       if(holding['availability'] == 'available') {
+         label = "Available at ";
+         return label + availabilityInfo(holding);
+       }
+       else if(holding['availability'] == 'check_holdings') {
+         label = "Other libraries: ";
+         return label + availabilityInfo(holding);
      }
+   }
  };
 
- availableLibrarySort = function (holdings) {
+ availableLibrarySort = function (holdings, holding) {
    if (holdings.indexOf('Available at Paley Library') > 0) {
        holdings.splice(holdings.indexOf('Available at Paley Library'), 1);
        holdings.unshift('Available at Paley Library');
-   }
- }
-
- unavailableLibrarySort = function (holdings) {
-   if (holdings.indexOf('Checked out or temporarily unavailable at Paley Library') > 0) {
-       holdings.splice(holdings.indexOf('Checked out or temporarily unavailable at Paley Library'), 1);
-       holdings.unshift('Checked out or temporarily unavailable at Paley Library');
    }
  }
 
@@ -85,7 +77,6 @@ var BlacklightAlma = function (options) {
   */
  BlacklightAlma.prototype.formatHoldings = function (holdings) {
    availableLibrarySort(holdings);
-   unavailableLibrarySort(holdings);
    checkHoldingsLibrarySort(holdings);
    list = holdings.filter(function (x, i, a) {
     return a.indexOf(x) == i;

--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -114,12 +114,6 @@ input[type="radio"] + label {
   display: none;
 }
 
-dd.blacklight-availability {
-  display: inline-block;
-  margin-left: 10px;
-  vertical-align: middle;
-}
-
 .availability-panel-heading {
   background-color: #A30733 !important;
   color: #fff !important;

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -1,5 +1,8 @@
 <% doc_presenter = show_presenter(document) %>
 
+<div class="blacklight-availability availability-ajax-load" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" >
+</div>
+
 <% @response["response"][:docs].each_with_index do |field, i| %>
   <% if document.fetch("availability_facet", [])[i] == "Online" %>
     <% if has_one_electronic_resource?(document) %>
@@ -18,7 +21,6 @@
   <% end %>
 
   <% if document.fetch("availability_facet", [])[i] == "At the Library" %>
-  <dd class="blacklight-availability availability-ajax-load" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" ></dd>
     <div class="row button-break"></div>
     <div data-controller="availability" data-availability-url="<%= item_url(document.id) %>">
       <button data-action="availability#item" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" class="btn btn-sm btn-default availability-toggle-details" data-toggle="collapse" data-target="#physical-document-<%=  document_counter %>, availability.button">

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -11,15 +11,14 @@
     <dl class="document-metadata dl-horizontal dl-invert">
     <% index_fields(document).each do |field_name, field| -%>
       <% if should_render_index_field? document, field %>
-        <dt class="blacklight-<%= field_name.parameterize %>"><%= render_index_field_label document, field: field_name %></dt>
+        <dt class="index-label blacklight-<%= field_name.parameterize %>"><%= render_index_field_label document, field: field_name %></dt>
         <dd class="blacklight-<%= field_name.parameterize %>">
           <% if field[:raw] %>
             <%= raw doc_presenter.field_value(field_name) %>
           <% else %>
             <%= doc_presenter.field_value(field_name) %>
           <% end -%>
-
-            </dd>
+        </dd>
       <% end -%>
     <% end -%>
           <%= render "index_availability_section", document: document, document_counter: document_counter %>


### PR DESCRIPTION
BL-422 Updates the availability information to match the rest of the brief view
- Available items should display a list of library names with a gray label "Available at: "
- Items with check_holdings status should display with a gray label "Other Libraries: "
- unavailable items should not display
![screen shot 2018-05-08 at 2 57 23 pm](https://user-images.githubusercontent.com/15167238/39776932-31c8eb94-52d0-11e8-917a-fe4e020a0445.png)
![screen shot 2018-05-08 at 2 57 45 pm](https://user-images.githubusercontent.com/15167238/39776938-335a65be-52d0-11e8-84db-2a5801a40145.png)

