### PR TITLE
BL-477 Update styles for online availability

### DIFF
--- a/app/assets/stylesheets/tucob.css.erb
+++ b/app/assets/stylesheets/tucob.css.erb
@@ -117,11 +117,6 @@ input[type="radio"] + label {
   margin-left: 5px;
 }
 
-div.online_resources {
-  border: 1px solid #ccc;
-  padding: 10px;
-}
-
 .collapse-button {
   width: 121px !important;
   white-space: normal;
@@ -137,7 +132,6 @@ div.online_resources {
 }
 
 .online-border {
-  border-bottom: 1px solid #ececec;
   padding-top: 0;
 }
 
@@ -165,14 +159,42 @@ div.physical-holding-panel {
 
 .online-panel-heading {
   background-color: #F1EFE8;
-  border-bottom: 1px solid #CFC7B0;
+  border: 1px solid #CFC7B0;
+  border-bottom: none;
+  font-size: 14px;
+  font-weight: bold;
   height: 40px;
-  margin: 0 0 15px 0;
-  padding: 10px;
+  margin: 0;
+  padding: 8px;
 }
 
 .online-panel-body {
-  margin: 10px;
+  margin-top: -20px;
+}
+
+.list_elec_links {
+  padding: 0;
+  margin-top: 0;
+  width: 100%;
+}
+
+.search_results_table {
+  border: 1px solid #CFC7B0;
+}
+
+.record_page_elec_links {
+  border: 1px solid #CFC7B0;
+  border-bottom: none;
+  padding: 0;
+  margin-top: 0;
+  width: 100%;
+}
+
+.electronic_links  {
+  border-bottom: 1px solid #CFC7B0;
+  display: block;
+  padding: 8px;
+  width: 100%;
 }
 
 /* ALMA DATA TABLE */
@@ -180,7 +202,7 @@ div.physical-holding-panel {
   border-bottom: 1px solid #CFC7B0;
 }
 
-table {
+table.border-bottom {
   border: 1px solid #CFC7B0;
   padding: 0 !important;
   margin: 0 !important;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,13 +58,13 @@ module ApplicationHelper
       else
         electronic_resource_link_builder(field)
       end
-    }.join("<br />").html_safe
+    }.join("").html_safe
   end
 
   def electronic_access_links(field)
     link_text = field.split("|").first.sub(/ *[ ,.\/;:] *\Z/, "")
     link_url = field.split("|").last
-    new_link = content_tag(:li, link_to(link_text, link_url, title: "Target opens in new window", target: "_blank"), class: "list_items")
+    new_link = content_tag(:td, link_to(link_text, link_url, title: "Target opens in new window", target: "_blank"), class: "electronic_links list_items")
     new_link
   end
 
@@ -95,7 +95,7 @@ module ApplicationHelper
   def electronic_resource_list_item(portfolio_pid, db_name, addl_info)
     item_parts = [render_alma_eresource_link(portfolio_pid, db_name), addl_info]
     item_html = item_parts.compact.join(" - ").html_safe
-    content_tag(:li, item_html , class: "list_items")
+    content_tag(:td, item_html , class: " electronic_links list_items")
   end
 
   def electronic_resource_link_builder(field)

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -10,9 +10,10 @@
       <span class="avail-label" aria-expanded="false">Online</span>
     </button>
       <div id="online-document-<%= document_counter %>" class="collapse online_resources">
-        <ul>
+        <table class="list_elec_links search_results_table">
           <%= check_for_full_http_link({document: document, field: "electronic_resource_display"}) %>
-        </ul>
+          <span class="border-bottom"></span>
+        </table>
       </div>
     <% end %>
   <% end %>

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -13,26 +13,20 @@
 
       <div class="panel-body online-panel">
         <h5 class="online-panel-heading">Online</h5>
-        <div class="online-panel-body">
-          <dd class="blacklight-<%= field_name.parameterize %>">
-            <ul>
-              <% doc_presenter.configuration.show_fields.fetch(field_name)[:helper_method] %>
-              <% values = Array.wrap(doc_presenter.field_value field_name) %>
-              <% values.each do |value| %>
-                <li class="list_items"> <%= safe_join(Array.wrap(value)) %> </li>
-              <% end %>
-            </ul>
-          </dd>
-        </div>
+          <table class="record_page_elec_links">
+            <% values = Array.wrap(doc_presenter.field_value field_name) %>
+            <% values.each do |value| %>
+            <tr>
+              <td class="list_items"> <%= safe_join(Array.wrap(value)) %> </li>
+            </tr>
+            <% end %>
+          </table>
       </div>
       <% end %>
     <% end %>
   <% end %>
 
   <% if document.fetch("availability_facet", []).include?("At the Library") %>
-    <% if document.fetch("availability_facet", []).include?("At the Library") && document.fetch("availability_facet", []).include?("Online") %>
-      <div class="online-border"></div>
-    <% end %>
     <div data-controller="show" data-show-url="<%= item_url(document.id) %>" class="physical-holding-panel panel-body">
       <div data-target="show.panel" class="panel-content" >
         <div data-target="show.spinner" class="spinner">

--- a/app/views/primo_central/_direct_link.html.erb
+++ b/app/views/primo_central/_direct_link.html.erb
@@ -1,1 +1,8 @@
-<%= link_to document_link_label, document_link  %>
+<table class="record_page_elec_links">
+  <tr>
+    <td>
+      <%= link_to document_link_label, document_link, class: "electronic_links"  %>
+    </td>
+  </tr>
+
+</table>

--- a/app/views/primo_central/_show_availability_section.html.erb
+++ b/app/views/primo_central/_show_availability_section.html.erb
@@ -8,7 +8,7 @@
   <div class="online-border"></div>
   <div class="availability_iframe physical-holding-panel panel-body">
     <h5 class="online-panel-heading">Online</h5>
-    <div class="online-panel-body">
+    <div class="primo-online-panel-body">
       <% availability_link_partials.each do |partial| %>
         <%= render(partial) %>
       <% end %>


### PR DESCRIPTION
BL-477 Add styling to online availability display:
- Tan header
- even spacing
- borders between links
![screen shot 2018-06-11 at 11 25 53 am](https://user-images.githubusercontent.com/15167238/41241143-3f07bb28-6d6a-11e8-844a-a53cdc0218ef.png)
