### PR TITLE
Add validations for request forms

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -64,16 +64,16 @@ class AlmawsController < ApplicationController
       item_pid: params[:item_pid],
     }
     @request_level = params[:request_level]
-      if @request_level == "bib"
-        request = Alma::BibRequest.submit(bib_options)
-      else
-        request = Alma::ItemRequest.submit(item_options)
-      end
+    if @request_level == "bib"
+      request = Alma::BibRequest.submit(bib_options)
+    else
+      request = Alma::ItemRequest.submit(item_options)
+    end
 
-      if request.success?
-        flash[:success] = "Your request has been submitted."
-        redirect_back(fallback_location: root_path)
-      end
+    if request.success?
+      flash[:success] = "Your request has been submitted."
+      redirect_back(fallback_location: root_path)
+    end
   end
 
   def send_booking_request

--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -35,10 +35,10 @@ class AlmawsController < ApplicationController
     else
       @request_options = Alma::RequestOptions.get(@mms_id, user_id: @user_id)
     end
-    end
+  end
 
   def send_hold_request
-    not_needed_date = DateTime.new(params[:last_interest_date]["year"].to_i, params[:last_interest_date]["month"].to_i, params[:last_interest_date]["day"].to_i)
+    not_needed_date = Date.strptime(params[:last_interest_date], "%Y-%m-%d")
     bib_options = {
     mms_id: params[:mms_id],
     user_id: current_user.uid,
@@ -64,21 +64,21 @@ class AlmawsController < ApplicationController
       item_pid: params[:item_pid],
     }
     @request_level = params[:request_level]
-    if @request_level == "bib"
-      request = Alma::BibRequest.submit(bib_options)
-    else
-      request = Alma::ItemRequest.submit(item_options)
-    end
+      if @request_level == "bib"
+        request = Alma::BibRequest.submit(bib_options)
+      else
+        request = Alma::ItemRequest.submit(item_options)
+      end
 
-    if request.success?
-      flash[:success] = "Your request has been submitted."
-      redirect_back(fallback_location: root_path)
-    end
+      if request.success?
+        flash[:success] = "Your request has been submitted."
+        redirect_back(fallback_location: root_path)
+      end
   end
 
   def send_booking_request
-    start_date = DateTime.new(params[:booking_start_date]["year"].to_i, params[:booking_start_date]["month"].to_i, params[:booking_start_date]["day"].to_i)
-    end_date = DateTime.new(params[:booking_end_date]["year"].to_i, params[:booking_end_date]["month"].to_i, params[:booking_end_date]["day"].to_i)
+    start_date = Date.strptime(params[:booking_start_date], "%Y-%m-%d")
+    end_date = Date.strptime(params[:booking_end_date], "%Y-%m-%d")
     bib_options = {
     mms_id: params[:mms_id],
     user_id: current_user.uid,
@@ -118,29 +118,40 @@ class AlmawsController < ApplicationController
   end
 
   def send_digitization_request
-    not_needed_date = DateTime.new(params[:last_interest_date]["year"].to_i, params[:last_interest_date]["month"].to_i, params[:last_interest_date]["day"].to_i)
+    not_needed_date = Date.strptime(params[:last_interest_date], "%Y-%m-%d")
     partial = params[:partial_or_full] == "true" ? true : false
-    options = {
+    bib_options = {
     mms_id: params[:mms_id],
     user_id: current_user.uid,
-    holding_id: params[:holding_id],
-    item_pid: params[:item_pid],
     chapter_or_article_title: params[:chapter_or_article_title],
     chapter_or_article_author: params[:chapter_or_article_author],
-    description: params[:description],
     request_type: "DIGITIZATION",
     target_destination: { value: "DIGI_DEPT_INST" },
     partial_digitization: partial,
     last_interest_date: not_needed_date,
     comment: params[:comment]
     }
+
+    item_options = {
+      mms_id: params[:mms_id],
+      user_id: current_user.uid,
+      holding_id: params[:holding_id],
+      item_pid: params[:item_pid],
+      chapter_or_article_title: params[:chapter_or_article_title],
+      chapter_or_article_author: params[:chapter_or_article_author],
+      description: params[:description],
+      request_type: "DIGITIZATION",
+      target_destination: { value: "DIGI_DEPT_INST" },
+      partial_digitization: partial,
+      last_interest_date: not_needed_date,
+      comment: params[:comment]
+    }
     @request_level = params[:request_level]
     if @request_level == "bib"
-      request = Alma::BibRequest.submit(options)
+      request = Alma::BibRequest.submit(bib_options)
     else
-      request = Alma::ItemRequest.submit(options)
+      request = Alma::ItemRequest.submit(item_options)
     end
-
     if request.success?
       flash[:success] = "Your request has been submitted."
       redirect_back(fallback_location: root_path)

--- a/app/javascript/packs/controllers/form_controller.js
+++ b/app/javascript/packs/controllers/form_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = [ ]
+
+  connect() {
+    this.booking_end_date()
+  }
+
+  initialize() {
+    this.required()
+  }
+
+  required() {
+    $("form input:radio").change(function() {
+      if ($("#partial_or_full_true").is(":checked")) {
+        $("#digitization-request-form #comment").attr("required", "required");
+      } else {
+        $("#digitization-request-form #comment").removeAttr("required");
+      }
+    });
+  }
+
+  booking_end_date() {
+    $('#booking_start_date').change(function() {
+      let dt = new Date($('#booking_start_date').val());
+      dt.setDate(dt.getDate() + 8);
+      let end = dt.toISOString().split("T")[0]
+      $('#booking_end_date').prop('min', $('#booking_start_date').val());
+      $('#booking_end_date').prop('max', end);
+    });
+  }
+}

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: booking_request_path, local: true, class: 'form-horizontal request-form', method: :post do |form| %>
-  <div class="container">
+  <div class="container" data-controller="form">
     <%= form.hidden_field :mms_id, value: params[:mms_id] %>
     <%= form.hidden_field :holding_id, value: @holding_id %>
     <%= form.hidden_field :item_pid, value: @item_pid %>
@@ -9,13 +9,13 @@
     <div class="row">
       <div class="col-sm-4 hold-form">
         <%= label("", :pickup_location, "Pickup Location:") %>
-        <%= select("", :pickup_location, @booking_location.collect { |lib| [ lib.last, lib.first ] }, {include_blank: true, required: true}, {class: "request-form form-control"}) %>
+        <%= select("", :pickup_location, @booking_location.collect { |lib| [ lib.last, lib.first ] }, {class: "request-form form-control"}, {include_blank: true, required: true}) %>
       </div>
     </div>
     <div class="row">
       <div class="col-sm-4 hold-form">
         <%= label("", :material_type, "Material Type:") %>
-        <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, required: true}, {class: "request-form form-control"}) %>
+        <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {class: "request-form form-control"}, {include_blank: true, required: true}) %>
       </div>
     </div>
 
