### PR TITLE
Add custom meta data to catalog email record.

### DIFF
--- a/app/models/concerns/blacklight/document/email.rb
+++ b/app/models/concerns/blacklight/document/email.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# This module provides the body of an email export based on the document's semantic values
+module Blacklight::Document::Email
+  # Return a text string that will be the body of the email
+  # Overridden in order to add our own custom fields to email text.
+  def to_email_text
+    semantics = to_semantic_values
+    body = []
+    [ "title", "imprint", "author",
+      "contributor", "isbn", "issn", "alma_mms" ].each do |field|
+      if !semantics[field.to_sym].blank?
+        value = semantics[field.to_sym]
+        label = "blacklight.email.text.#{field}"
+        body << I18n.t(label, value: value.join(" "))
+      end
+    end
+
+    return body.join("\n") unless body.empty?
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -4,6 +4,17 @@ class SolrDocument
   include Blacklight::Solr::Document
 
   # self.unique_key = 'id'
+  field_semantics.merge!(
+    title: "title_statement_display" ,
+    imprint: "imprint_display",
+    author: "creator_display",
+    contributor: "contributor_display",
+    isbn: "isbn_display",
+    issn: "issn_display",
+    language: "language_display",
+    format: "format",
+    alma_mms: "alma_mms_display",
+  )
 
   # Email uses the semantic field mappings below to generate the body of an email.
   SolrDocument.use_extension(Blacklight::Document::Email)

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -28,6 +28,13 @@ en:
       librarian_view:
         title: "Staff View"
 
+    email:
+      text:
+        imprint: "Imprint: %{value}"
+        contributor: "Contributor: %{value}"
+        issn: "ISSN: %{value}"
+        isbn: "ISBN: %{value}"
+        alma_mms: "MMS: %{value}"
     sms:
       form:
         title: "Text This"


### PR DESCRIPTION
REF BL-500

Unfortunately the way to add fields to emails and sms differs from the
standard way of adding fields in other contexts.

I've created a BL issue to address this. But because that work may
likely introduce some backwards incompatibility, I decided to implement
this change in the non standard way and I may in the future refactor
this work to add the fields via the catalog controller per change in BL.

see https://github.com/projectblacklight/blacklight/issues/1923