### PR TITLE
Fix single operator used for all advanced query.

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -29,16 +29,16 @@ module AdvancedHelper
     key_value
   end
 
-  # Get default value for op_row[] field in advanced_search form.
+  # Get default value for operator[] field in advanced_search form.
   def op_row_default(count)
-    if !params["op_row"]
+    if !params["operator"]
       "contains"
     else
-      # Always select from last rows count of total values in op_row[]
+      # Always select from last rows count of total values in operator[]
       # @see BL-334
       rows = params.select { |k| k.match(/^q_/) }
       count_rows = rows.to_h.count
-      params["op_row"][-count_rows + count - 1]
+      params["operator"][-count_rows + count - 1]
     end
   end
 

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -30,7 +30,7 @@ module AdvancedHelper
   end
 
   # Get default value for operator[] field in advanced_search form.
-  def op_row_default(count)
+  def operator_default(count)
     if !params["operator"]
       "contains"
     else

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -114,9 +114,9 @@ class SearchBuilder < Blacklight::SearchBuilder
         p = params.to_unsafe_h.compact
 
         fields = p.select { |k| k.match(/(^q$|^q_)/) }
-        ops = p.fetch("op_row", ["default"])
+        ops = p.fetch("operator", ["default"])
 
-        # Always use last rows count of total values in op_row[]
+        # Always use last rows count of total values in operator[]
         # @see BL-334
         rows = p.select { |k| k.match(/^q_/) }
         rows_count = rows.count

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -7,8 +7,8 @@
     </div>
 
     <div class="col-sm-2">
-      <label for="op_row[]" class="sr-only">Operator</label>
-      <%= select_tag("operator", options_for_select({"contains"=> :contains, "is (exact)" => :is, "begins with" => :begins_with}.sort, op_row_default(count)), :class => "form-control", :id =>"op_row[]") %>
+      <label for="operator[]" class="sr-only">Operator</label>
+      <%= select_tag("operator[]", options_for_select({"contains"=> :contains, "is (exact)" => :is, "begins with" => :begins_with}.sort, operator_default(count)), :class => "form-control", :id =>"operator[]") %>
     </div>
 
     <div class="col-sm-3">

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Advanced Search" do
 
     scenario "searching title for x AND y" do
       visit "catalog?#{{
-        op_row: ["contains", "contains"],
+        operator: ["contains", "contains"],
         f_1: "title", q_1: "full", op_1: "AND",
         f_2: "title", q_2: "exercises",
         search_field: "advanced",
@@ -46,7 +46,7 @@ RSpec.feature "Advanced Search" do
 
     scenario "searching title for x OR y" do
       visit "catalog?#{{
-        op_row: ["contains", "contains"],
+        operator: ["contains", "contains"],
         f_1: "title", q_1: "full", op_1: "OR",
         f_2: "title", q_2: "exercises",
         search_field: "advanced",
@@ -58,7 +58,7 @@ RSpec.feature "Advanced Search" do
 
     scenario "searching title for x NOT y" do
       visit "catalog?#{{
-        op_row: ["contains", "contains"],
+        operator: ["contains", "contains"],
         f_1: "title", q_1: "full", op_1: "NOT",
         f_2: "title", q_2: "exercises",
         search_field: "advanced",
@@ -71,7 +71,7 @@ RSpec.feature "Advanced Search" do
 
     scenario "searching with begins_with" do
       visit "catalog?#{{
-        op_row: ["begins_with"],
+        operator: ["begins_with"],
         f_1: "title", q_1: "full",
         search_field: "advanced",
       }.to_query}"
@@ -82,7 +82,7 @@ RSpec.feature "Advanced Search" do
 
     scenario "searching with begins_with x OR begins_with y" do
       visit "catalog?#{{
-        op_row: ["begins_with", "begins_with"],
+        operator: ["begins_with", "begins_with"],
         f_1: "title", q_1: "silencio", op_1: "OR",
         f_2: "title", q_2: "full",
         search_field: "advanced",
