### PR TITLE
Exclude basic search fields from advanced search.

### DIFF
--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -4,12 +4,12 @@
   <% unless (search_context_str = render_search_to_s( advanced_search_context)).blank? %>
       <div class="constraints well search_history">
         <h4><%= t 'blacklight_advanced_search.form.search_context' %></h4>
-        <%= search_context_str %>
+        <%= search_context_str.to_s %>
       </div>
     <% end %>
 
 
-  <%= render_hash_as_hidden_fields(search_state.params_for_search(advanced_search_context)) %>
+  <%= render_hash_as_hidden_fields(advanced_search_context) %>
 
   <div id="advanced_search" class="form-group">
     <%= render 'advanced/advanced_search_fields' %>


### PR DESCRIPTION
REF BL-509

@see also:
https://github.com/projectblacklight/blacklight_advanced_search/pull/81

Fixes issue where advanced search gets polluted with basic search
params.