### PR TITLE
Remove basic search bar from advance searches.

### DIFF
--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -91,3 +91,7 @@ a.advanced_search {
 	font-weight: bold;
 	letter-spacing: 1px;
 }
+
+.header-advanced-search-link div.navbar-form {
+  margin-left: 0;
+}

--- a/app/views/advanced/_search_form.html.erb
+++ b/app/views/advanced/_search_form.html.erb
@@ -1,0 +1,3 @@
+<div class="header-advanced-search-link">
+  <%= render "advanced_search_link" %>
+</div>

--- a/app/views/application/_search_form.html.erb
+++ b/app/views/application/_search_form.html.erb
@@ -1,0 +1,1 @@
+../catalog/_search_form.html.erb

--- a/app/views/primo_advanced/_search_form.html.erb
+++ b/app/views/primo_advanced/_search_form.html.erb
@@ -1,0 +1,1 @@
+../advanced/_search_form.html.erb

--- a/app/views/primo_advanced/index.html.erb
+++ b/app/views/primo_advanced/index.html.erb
@@ -4,7 +4,6 @@
 
     <h2 class="advanced page-header">
         <%= t("blacklight_advanced_search.articles_title") %>
-        <%= link_to t("blacklight_advanced_search.form.start_over"), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-default pull-right advanced-search-start-over" %>
     </h2>
 
     <div class="row">

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -18,6 +18,6 @@
 </div>
 <div id="search-navbar" class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="<%= container_classes %>">
-    <%= render_search_bar  %>
+    <%= render "search_form"  %>
   </div>
 </div>


### PR DESCRIPTION
REF BL-486

* Removes the basic search bar from the advanced/articles_advance pages.
* Removes top "Start Over" button from articles_advance page.