### PR TITLE
Add back div removed by mistake.

### DIFF
--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -6,5 +6,7 @@
       <%= image_tag default_cover_image(document), :class => "default" %>
     <% end %>
   </div>
-  <%= render "fields", document: document, document_counter: document_counter %>
+  <div class="book_info col-sm-9 col-lg-10">
+    <%= render "fields", document: document, document_counter: document_counter %>
+  </div>
 </div>


### PR DESCRIPTION
REF BL-512

This div was removed by mistake when refactoring index fields view in
order to re-use inside of the bento more search.