### PR TITLE
Extend the commit timeout.

### DIFF
--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -34,7 +34,7 @@ settings do
   # set this to be non-negative if threshold should be enforced
   provide "solr_writer.max_skipped", -1
   # extend commit timeout
-  provide "solr_writer.commit_timeout", 300
+  provide "solr_writer.commit_timeout", (15 * 60)
   provide "solr.url", solr_url
   provide "solr_writer.commit_on_close", "false"
 end


### PR DESCRIPTION
We had it at 300 seconds.  The default in traject is (10 * 60).
I'm extending it by 5 minutes from default to (15 * 60).