### PR TITLE
Do not render articles bento box if results are empty.

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -10,9 +10,16 @@ module SearchHelper
     search_catalog_url(search_state.add_facet_params_and_redirect(facet_field, item))
   end
 
-  def empty_resource_types?(result)
+  def renderable_results
+    @results.select { |engine_id, result| render_search? result }
+  end
+
+  def render_search?(result)
     engine_id = result.engine_id
-    (engine_id == "more" || engine_id == "resource_types") && total_items(result) == 0
+    ! ((engine_id == "more" ||
+        engine_id == "resource_types" ||
+        engine_id == "articles") &&
+       total_items(result) == 0)
   end
 
   def bento_titleize(id)

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,5 +1,5 @@
     <% if @results %>
-    <% if !cookies.fetch("bentoOnce", false) %>
+      <% if !cookies.fetch("bentoOnce", false) %>
         <div class="row" data-target="explanation.bento" data-controller="explanation">
           <div class="col-md-6 col-md-offset-3">
             <p>
@@ -13,15 +13,13 @@
         </div>
       <% end %>
       <div class="row bento-results">
-        <% @results.each_pair do |engine_id, result| %>
-          <% unless empty_resource_types?(result) %>
+        <% renderable_results.each_pair do |engine_id, result| %>
           <div class="col-xl-3 col-lg-3 col-md-3 col-sm-8 col-xs-12 bento_compartment <%= engine_id %>">
-                  <h2><%= bento_icons(engine_id) %><%= bento_titleize(engine_id) %> </h2>
-                  <%= render :layout => "layouts/bento_box_wrapper", :locals => {:results => result } do %>
-                      <%= bento_search result %>
-                  <% end %>
-                </div>
-          <% end %>
+            <h2><%= bento_icons(engine_id) %><%= bento_titleize(engine_id) %> </h2>
+            <%= render :layout => "layouts/bento_box_wrapper", :locals => {:results => result } do %>
+              <%= bento_search result %>
+            <% end %>
+          </div>
         <% end %>
       </div>
     <% else %>


### PR DESCRIPTION
REF BL-529

Refactors code to remove logic that limits boxes that get rendered when no
results are returned to happen in helper method instead of directly in
the template.