### PR TITLE
Fix google_book image not showing up.

### DIFF
--- a/app/assets/javascripts/book_covers.js
+++ b/app/assets/javascripts/book_covers.js
@@ -4,10 +4,15 @@ $(document).on('turbolinks:load', function() {
     lccn = $(thumbnail).attr('data-lccn');
     isbn = $(thumbnail).attr('data-isbn');
     if(lccn) {
-      queries.push("LCCN:" + lccn);
+      isbn.split(",").map(function(value){
+        queries.push("LCCN:" + value);
+      })
     }
-    else if(isbn) {
-      queries.push("ISBN:" + isbn);
+
+    if(isbn) {
+      isbn.split(",").map(function(value){
+        queries.push("ISBN:" + value);
+      })
     }
   });
 
@@ -24,8 +29,8 @@ $(document).on('turbolinks:load', function() {
         if(b.hasOwnProperty("thumbnail_url")) {
           type = b.bib_key.split(":")[0];
           identifier = b.bib_key.split(":")[1];
-          $('[data-' + type.toLowerCase() + '=' + identifier + '] .book_cover').attr("src" , b.thumbnail_url).removeClass("invisible").addClass("google-image");
-          $('[data-' + type.toLowerCase() + '=' + identifier + '] .default').remove();
+          $('[data-' + type.toLowerCase() + '*=' + identifier + '] .book_cover').attr("src" , b.thumbnail_url).removeClass("invisible").addClass("google-image");
+          $('[data-' + type.toLowerCase() + '*=' + identifier + '] .default').remove();
         }
       }
     }

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -13,15 +13,21 @@ module CatalogHelper
   end
 
   def isbn_data_attribute(document)
-    value = document.fetch(:isbn_display, []).first
-    # Get the first ISBN and strip non-numerics
-    "data-isbn=#{value.gsub(/\D/, '')}" if value
+    values = document.fetch(:isbn_display, [])
+    values = [values].flatten.map { |value|
+      value.gsub(/\D/, "") if value
+    }.compact.join(",")
+
+    "data-isbn=#{values}" if !values.empty?
   end
 
   def lccn_data_attribute(document)
-    value = document.fetch(:lccn_display, []).first
-    # Get the first ISSN and strip non-numerics
-    "data-lccn=#{value.first.gsub(/\D/, '')}" if value
+    values = document.fetch(:lccn_display, [])
+    values = [values].flatten.map { |value|
+      value.gsub(/\D/, "") if value
+    }.compact.join(",")
+
+    "data-lccn=#{values}" if !values.empty?
   end
 
   def default_cover_image(document)


### PR DESCRIPTION
REF BL-470

I've studied the code for generating the google_book images and found
multiple  potential sources of issues that can cause images to not show
up when they otherwise might.

1. We are only selecting one id item from lccn or isbn number even when
multiple are present.  We are selecting the first item.  But this can
cause issues if the sort order is different in different system.

2. We are choosing either the lccn or isbn number but not both.

3. We are not properly handling cases where the id is returned as
a string and not a list of ids.

This change updates the book-image code to search for images on multiple
id and id types so that sorting is not an issue and so that if one id
fails we still try other ids that might return a book image.

This change also fixes handling the case where a string value is
returned to the function vs an array of strings.  In the case where
a string value was being returned we were selecting the first letter of
the id and using that first letter as an id for an image.