@@ -95,7 +95,7 @@ RSpec.feature "Advanced Search" do
     scenario "searching crazy long title with colon in it" do
       title = "Religious liberty : the positive dimension : an address / by Franklin H. Littell at Doane College on April 26, 1966."
       visit "catalog?#{{
-        op_row: ["contains"],
+        operator: ["contains"],
         f_1: "all_fields", q_1: title,
         search_field: "advanced",
       }.to_query}"
@@ -115,7 +115,7 @@ RSpec.feature "Advanced Search" do
     end
     scenario "searching with is operator" do
       visit "catalog?#{{
-        op_row: ["is"],
+        operator: ["is"],
         f_1: "all_fields", q_1: "introduction to issues",
         search_field: "advanced",
       }.to_query}"
@@ -126,7 +126,7 @@ RSpec.feature "Advanced Search" do
 
     scenario "searching NOT something" do
       visit "catalog?#{{
-        op_row: ["contains"],
+        operator: ["contains"],
         f_1: "all_fields", q_1: "NOT introduction to issues",
         search_field: "advanced",
       }.to_query}"

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helpe
     end
   end
 
-  describe ".op_row_default" do
+  describe ".operator_default" do
     example "default" do
-      expect(helper.op_row_default(2)).to eq("contains")
+      expect(helper.operator_default(2)).to eq("contains")
     end
 
     # REF BL-334
@@ -25,7 +25,7 @@ RSpec.describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helpe
       )
       allow(helper).to receive(:params).and_return(params)
 
-      expect(helper.op_row_default(2)).to eq("bar")
+      expect(helper.operator_default(2)).to eq("bar")
     end
   end
 

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helpe
         q_1: "james",
         q_2: "john",
         q_3: "david",
-        op_row: [ "fizz", "fizz", "fizz", "foo", "bar", "bum" ]
+        operator: [ "fizz", "fizz", "fizz", "foo", "bar", "bum" ]
       )
       allow(helper).to receive(:params).and_return(params)
 

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe SearchBuilder , type: :model do
 
   describe "#process_params!" do
     let(:params) { ActionController::Parameters.new(
-      "op_row" => ["bizz", "buzz", "bazz"],
+      "operator" => ["bizz", "buzz", "bazz"],
       "f_1" => "all_fields", "q_1" => "Hello",
       "f_2" => "all_fields", "q_2" => "Beautiful",
       "f_3" => "all_fields", "q_3" => "World",
@@ -178,7 +178,7 @@ RSpec.describe SearchBuilder , type: :model do
 
     it "handles a typical advanced search params as expected" do
       params = ActionController::Parameters.new(
-        "op_row" => ["bizz", "buzz", "bazz"],
+        "operator" => ["bizz", "buzz", "bazz"],
         "f_1" => "all_fields", "q_1" => "Hello",
         "f_2" => "all_fields", "q_2" => "Beautiful",
         "f_3" => "all_fields", "q_3" => "World",
@@ -199,9 +199,9 @@ RSpec.describe SearchBuilder , type: :model do
     end
 
     # REF BL-334
-    it "uses the last 3 values in op_row not all of it" do
+    it "uses the last 3 values in operator not all of it" do
       params = ActionController::Parameters.new(
-        "op_row" => ["foo", "foo", "foo", "bizz", "buzz", "bazz"],
+        "operator" => ["foo", "foo", "foo", "bizz", "buzz", "bazz"],
         "f_1" => "all_fields", "q_1" => "Hello",
         "f_2" => "all_fields", "q_2" => "Beautiful",
         "f_3" => "all_fields", "q_3" => "World",


### PR DESCRIPTION
REF BL-323

Do to a change introduced in BL-323 (#376) we no longer add an
individual operator per field row query.  Instead we use one operator
for all queries.

This update fixes that issue by replacing occurrences of `op_row` with the
new name, `operator`.