### PR TITLE
Follow up on some article advanced search issues.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GIT
 
 GIT
   remote: https://github.com/tulibraries/primo
-  revision: b5c4e85e12d82bfcf35cf17d4968726c61847883
+  revision: a69121ada5095bccc4c9f14b6a8e42c9e0a87031
   specs:
     primo (0.1.0)
       httparty

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -34,7 +34,7 @@ class PrimoCentralController < CatalogController
     config.add_search_field :any, label: "All Fields"
     config.add_search_field :title
     config.add_search_field :creator, label: "Author/Creator"
-    config.add_search_field :subject
+    config.add_search_field :sub, label: "Subject"
     config.add_search_field(:description, label: "Description") do |field|
       field.include_in_simple_select = false
     end

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -35,6 +35,9 @@ class PrimoCentralController < CatalogController
     config.add_search_field :title
     config.add_search_field :creator, label: "Author/Creator"
     config.add_search_field :subject
+    config.add_search_field(:description, label: "Description") do |field|
+      field.include_in_simple_select = false
+    end
     config.add_search_field :isbn, label: "ISBN"
     config.add_search_field :issn, label: "ISSN"
 

--- a/app/models/blacklight/primo_central/repository.rb
+++ b/app/models/blacklight/primo_central/repository.rb
@@ -11,6 +11,7 @@ module Blacklight::PrimoCentral
     # Execute a search against Primo PNXS API.
     def search(params = {})
       data = params[:query]
+
       duration =
         if data[:id]
           duration_for(:article_record_cache_life)

--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -59,7 +59,7 @@ module Blacklight::PrimoCentral
           value = blacklight_params["q_#{count}"]
           precision = blacklight_params["operator_#{count}"]
           field = blacklight_params["f_#{count}"]
-          operator = blacklight_params["op_#{count}"]
+          operator = blacklight_params["op_#{count}"] || "AND"
 
           if !value&.empty? && !value.nil?
             { value: value, field: field, precision: precision, operator: operator }
@@ -80,9 +80,9 @@ module Blacklight::PrimoCentral
         query = primo_central_parameters[:query][:q]
       end
 
-      q = Primo::Pnxs::Query.send(op, query)
+      pq = Primo::Pnxs::Query.send(op, query)
 
-      primo_central_parameters[:query][:q] = q
+      primo_central_parameters[:query][:q] = pq
 
       blacklight_params.fetch(:f, {})
         .merge(blacklight_params.fetch(:f_inclusive, {}))

--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -59,7 +59,7 @@ module Blacklight::PrimoCentral
           value = blacklight_params["q_#{count}"]
           precision = blacklight_params["operator_#{count}"]
           field = blacklight_params["f_#{count}"]
-          operator = blacklight_params["op_#{count}"] || "AND"
+          operator = blacklight_params["op_#{count}"]
 
           if !value&.empty? && !value.nil?
             { value: value, field: field, precision: precision, operator: operator }

--- a/app/views/primo_advanced/_advanced_search_fields.html.erb
+++ b/app/views/primo_advanced/_advanced_search_fields.html.erb
@@ -8,7 +8,7 @@
 
     <div class="col-sm-2">
       <label for="<%= "operator_#{count}" %>" class="sr-only">Operator</label>
-      <%= select_tag("operator_#{count}", options_for_select({"contains"=> :contains, "is (exact)" => :is, "begins with" => :begins_with}.sort, operator_default(count)), :class => "form-control", :id =>"operator_#{count}") %>
+      <%= select_tag("operator_#{count}", options_for_select({"contains"=> :contains, "is (exact)" => :exact, "begins with" => :begins_with}.sort, operator_default(count)), :class => "form-control", :id =>"operator_#{count}") %>
     </div>
 
     <div class="col-sm-3">

--- a/app/views/primo_advanced/_advanced_search_fields.html.erb
+++ b/app/views/primo_advanced/_advanced_search_fields.html.erb
@@ -8,7 +8,7 @@
 
     <div class="col-sm-2">
       <label for="<%= "operator_#{count}" %>" class="sr-only">Operator</label>
-      <%= select_tag("operator_#{count}", options_for_select({"contains"=> :contains, "is (exact)" => :exact, "begins with" => :begins_with}.sort, operator_default(count)), :class => "form-control", :id =>"operator_#{count}") %>
+      <%= select_tag("operator_#{count}", options_for_select({"contains"=> :contains, "is (exact)" => :exact }.sort, operator_default(count)), :class => "form-control", :id =>"operator_#{count}") %>
     </div>
 
     <div class="col-sm-3">


### PR DESCRIPTION
REF BL-398

* Fixes the wrong operator being set for is(exact) searches.
* Fixes wrong field used for subject field.
* Allows Search of description.

Issues that cannot be addressed with this PR.
* start_with/begins_with operator has bug on primo API end
* NOT boolean operator is currently working as expected but we should revisit UI.
* Start over works a expected because facets require a search to appear.