### PR TITLE
Redirect user to "users/account" after login.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,4 +42,15 @@ class ApplicationController < ActionController::Base
       !response.spelling.nil? &&
       response.spelling.words.any?
   end
+
+  protected
+    def after_sign_in_path_for(resource)
+      sign_in_url = helpers.new_user_with_redirect_path
+      if request.referer == sign_in_url ||
+          request.referer == request.env["HTTP_ORIGIN"] + sign_in_url
+        super
+      else
+        stored_location_for(resource) || request.referer || root_path
+      end
+    end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Users
+  class SessionsController < Devise::SessionsController
+    def new
+      self.resource = resource_class.new(sign_in_params)
+      store_location_for(resource, params[:redirect_to])
+      super
+    end
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -12,4 +12,8 @@ module UsersHelper
     options[:disabled] = true unless loan.renewable?
     options
   end
+
+  def new_user_with_redirect_path(redirect = request.url)
+    new_user_session_path(redirect_to: redirect)
+  end
 end

--- a/app/views/shared/_nav_bar_login_links.html.erb
+++ b/app/views/shared/_nav_bar_login_links.html.erb
@@ -4,6 +4,6 @@
     </li>
 <% else %>
     <li>
-    <%= link_to t('blacklight.header_links.login'), new_user_with_redirect_path("/users/account") %>
+    <%= link_to t('blacklight.header_links.login'), new_user_with_redirect_path(users_account_path) %>
     </li>
 <% end %>

--- a/app/views/shared/_nav_bar_login_links.html.erb
+++ b/app/views/shared/_nav_bar_login_links.html.erb
@@ -4,6 +4,6 @@
     </li>
 <% else %>
     <li>
-      <%= link_to t('blacklight.header_links.login'), new_user_session_path %>
+    <%= link_to t('blacklight.header_links.login'), new_user_with_redirect_path("/users/account") %>
     </li>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,10 @@ Rails.application.routes.draw do
     post :stop_impersonating, on: :collection
   end
 
-  devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
+  devise_for :users, controllers: {
+    omniauth_callbacks: "users/omniauth_callbacks",
+    sessions: "users/sessions"
+  }
 
   # auth
   authenticate do


### PR DESCRIPTION
REF BL-522

This commit adds a way to generate login forms that can dynamically
redirect the user to a specified path.

The current default redirect path for the My Accounts link has been set to
"/users/account".