### PR TITLE
BL-469 Add physical_material_type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tulibraries/alma_rb
-  revision: 6060ca25486bd1fc24f8325d6e3a233fedeafb8e
+  revision: a4f0ed3174310308637d2fbd1247160161b5e998
   specs:
     alma (0.2.5)
       ezwadl

--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -3,6 +3,9 @@
 module AlmaDataHelper
   include Blacklight::CatalogHelperBehavior
 
+  PHYSICAL_TYPE_EXCLUSIONS = /BOOK|ISSUE|SCORE|KIT|MAP|ISSBD|GOVRECORD|OTHER/i
+
+
   def availability_status(item)
     if item.in_place?
       if item.non_circulating?
@@ -27,6 +30,12 @@ module AlmaDataHelper
   def description(item)
     if item.description.present?
       return "Description: " + item.description
+    end
+  end
+
+  def physical_material_type(item)
+    if item.physical_material_type.present? && !PHYSICAL_TYPE_EXCLUSIONS.match(item.physical_material_type)
+      return item.physical_material_type
     end
   end
 

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -4,7 +4,7 @@
       <% sort_order_for_holdings(@items).each do |key,items| %>
         <thead class="table-heading">
           <tr>
-            <th colspan="5">
+            <th colspan="6">
               <%= library_name_from_short_code(key) %>
             </th>
           </tr>
@@ -15,6 +15,7 @@
               <td scope="row"><%= location_status(item) %></td>
               <td scope="row"><%= item.call_number %> <%= alternative_call_number(item) %></td>
               <td scope="row"><%= description(item) %></td>
+              <td scope="row"><%= physical_material_type(item) %></td>
               <td scope="row"><%= public_note(item) %></td>
               <td scope="row"><%= availability_status(item) %></td>
             <!-- <tr>

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -107,6 +107,36 @@ RSpec.describe AlmaDataHelper, type: :helper do
     end
   end
 
+  describe "#physical_material_type(item)" do
+    context "item includes physical_material_type" do
+      let(:item) do
+        Alma::BibItem.new("item_data" =>
+           { "physical_material_type" =>
+             { "value" => "DVD" }
+           }
+         )
+      end
+
+      it "displays physical_material_type" do
+        expect(physical_material_type(item)).to eq "DVD"
+      end
+    end
+
+    context "item does NOT include PHYSICAL_TYPE_EXCLUSIONS" do
+      let(:item) do
+        Alma::BibItem.new("item_data" =>
+           { "physical_material_type" =>
+             { "value" => "BOOK" }
+           }
+         )
+      end
+
+      it "displays nothing" do
+        expect(physical_material_type(item)).to eq nil
+      end
+    end
+  end
+
   describe "#public_note(item)" do
     context "item includes public note" do
       let(:item) do


### PR DESCRIPTION
BL-469 Adds physical_material_type from the alma api to certain types of records
- It should not display for Book, Issue, Music Score, Kit, Map, Bound Issue, Government Document, Other
- Displays in the third column of the availability table
![screen shot 2018-06-07 at 2 19 07 pm](https://user-images.githubusercontent.com/15167238/41118375-c3836196-6a5d-11e8-9878-e0c52463b369.png)
