### PR TITLE
Raise exception for article id search not found.

### DIFF
--- a/app/models/blacklight/primo_central/repository.rb
+++ b/app/models/blacklight/primo_central/repository.rb
@@ -37,6 +37,10 @@ module Blacklight::PrimoCentral
           facet_counts: response["facets"].length,
           numFound: response["info"]["total"]
         )
+      else
+        if response.count == 1
+          raise Blacklight::Exceptions::RecordNotFound
+        end
       end
 
       blacklight_config.response_model.new(response, data, response_opts)


### PR DESCRIPTION
In order to hook into the 404 status for article ids that are not found
we need to raise a Blacklight::Exceptions::RecordNotFound exception;
Otherwise, a nonsensical page is rendered to the user.