### PR TITLE
Do not cache the xhr format of sign_in form.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,4 +4,10 @@ class SessionsController < Devise::SessionsController
   include Sessions::SocialLogin
 
   layout proc { |controller| false if request.xhr? }
+
+  # Overrides Devise::SessionsController#new.
+  def new
+    no_cache unless request.xhr?.nil?
+    super
+  end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SessionsController, type: :controller do
+  before(:each) do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+  end
+
+  describe "new session over ajax" do
+    it "should set headers not to cache" do
+      request.headers["X-Requested-With"] = "XMLHttpRequest"
+      request.headers["HTTP_ACCEPT"] = "*/*"
+      get :new
+
+      expect(response.headers["Cache-Control"]).to eq("no-cache, no-store")
+      expect(response.headers["Pragma"]).to eq("no-cache")
+      expect(response.headers["Expires"]).to eq("Fri, 01 Jan 1990 00:00:00 GMT")
+    end
+  end
+
+  describe "new session not over ajax" do
+    it "should not set no-cache headers" do
+      get :new
+      expect(response.headers["Pragma"]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
REF BL-565

The xhr format of the sign in form is the simple form we get in modal
context.  If the browser caches that before it caches the regular form,
then clicking the back button after logout from account page will bring
you back to a very simple page with a form in it (the modal context sign
in).

The expected behavior is that clicking the back button will bring you
to the regular sign in (non modal) page.  This is achieved by not allowing the
browser to cache the modal sign in page.