### PR TITLE
Fix not properly mapping fields in advanced search.

### DIFF
--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -58,7 +58,7 @@ module Blacklight::PrimoCentral
         build_query = (1..rows_count).map do |count|
           value = blacklight_params["q_#{count}"]
           precision = blacklight_params["operator_#{count}"]
-          field = blacklight_params["f_#{count}"]
+          field = to_primo_field(blacklight_params["f_#{count}"])
           operator = blacklight_params["op_#{count}"]
 
           if !value&.empty? && !value.nil?
@@ -122,6 +122,7 @@ module Blacklight::PrimoCentral
           isbn_t: :isbn,
           issn_t: :issn,
           subject: :sub,
+          description: :desc,
         }
           .with_indifferent_access
           .fetch(field, field) || :any

--- a/spec/models/primo_search_builder_spec.rb
+++ b/spec/models/primo_search_builder_spec.rb
@@ -61,7 +61,16 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new(q_1: "foo") }
 
       it "properly sets a query to be a build query" do
-        expected = [{ "value" => "foo", "field" => nil, "precision" => nil, "operator" => nil }]
+        expected = [{ "value" => "foo", "field" => :any, "precision" => nil, "operator" => nil }]
+        expect(primo_central_parameters["query"]["q"]["value"]).to eq(expected)
+      end
+    end
+
+    context "description field is used in advanced setting" do
+      let(:params) { ActionController::Parameters.new(q_1: "foo", f_1: "description") }
+
+      it "properly maps description to desc" do
+        expected = [{ "value" => "foo", "field" => :desc, "precision" => nil, "operator" => nil }]
         expect(primo_central_parameters["query"]["q"]["value"]).to eq(expected)
       end
     end
@@ -78,7 +87,7 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new(q_1: "foo", q_2: "") }
 
       it "should skip empty advanced queries" do
-        expected = [{ "value" => "foo", "field" => nil, "precision" => nil, "operator" => nil }]
+        expected = [{ "value" => "foo", "field" => :any, "precision" => nil, "operator" => nil }]
         expect(primo_central_parameters["query"]["q"]["value"]).to eq(expected)
       end
     end


### PR DESCRIPTION
REF BL-398

Because we are not properly mapping fields in the advanced search
context we are seeing either failing searches or getting odd results.

This commit fixes that issue by making sure the filter is applied in the
advanced search context and adding a map from `description` to `desc`

TODO: Add add maps in Primo gem.