### PR TITLE
Monitor articles not found.

### DIFF
--- a/app/models/blacklight/primo_central/repository.rb
+++ b/app/models/blacklight/primo_central/repository.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+class ArticleNotFound < RuntimeError
+end
+
 module Blacklight::PrimoCentral
   class Repository < Blacklight::AbstractRepository
     def find(id, params = {})
@@ -39,7 +42,7 @@ module Blacklight::PrimoCentral
         )
       else
         if response.count == 1
-          raise Blacklight::Exceptions::RecordNotFound
+          raise ArticleNotFound
         end
       end
 


### PR DESCRIPTION
REF BL-536

There are times when a valid id may not be returning articles from the pnx
api.  We want to monitor these events to be able to report issue.

This commit updates the exception thrown when an article is not found so
that the controller does not gracefully handle the event and the
exception gets sent to honeybadger.