### PR TITLE
Try to fix libqa routing issue.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
+  post "catalog/:id/track" => "catalog#track"
   post "articles/:id/track" => "primo_central#track", as: :track_primo_central
 
   resources :users, only: [:index] do


### PR DESCRIPTION
REF BL-414

Adding a similar configuration to the app router fixed a similar issue
with primo_central tracking so I'm hopping this will do the same for
catalog/bookmarks tracking on libqa.

For example the following track requests fail with 404:

```
https://libqa.library.temple.edu/catalog/catalog/991017730139703811/track?counter=1&search_id=2708

https://libqa.library.temple.edu/catalog/TN_crossref10-dot-1177-slash-0361684312464862/track?counter=4
```

We should probably add a redirect for catalog/:id/track where :id
matches /^TN_/, too.