### PR TITLE
Do not use four_digit_year method unnecessarily.

### DIFF
--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -342,9 +342,9 @@ module Traject
           rec.fields(["008"]).each do |field|
             # [TODO] date_pub_status for future use. How should we display date data depending on value of date_pub_status?
             date_pub_status = Traject::TranslationMap.new("marc_date_type_pub_status")[field.value[6]]
-            date1 = four_digit_year(field.value[7..10])
+            date1 = field.value[7..10]
             # [TODO] date2 for future use. How should we display dates if there are a date1 and date2?
-            date2 = four_digit_year(field.value[11..14])
+            date2 = field.value[11..14]
             acc << date1 unless date1.nil?
           end
         end


### PR DESCRIPTION
When we were using 260 for date field there was some ambiguity about
where and what the four digit date was in the field.  Thus, a search of
the string was necessary.

However, now that we are using field 008, the four digit date is in
a very specific area per a standard.  Thus a search is not needed.

I'm not removing the method for now because it still may prove useful.
(But I'm also OK removing that method if that's a better choice).

@see https://www.loc.gov/marc/bibliographic/bd008.html