### PR TITLE
Configure email.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,15 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: "temple.edu",
+    user_name: "books@temple.edu",
+    password: ENV["BOOKS_AT_TEMPLE_PASSWORD"],
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true


### PR DESCRIPTION
REF BL-241

Depends on setting BOOKS_AT_TEMPLE_PASSWORD environment variable.

To test configuration locally:

* Open up the `rails console` and add the following:

```ruby
Rails.application.configure do
  config.action_mailer.smtp_settings = {
    address: "smtp.gmail.com",
    port: 587,
    domain: "temple.edu",
    user_name: "books@temple.edu",
    password: "NOT_THIS_PASSWORD_THE_REAL_ONE",
    authentication: :plain,
    enable_starttls_auto: true
  }
end

ActionMailer::Base.mail({
  from: "books.temple.edu",
  to: "your_email_hear",
  subject: "Test",
  body: "Test",
}).deliver_now

```