### PR TITLE
Index record availability and skip unavailable items.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,8 +100,10 @@ module ApplicationHelper
 
   def electronic_resource_link_builder(field)
     return if field.empty?
-    portfolio_pid, db_name, addl_info = field.split("|")
+    portfolio_pid, db_name, addl_info, availability = field.split("|")
+    return if availability == "Not Available"
     db_name ||= "Find it online"
+    addl_info = nil if addl_info&.empty?
     electronic_resource_list_item(portfolio_pid, db_name, addl_info)
   end
 

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -148,7 +148,7 @@ module Traject
       def extract_electronic_resource
         lambda do |rec, acc, context|
           rec.fields("PRT").each do |f|
-            selected_subfields = [f["a"], f["c"], f["g"]].compact.join("|")
+            selected_subfields = [f["a"], f["c"], f["g"], f["9"]].join("|")
             acc << selected_subfields
           end
           # Short circuit if PRT field present.

--- a/spec/fixtures/marc_files/url_field_examples.xml
+++ b/spec/fixtures/marc_files/url_field_examples.xml
@@ -21,6 +21,7 @@
       <subfield code="f">Access full text online.</subfield>
       <subfield code="d">MAIN</subfield>
       <subfield code="8">53377910870003811</subfield>
+      <subfield code="9">Available</subfield>
     </datafield>
     <datafield tag="PRT" ind1=" " ind2=" ">
       <subfield code="a">bar</subfield>
@@ -28,6 +29,7 @@
       <subfield code="f">Access full text online.</subfield>
       <subfield code="d">MAIN</subfield>
       <subfield code="8">53377910870003811</subfield>
+      <subfield code="9">Not Available</subfield>
     </datafield>
   </record>
   <record>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe ApplicationHelper, type: :helper do
         expect(electronic_resource_link_builder(field)).to have_text("Sample Text")
       end
     end
+
+    context "item is not available" do
+      let(:field) { "|||Not Available" }
+      it "skips items that are not available" do
+        expect(electronic_resource_link_builder(field)).to be_nil
+      end
+    end
   end
 
   describe "#check_for_full_http_link(args)" do

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe Traject::Macros::Custom do
         context "single PRT field to electronic_resource_display" do
           it "maps a single PRT field" do
             expect(subject.map_record(records[1])).to eq(
-              "electronic_resource_display" => ["foo"]
+              "electronic_resource_display" => ["foo|||"]
             )
           end
         end
@@ -377,7 +377,7 @@ RSpec.describe Traject::Macros::Custom do
         context "multiple PRT fields present" do
           it "maps a multiple PRT fields to electronic_resource_display" do
             expect(subject.map_record(records[2])).to eq(
-              "electronic_resource_display" => ["foo", "bar"]
+              "electronic_resource_display" => ["foo|||Available", "bar|||Not Available"]
             )
           end
         end
@@ -421,14 +421,14 @@ RSpec.describe Traject::Macros::Custom do
         context "856 field has exception" do
           it "only maps the PRT field to electronic_resource_display" do
             expect(subject.map_record(records[7])).to eq(
-              "electronic_resource_display" => ["foo"]
+              "electronic_resource_display" => ["foo|||"]
             )
           end
         end
         context "856 has no exception" do
           it "only maps the PRT field to electronic_resource_display" do
             expect(subject.map_record(records[8])).to eq(
-              "electronic_resource_display" => ["foo"]
+              "electronic_resource_display" => ["foo|||"]
             )
           end
         end
@@ -540,7 +540,7 @@ RSpec.describe Traject::Macros::Custom do
       context "multiple PRT fields present" do
         it "reverses the order of multipe PRT fields" do
           expect(subject.map_record(records[2])).to eq(
-            "url_more_links_display" => ["bar", "foo"]
+            "url_more_links_display" => ["bar|||Not Available", "foo|||Available"]
           )
         end
       end


### PR DESCRIPTION
REF BL-480
* Updates the traject indexer configuration to capture a record's
availability.
* Skips building a link to unavailable records.
* Removes premature compact of data that breaks structural integrity of
the electronic_resource_display field.