### PR TITLE
No lowercase booleans

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -62,6 +62,8 @@ class CatalogController < ApplicationController
         "5<-2",
         URI.escape("6<90%")
           ],
+      "mm.autorelax" => "true",
+      lowercaseOperators: false,
       ps: "3",
       tie: "0.01",
       qf: %w[

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -45,10 +45,10 @@ RSpec.describe CatalogController, type: :controller do
 
   describe "using lower case boolen operators in normal search", :focus do
     render_views
-    let(:uppercase_and) { JSON.parse(get(:index, params: { q: "race AND education" }, format: :json).body)["response"]["pages"]["total_count"]}
+    let(:uppercase_and) { JSON.parse(get(:index, params: { q: "race AND education" }, format: :json).body)["response"]["pages"]["total_count"] }
     let(:lowercase_and) { JSON.parse(get(:index, params: { q: "race and education" }, format: :json).body)["response"]["pages"]["total_count"] }
 
-    it 'returns more results that using uppercase boolean' do
+    it "returns more results that using uppercase boolean" do
       expect(lowercase_and).to be > uppercase_and
     end
   end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CatalogController, type: :controller do
     end
   end
 
-  describe "using lower case boolen operators in normal search", :focus do
+  describe "using lower case boolen operators in normal search" do
     render_views
     let(:uppercase_and) { JSON.parse(get(:index, params: { q: "race AND education" }, format: :json).body)["response"]["pages"]["total_count"] }
     let(:lowercase_and) { JSON.parse(get(:index, params: { q: "race and education" }, format: :json).body)["response"]["pages"]["total_count"] }

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -43,4 +43,13 @@ RSpec.describe CatalogController, type: :controller do
     end
   end
 
+  describe "using lower case boolen operators in normal search", :focus do
+    render_views
+    let(:uppercase_and) { JSON.parse(get(:index, params: { q: "race AND education" }, format: :json).body)["response"]["pages"]["total_count"]}
+    let(:lowercase_and) { JSON.parse(get(:index, params: { q: "race and education" }, format: :json).body)["response"]["pages"]["total_count"] }
+
+    it 'returns more results that using uppercase boolean' do
+      expect(lowercase_and).to be > uppercase_and
+    end
+  end
 end


### PR DESCRIPTION
Don't treat lower-case "and", "not", "or" as boolean operators, only the upper-case versions. 