### PR TITLE
Refix shibboleth login redirect

### DIFF
--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -15,7 +15,7 @@
             <button class="btn btn-primary request-button" data-action="requests#hold">Request</button>
             <div id="stimulus-modal" data-target="requests.modal"></div>
           <% else %>
-            <%= link_to(t("blacklight.requests.log_in"), new_user_session_with_redirect_path(@redirect_to),  data: {"ajax-modal": "trigger"}) %>            <%# TODO: Redirect back to this page %>
+            <%= link_to(t("blacklight.requests.log_in"), new_user_session_with_redirect_path(request.url),  data: {"ajax-modal": "trigger"}) %>            <%# TODO: Redirect back to this page %>
           <% end %>
         </div>
       </div>

--- a/spec/features/indices_spec.rb
+++ b/spec/features/indices_spec.rb
@@ -6,7 +6,7 @@ require "traject/command_line"
 require "yaml"
 require "pry"
 
-RSpec.feature "Indices" do
+RSpec.feature "Indices, :focus" do
   let (:fixtures) {
     YAML.load_file("#{fixture_path}/features.yml")
   }
@@ -100,5 +100,13 @@ RSpec.feature "Indices" do
       expect(current_url).to eq item_url
       expect(page).to have_text(item["title"])
     end
+
+
+    scenario "Login link with proper redirect_to params are on search pages" do
+      pending("The expected href appears in the browser, but not in Capybara, ¯\\_(ツ)_/¯")
+      visit "catalog/#{item['doc_id']}"
+      expect(page).to find(:xpath, "//div[@id='requests-container']/a[contains(@href,'redirect_to')]")
+    end
+
   end
 end

--- a/spec/features/indices_spec.rb
+++ b/spec/features/indices_spec.rb
@@ -6,7 +6,7 @@ require "traject/command_line"
 require "yaml"
 require "pry"
 
-RSpec.feature "Indices, :focus" do
+RSpec.feature "Indices" do
   let (:fixtures) {
     YAML.load_file("#{fixture_path}/features.yml")
   }


### PR DESCRIPTION
This fixes the shibboleth redirect login, which was broken when we moved the rendering of the Request button outside the Availability panel. The requisite instance variable was no longer defined, so it was not providing any request info.

While I can reproduce the fix in the browser, I cannot get the fixed behavior to work in Capybara. The link never includes the `redirect_to` parameter. 🤷‍♂️ 

I've added a pending capybara test so we can come back to it, but grrrrrrrrr. 