### PR TITLE
Allow two minutes to read network files.

### DIFF
--- a/lib/oai/alma.rb
+++ b/lib/oai/alma.rb
@@ -29,7 +29,7 @@ module Oai
         loop do
           logger.info("Retrieving #{oai_url}")
           puts "Retrieving #{oai_url}"
-          response = HTTParty.get(oai_url)
+          response = HTTParty.get(oai_url, timeout: 120)
           oai = Nokogiri::XML(response.body)
           tmp_path = File.join(Rails.root, "tmp", "alma", "oai")
           FileUtils::mkdir_p tmp_path
@@ -44,6 +44,7 @@ module Oai
       rescue => e
         logger.fatal("Fatal Error")
         logger.fatal(e)
+        exit(1)
       end
       harvest_files
     end


### PR DESCRIPTION
Update the read timeout for harvest task to 2 minutes.

The harvest task uses HTTParty which in turn uses the Net::HTTP default
of 60 seconds.

This commit doubles the default read timeout to 120 seconds.

Also, this commit forces an exit if harvest throws an error which should
fix the false positive we see on network errors.