### PR TITLE
Flatten the topics value on index.

### DIFF
--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -139,7 +139,7 @@ module Traject
               subjects << subject.map { |s| Traject::Macros::Marc21.trim_punctuation(s) }.join(SEPARATOR)
             end
           end
-          subjects.flatten
+          subjects = subjects.flatten
           acc.replace(subjects)
           acc.uniq!
         end

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -588,11 +588,10 @@ RSpec.describe Traject::Macros::Custom do
 
       it "maps data from the 600 to the expected field" do
         expect(subject.map_record(records[1])).to eq(
-          "subject_topic_facet" => [["Subject Topic moves on to the year 3000"]]
+          # Note that value is flattened
+          "subject_topic_facet" => ["Subject Topic moves on to the year 3000"]
           )
       end
-
-
     end
   end
 end


### PR DESCRIPTION
REF BL-419

Flatten the topics value on index so that [["value"]] does not get sent
to Solr.

To test.
* Re-index and search for "Catholic Church"
* Verify that you do not see the topics facet field "[Catholic Church]"