### PR TITLE
Make the min must match tighter.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -65,9 +65,8 @@ class CatalogController < ApplicationController
       echoParams: "explicit",
       rows: "10",
       mm: [
-        "2<-1",
-        "5<-2",
-        URI.escape("6<90%")
+       "5<-1",
+        URI.escape("8<90%")
           ],
       "mm.autorelax" => "true",
       lowercaseOperators: false,

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CatalogController, type: :controller do
 
   describe "using lower case boolen operators in normal search" do
     render_views
-    let(:uppercase_and) { JSON.parse(get(:index, params: { q: "race affirmative action AND higher education n" }, format: :json).body)["response"]["pages"]["total_count"] }
+    let(:uppercase_and) { JSON.parse(get(:index, params: { q: "race affirmative action AND higher education" }, format: :json).body)["response"]["pages"]["total_count"] }
     let(:lowercase_and) { JSON.parse(get(:index, params: { q: "race affirmative action and higher education " }, format: :json).body)["response"]["pages"]["total_count"] }
 
     it "returns more results that using uppercase boolean" do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe CatalogController, type: :controller do
 
   describe "using lower case boolen operators in normal search" do
     render_views
-    let(:uppercase_and) { JSON.parse(get(:index, params: { q: "race AND education" }, format: :json).body)["response"]["pages"]["total_count"] }
-    let(:lowercase_and) { JSON.parse(get(:index, params: { q: "race and education" }, format: :json).body)["response"]["pages"]["total_count"] }
+    let(:uppercase_and) { JSON.parse(get(:index, params: { q: "race affirmative action AND higher education n" }, format: :json).body)["response"]["pages"]["total_count"] }
+    let(:lowercase_and) { JSON.parse(get(:index, params: { q: "race affirmative action and higher education " }, format: :json).body)["response"]["pages"]["total_count"] }
 
     it "returns more results that using uppercase boolean" do
       expect(lowercase_and).to be > uppercase_and


### PR DESCRIPTION
Improves known item searching.

This broke one test, which had to be tweaked to continue working