### PR TITLE
Additional updates to bento UX.

### DIFF
--- a/app/assets/stylesheets/partials/_bento.scss
+++ b/app/assets/stylesheets/partials/_bento.scss
@@ -87,6 +87,12 @@
 	font-weight: bold;
 }
 
+.bento-results h2 a,
+.bento-results h2 a:hover,
+.bento-results h2 a:active {
+  color: black;
+}
+
 .total-results a,
 .online-only a,
 .bento_item_title a {

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,7 +5,7 @@ class SearchController < CatalogController
   include CatalogConfigReinit
 
   blacklight_config.configure do |config|
-    config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :separate_formats
+    config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :separate_formats, no_label: true
     config.add_facet_field "format", label: "Resource Type", url_method: :path_for_more_facet
   end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,7 +5,7 @@ class SearchController < CatalogController
   include CatalogConfigReinit
 
   blacklight_config.configure do |config|
-    config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :separate_formats, no_label: true
+    config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :index_translate_resource_type_code, no_label: true
     config.add_facet_field "format", label: "Resource Type", url_method: :path_for_more_facet
   end
 

--- a/app/helpers/primo_central_helper.rb
+++ b/app/helpers/primo_central_helper.rb
@@ -18,18 +18,20 @@ module PrimoCentralHelper
   end
 
   def doc_translate_language_code(presenter)
-    codes = presenter[:document][:languageId]
+    codes = presenter[:document][:languageId] || []
     codes.map { |c| translate_code(c, "language") }
   end
 
   def doc_translate_resource_type_code(presenter)
     codes = presenter[:document][:type]
-    codes.map { |c| translate_code(c, "resource_type") }
+    codes&.map { |c| translate_code(c, "resource_type") }
   end
 
   def index_translate_resource_type_code(presenter)
     codes = doc_translate_resource_type_code(presenter)
-    presenter[:document][:format] = codes
+    if codes
+      presenter[:document][:format] = codes
+    end
     separate_formats(presenter)
   end
 

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -10,20 +10,52 @@ module SearchHelper
     search_catalog_url(search_state.add_facet_params_and_redirect(facet_field, item))
   end
 
-  def renderable_results
-    @results.select { |engine_id, result| render_search? result }
+  def renderable_results(results = @results, options = {})
+    results.select { |engine_id, result| render_search?(result, options) }
   end
 
-  def render_search?(result)
-    engine_id = result.engine_id
-    ! ((engine_id == "more" ||
-        engine_id == "resource_types" ||
-        engine_id == "journals") &&
-       total_items(result) == 0)
+  def render_search?(result, options = {})
+    id = result.engine_id
+    !(["more", "resource_types", "journals"].include?(id) &&
+       total_items(result) == 0) &&
+    !(is_child_box?(id) && !options[:render_child_box])
   end
 
   def bento_titleize(id)
     engine = BentoSearch.get_engine(id)
     link_to id.titleize , engine.url(self)
+  end
+
+  def render_bento_results(results = @results, options = {})
+    results_class = options[:results_class] || "row bento-results"
+    comp_class = options[:comp_class] || "col-xl-3 col-lg-3 col-md-3 col-sm-8 col-xs-12 bento_compartment"
+    render partial: "bento_results", locals: {
+      results_class: results_class,
+      comp_class: comp_class,
+      results: results, options: options }
+  end
+
+  def render_linked_results(engine_id)
+    engine_ids = engine_display_configurations[engine_id][:linked_engines] || [] rescue []
+    results = @results.select { |id, result| engine_ids.include? id }
+    render_bento_results(results, render_child_box: true, results_class: "bento_results", comp_class: "bento_compartment")
+  end
+
+  def is_child_box?(id)
+    linked_engines.include? id
+  end
+
+  def linked_engines
+    engine_display_configurations.select { |id, config| config[:linked_engines] }
+      .map { |id, config| config[:linked_engines] }
+      .flatten
+  end
+
+
+  def engine_display_configurations
+    @engine_configurations ||= @results.map   { |engine_id, result|
+      config = BentoSearch.get_engine(engine_id).configuration[:for_display]
+      [engine_id, config]
+    }.to_h
   end
 end

--- a/app/views/bento_search/_std_item.html.erb
+++ b/app/views/bento_search/_std_item.html.erb
@@ -82,6 +82,9 @@
       <% end %>
 
       <% if item.engine_id == "articles" %>
+        <div class="bento_item_body">
+          <%= render partial: "fields", locals: { document: item.custom_data, document_counter: 0 } %>
+        </div>
         <%= render :partial => "primo_availability", :object => item, :as => 'item' %>
       <% end %>
 

--- a/app/views/bento_search/_std_item.html.erb
+++ b/app/views/bento_search/_std_item.html.erb
@@ -87,6 +87,5 @@
         </div>
         <%= render :partial => "primo_availability", :object => item, :as => 'item' %>
       <% end %>
-
   </div>
 <% end %>

--- a/app/views/catalog/_fields.html.erb
+++ b/app/views/catalog/_fields.html.erb
@@ -4,8 +4,10 @@
 <dl class="document-metadata dl-horizontal dl-invert">
 <% index_fields(document).each do |field_name, field| -%>
   <% if should_render_index_field? document, field %>
+    <% unless field[:no_label] %>
     <dt class="index-label blacklight-<%= field_name.parameterize %>"><%= render_index_field_label document, field: field_name %></dt>
     <dd class="blacklight-<%= field_name.parameterize %>">
+    <% end %>
       <% if field[:raw] %>
         <%= raw doc_presenter.field_value(field_name) %>
       <% else %>

--- a/app/views/search/_bento_results.html.erb
+++ b/app/views/search/_bento_results.html.erb
@@ -1,0 +1,11 @@
+<div class="<%= results_class %>">
+  <% renderable_results(results, options).each_pair do |engine_id, result| %>
+    <div class="<%= comp_class %> <%= engine_id %>">
+      <h2><%= bento_icons(engine_id) %><%= bento_titleize(engine_id) %> </h2>
+      <%= render :layout => "layouts/bento_box_wrapper", :locals => {:results => result } do %>
+        <%= bento_search result %>
+      <% end %>
+      <%= render_linked_results(engine_id) %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -12,16 +12,7 @@
           </div>
         </div>
       <% end %>
-      <div class="row bento-results">
-        <% renderable_results.each_pair do |engine_id, result| %>
-          <div class="col-xl-3 col-lg-3 col-md-3 col-sm-8 col-xs-12 bento_compartment <%= engine_id %>">
-            <h2><%= bento_icons(engine_id) %><%= bento_titleize(engine_id) %> </h2>
-            <%= render :layout => "layouts/bento_box_wrapper", :locals => {:results => result } do %>
-              <%= bento_search result %>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
+      <%= render_bento_results %>
     <% else %>
       <%= render("home_text") %>
     <% end %>

--- a/config/initializers/bento_search.rb
+++ b/config/initializers/bento_search.rb
@@ -27,6 +27,7 @@ BentoSearch.register_engine("more") do |conf|
   conf.engine = "BentoSearch::MoreEngine"
   conf.for_display do |display|
     display.decorator = "TulDecorator"
+    display.linked_engines = ["resource_types"]
   end
 end
 


### PR DESCRIPTION
REF BL-534

* Refactor to allow boxes to include linked boxes (children)
* Link "resource types" box to "more" box.
* Updates engine title link color to black
* Remove labels for type fields.
* Add type fields to Article items