### PR TITLE
Add sorting fields to articles.

### DIFF
--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -69,6 +69,13 @@ class PrimoCentralController < CatalogController
     config.add_show_field :lccn, label: "LCCN"
     config.add_show_field :doi, label: "DOI"
     config.add_show_field :languageId, label: "Language", multi: true, helper_method: :doc_translate_language_code
+
+    # Sort fields
+    config.add_sort_field :rel, label: "relevance"
+    config.add_sort_field :title, label: "title (A to Z)"
+    config.add_sort_field :creator, label: "author/creator (A to Z)"
+    config.add_sort_field :date, label: "date (new to old)"
+    config.add_sort_field :date2, label: "date (old to new)"
   end
 
   def render_sms_action?(_config, _options)

--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -19,6 +19,7 @@ module Blacklight::PrimoCentral
           primo_central_parameters[:query] = {
             limit: per_page,
             offset:  offset,
+            view: "full",
             q: { value: queries },
           }
         else
@@ -58,6 +59,10 @@ module Blacklight::PrimoCentral
     end
 
     def set_query_sort_order(primo_central_parameters)
+      if blacklight_params[:sort] && blacklight_params[:sort] != "rel"
+        sort = blacklight_params[:sort]
+        primo_central_parameters[:query][:sort] = sort
+      end
     end
 
     def process_advanced_search(primo_central_parameters)


### PR DESCRIPTION
REF BL-514

Adds sorting to article searches.  The fields used are the same as what
is currently available in the catalog search.

I've implemented this as per the (limited) documentation on the API. As
far as I can tell it does not seem to work as I would expect it.  I'm
hoping there is a configuration change we can make on the API itself to
make the sorting better.

I read the following documentation (not pnxs specific) that leads me to
believe sorting can only happen with the full view API so I'm making
sure to make that the default for our search:

https://knowledge.exlibrisgroup.com/Primo/Knowledge_Articles/Default_sorting_in_Primo_Brief_Result_List

Never the less, I don't think it made much of a difference.

This may be an API bug we will have to address with ExLibris.