@@ -31,14 +31,14 @@
     <div class="row hold-form">
       <div class="col-sm-5">
         <%= form.label(:booking_start_date, "Booking Start Date:") %>
-        <%= select_date Date.tomorrow, prefix: :booking_start_date %>
+        <%= date_field_tag :booking_start_date, "", min: Date.tomorrow, required: true %>
       </div>
     </div>
 
     <div class="row hold-form">
       <div class="col-sm-5">
         <%= form.label(:booking_end_date, "Booking End Date:") %>
-        <%= select_date Date.tomorrow, prefix: :booking_end_date %>
+        <%= date_field_tag :booking_end_date, "", required: true %>
       </div>
     </div>
 

--- a/app/views/almaws/_digitization_request_form.html.erb
+++ b/app/views/almaws/_digitization_request_form.html.erb
@@ -7,7 +7,7 @@
   <%= form.hidden_field :request_level, value: @request_level %>
 
 
-  <div class="container">
+  <div class="container" data-controller="form">
     <div class="form-group row">
       <div class="col-sm-4">
         <%= form.label(:chapter_or_article_title, "Chapter/Article Title:", class: "col-form-label") %>
@@ -46,24 +46,24 @@
     <div class="form-group row">
       <div class="col-sm-5">
         <%= form.label(:last_interest_date, "Not Needed After (optional):") %>
-        <%= select_date Date.today, prefix: :last_interest_date %>
+        <%= date_field_tag :last_interest_date, Date.today() + 10 %>
       </div>
     </div>
 
     <div class="form-group row">
       <div class="col-sm-4">
-        <%= form.label(:comment, "Notes: (optional)") %>
-        <%= form.text_area :comment, class: "request-form form-control" %>
+        <%= form.label(:comment, "Notes: (Required for partial requests)") %>
+        <%= form.text_area :comment, class: "request-form form-control", required: true %>
       </div>
     </div>
 
-    <div class="form-group row">
+    <div class="form-group row partial_or_full">
       <div class="col-sm-2 ">
         <%= radio_button_tag(:partial_or_full, "true", checked: true) %>
         <%= form.label(:partial_or_full_Partial, "Partial", class: "form-radio-label") %>
       </div>
 
-      <div class="col-sm-2">
+      <div class="col-sm-3">
         <%= radio_button_tag(:partial_or_full, "false") %>
         <%= form.label(:partial_or_full_Full_Chapter, "Full Chapter", class: "form-radio-label") %>
       </div>

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -1,5 +1,6 @@
-<%= form_with url: hold_request_path, local: true, id: "hold-request-form", class: 'form-horizontal request-form', method: :post do |form| %>
-  <div class="container">
+<%= form_with url: hold_request_path, remote: true, id: "hold-request-form", class: 'form-horizontal request-form', method: :post do |form| %>
+  <div class="container" data-controller="form">
+
     <%= form.hidden_field :mms_id, value: params[:mms_id] %>
     <%= form.hidden_field :holding_id, value: @holding_id %>
     <%= form.hidden_field :item_pid, value: @item_pid %>
@@ -9,7 +10,7 @@
     <div class="row">
       <div class="col-sm-4 hold-form">
         <%= label("", :pickup_location, "Pickup Location:") %>
-        <%= select("", :pickup_location, @pickup_locations.collect { |lib| [ lib.values.first, lib.keys.first ] }, {include_blank: true, required: true}, {class: "request-form form-control"}) %>
+        <%= select("", :pickup_location, @pickup_locations.collect { |lib| [ lib.values.first, lib.keys.first ] }, {class: "request-form form-control"}, {include_blank: true, required: true }) %>
       </div>
     </div>
 
@@ -25,7 +26,7 @@
     <div class="row hold-form">
       <div class="col-sm-5">
         <%= form.label(:not_needed, "Not Needed After (optional):") %>
-        <%= select_date Date.today, prefix: :last_interest_date %>
+        <%= date_field_tag :last_interest_date, Date.today() + 10 %>
       </div>
     </div>
 


### PR DESCRIPTION
Adds browser validations to request forms
- Hold: pickup location, description (if present) are both required
- Booking: start date and end date (dates must be in the future and end date not greater than 8 days after start date), pickup location, material type
- Digitization: title, author, start page, end page, comments(only if partial is selected)