### PR TITLE
Fix bug with pickup locations

### DIFF
--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -63,12 +63,15 @@ module CobAlma
     end
 
     def self.equipment(items_list)
+      pickup_locations = []
       items_list.each do |item|
         if item.circulation_policy == "Equipment"
-          pickup_locations = [item.library, item.library_name]
+          pickup_locations << item.item_data.fetch("library")
+        else
+          pickup_locations = []
         end
-        pickup_locations
       end
+      pickup_locations
     end
 
     def self.descriptions(items_list)

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -7,7 +7,7 @@
     <%= form.hidden_field :user_id, value: @user_id %>
     <%= form.hidden_field :request_level, value: @request_level %>
 
-    <% unless @equipment %>
+    <% if @equipment.empty? %>
       <div class="row">
         <div class="col-sm-4 hold-form">
           <%= label("", :pickup_location, "Pickup Location:") %>
@@ -16,11 +16,11 @@
       </div>
     <% end %>
 
-    <% if @equipment %>
+    <% if @equipment.present? %>
       <div class="row">
         <div class="col-sm-4 hold-form">
           <%= label("", :pickup_location, "Pickup Location:") %>
-          <%= select("", :pickup_location, @equipment.collect { |lib| [ lib.library_name, lib.library ] }.uniq, {class: "request-form form-control"}, {include_blank: true, required: true, "aria-required": true }) %>
+          <%= select("", :pickup_location, @equipment.collect { |lib| [ lib.fetch("desc", ""), lib.fetch("value", "") ] }.uniq, {class: "request-form form-control"}, {include_blank: true, required: true, "aria-required": true }) %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Pickup locations were being limited to only owning library.  
- equipment should be limited to owning library
- all other resource types should default to valid pickup locations
