### PR TITLE
Bl-317 allows boundwith records to have availability shown and to be requested 

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -4,6 +4,7 @@ class AlmawsController < ApplicationController
   layout false
 
   def item
+    
     @mms_id = params[:mms_id]
     start = Time.now
     bib_items = Alma::BibItem.find(@mms_id, limit: 100)

--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -4,7 +4,6 @@ class AlmawsController < ApplicationController
   layout false
 
   def item
-    
     @mms_id = params[:mms_id]
     start = Time.now
     bib_items = Alma::BibItem.find(@mms_id, limit: 100)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -60,6 +60,7 @@ class CatalogController < ApplicationController
         isbn_display
         lccn_display
         url_finding_aid_display
+        bound_with_ids
       ].join(" "),
       defType: "edismax",
       echoParams: "explicit",
@@ -356,6 +357,8 @@ class CatalogController < ApplicationController
     config.add_show_field "language_display", label: "Language"
     config.add_show_field "url_more_links_display", label: "Other Links", helper_method: :check_for_full_http_link
     config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :check_for_full_http_link
+
+    config.add_show_field "bound_with_ids", display: false
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -5,7 +5,7 @@
 
   <% if document.fetch("availability_facet", []).include? "At the Library" %>
     <div class="row button-break"></div>
-    <div data-controller="availability" data-availability-url="<%= item_url(document.id, redirect_to: request.url) %>">
+    <div data-controller="availability" data-availability-url="<%= item_url(document.alma_availability_mms_ids.first, redirect_to: request.url) %>">
       <div class="controls">
         <button data-action="availability#item" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" class="btn btn-sm btn-default availability-toggle-details" data-toggle="collapse" data-target="#physical-document-<%=  document_counter %>, availability.button" id="available_button-<%=  document_counter %>">
           <span role="spin" aria-expanded="false">Loading...</span>
@@ -15,7 +15,7 @@
             <button id="request-btn-<%=  document_counter %>" class="btn btn-primary request-button" data-action="requests#hold">Request</button>
             <div id="stimulus-modal" data-target="requests.modal"></div>
           <% else %>
-            <%= link_to(t("blacklight.requests.log_in"), new_user_session_with_redirect_path(request.url),  data: {"ajax-modal": "trigger"}) %>            
+            <%= link_to(t("blacklight.requests.log_in"), new_user_session_with_redirect_path(request.url),  data: {"ajax-modal": "trigger"}) %>
           <% end %>
         </div>
       </div>

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -1,7 +1,7 @@
 <% doc_presenter = show_presenter(document) %>
 <%# partial to display availability details in catalog show view -%>
 <div class="col-sm-12">
-<div id="record-view-iframe" data-availability-id="<%= document.id %>" class="panel" data-controller="show" data-show-url="<%= item_url(document.id) %>">
+<div id="record-view-iframe" data-availability-id="<%= document.alma_availability_mms_ids.first %>" class="panel" data-controller="show" data-show-url="<%= item_url(document.alma_availability_mms_ids.first, redirect_to: request.url) %>">
   <div class="availability-panel-heading panel-heading">
     <h4 id="availability-heading" class="text-left">Availability</h4>
     <div id="heading-request">
@@ -20,7 +20,7 @@
   <%= render_online_availability(doc_presenter) %>
 
   <% if document.fetch("availability_facet", []).include?("At the Library") %>
-    <div data-show-url="<%= item_url(document.id, redirect_to: request.url) %>" class="physical-holding-panel panel-body">
+    <div data-show-url="<%= item_url(document.alma_availability_mms_ids.first, redirect_to: request.url) %>" class="physical-holding-panel panel-body">
       <div class="panel-content" >
         <div id="avail-spinner" data-target="show.spinner" class="spinner">
           <span class="glyphicon glyphicon-refresh glyphicon-spin" role="spinbutton"></span>

--- a/bin/boundwith_process.rb
+++ b/bin/boundwith_process.rb
@@ -11,6 +11,10 @@ parentdoc = File.open(parentmarcfile) { |f| Nokogiri::XML(f) }
 ### this file doesn't contain a namespace, so no xmlns in the xpath queries
 childmarcfile = "alma_bibs_boundwith_children_2018080216_8286523500003811_new.xml"
 childdoc = File.open(childmarcfile) { |f| Nokogiri::XML(f) }
+#childrecordids = childdoc.xpath("//xmlns:datafield[@tag='774']//xmlns:subfield[@code='w']")
+# childrecordids.each do |cr|
+#   puts cr.text
+# end
 
 parentrecords = parentdoc.xpath("//xmlns:record")
 parentrecords.each do |pr|
@@ -26,6 +30,7 @@ parentrecords.each do |pr|
         parentITM = pr.xpath("xmlns:datafield[@tag='ITM']")
         if !parentITM.to_s.empty?
           childrecord.add_child(parentITM[0].clone())
+          childrecord.add_child("<datafield ind1=\" \" ind2=\" \" tag=\"ADF\">\n\      <subfield code=\"a\">#{parentid}</subfield>\n    </datafield>")
         else
           puts "Parent " + parentid.to_s + " does not have an ITM field for its child " + childid.to_s
         end

--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -231,3 +231,10 @@ to_field "record_update_date", extract_marc("ADMb")
 # each_record do |record, context|
 #   puts context
 # end
+
+# Boost records with holdings from specific libraries
+# we actually want to negative boost specific libraries, but that is not possible
+# so we are going to boost everything except the less relevant libraries
+to_field "library_based_boost_t", library_based_boost
+
+to_field "bound_with_ids", extract_marc("ADFa")

--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -222,3 +222,12 @@ to_field "changed_back_to_display", extract_marc("785|08|iabdghkmnopqrstuxyz3", 
 # we actually want to negative boost specific libraries, but that is not possible
 # so we are going to boost everything except the less relevant libraries
 to_field "library_based_boost_t", library_based_boost
+
+# Administrative data enrichment fields
+# a=create date, b=update date, c=Suppress from publishing, d=Originating system, e=Originating system ID, f=Originating system version
+to_field "record_creation_date", extract_marc("ADMa")
+to_field "record_update_date", extract_marc("ADMb")
+
+# each_record do |record, context|
+#   puts context
+# end

--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -42,7 +42,7 @@ settings do
 end
 
 each_record do |record, context|
-  if record["245"]["a"].include?("Host bibliographic record for boundwith item barcode")
+  if record.fields("245").any? { |f| f["a"].to_s.downcase.include? "host bibliographic record for boundwith item barcode" }
     context.skip!("Skipping Boundwith host record")
   end
 end

--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -223,18 +223,4 @@ to_field "changed_back_to_display", extract_marc("785|08|iabdghkmnopqrstuxyz3", 
 # so we are going to boost everything except the less relevant libraries
 to_field "library_based_boost_t", library_based_boost
 
-# Administrative data enrichment fields
-# a=create date, b=update date, c=Suppress from publishing, d=Originating system, e=Originating system ID, f=Originating system version
-to_field "record_creation_date", extract_marc("ADMa")
-to_field "record_update_date", extract_marc("ADMb")
-
-# each_record do |record, context|
-#   puts context
-# end
-
-# Boost records with holdings from specific libraries
-# we actually want to negative boost specific libraries, but that is not possible
-# so we are going to boost everything except the less relevant libraries
-to_field "library_based_boost_t", library_based_boost
-
 to_field "bound_with_ids", extract_marc("ADFa")

--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -41,6 +41,12 @@ settings do
   provide "solr_writer.commit_on_close", "false"
 end
 
+each_record do |record, context|
+  if record["245"]["a"].include?("Host bibliographic record for boundwith item barcode")
+    context.skip!("Skipping Boundwith host record")
+  end
+end
+
 to_field "id", extract_marc("001", first: true)
 to_field "marc_display_raw", get_xml
 to_field("text", extract_all_marc_values, &to_single_string)

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -274,6 +274,10 @@ module Traject
           unless rec.fields("HLD").empty?
             acc << "At the Library"
           end
+          unless rec.fields("ADF").empty?
+            acc << "At the Library"
+          end
+
           acc.uniq!
         }
       end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -493,6 +493,9 @@
    <!--field name="library_facet" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="subject" type="string" indexed="true" stored="true" multiValued="true"/ -->
 
+   <field name="record_creation_date" type="string" indexed="true" stored="true" multiValued="false"/>
+   <field name="record_update_date" type="string" indexed="true" stored="true" multiValued="false"/>
+
    <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
         will be used if the name matches any of the patterns.
         RESTRICTION: the glob-like pattern in the name attribute must have

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -496,6 +496,8 @@
    <field name="record_creation_date" type="string" indexed="true" stored="true" multiValued="false"/>
    <field name="record_update_date" type="string" indexed="true" stored="true" multiValued="false"/>
 
+   <field name="bound_with_ids" type="string" indexed="true" stored="true" multiValued="true"/>
+
    <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
         will be used if the name matches any of the patterns.
         RESTRICTION: the glob-like pattern in the name attribute must have

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -493,9 +493,6 @@
    <!--field name="library_facet" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="subject" type="string" indexed="true" stored="true" multiValued="true"/ -->
 
-   <field name="record_creation_date" type="string" indexed="true" stored="true" multiValued="false"/>
-   <field name="record_update_date" type="string" indexed="true" stored="true" multiValued="false"/>
-
    <field name="bound_with_ids" type="string" indexed="true" stored="true" multiValued="true"/>
 
    <!-- Dynamic field definitions.  If a field name is not found, dynamicFields

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -55,16 +55,22 @@
     <defaultQuery>*:*</defaultQuery>
   </admin>
 
+  <initParams path="/update/**">
+   <lst name="defaults">
+     <str name="update.chain">DocCentricVersioningOnDate</str>
+   </lst>
+ </initParams>
+
   <updateHandler class="solr.DirectUpdateHandler2">
     <autoCommit>
       <maxDocs>1000000</maxDocs>
       <maxTime>900000</maxTime>
       <openSearcher>true</openSearcher>
     </autoCommit>
+    <updateLog>
+      <str name="dir">${solr.ulog.dir:}</str>
+    </updateLog>
   </updateHandler>
-
-
-
 
   <!-- SearchHandler
 
@@ -466,6 +472,7 @@
                  initialSize="${filterCacheInitialSize:2048}"
                  autowarmCount="256"/>
 
+
     <queryResultCache class="solr.LRUCache"
                       size="${queryResultCacheSize:2048}"
                       initialSize="${queryResultCacheInitialSize:2048}"
@@ -480,6 +487,21 @@
     <queryResultWindowSize>100</queryResultWindowSize>
     <queryResultMaxDocsCached>500</queryResultMaxDocsCached>
     <slowQueryThresholdMillis>500</slowQueryThresholdMillis>
-</query>
+  </query>
+
+  <updateRequestProcessorChain name="DocCentricVersioningOnDate">
+    <processor class="solr.ParseDateFieldUpdateProcessorFactory">
+      <arr name="format">
+        <str>yyyy-MM-dd HH:mm:ss</str>
+      </arr>
+    </processor>
+    <processor class="solr.DocBasedVersionConstraintsProcessorFactory">
+      <str name="versionField">record_update_date</str>
+      <bool name="ignoreOldUpdates">false</bool>
+    </processor>
+    <processor class="solr.DistributedUpdateProcessorFactory" />
+    <processor class="solr.RunUpdateProcessorFactory" />
+    <processor class="solr.LogUpdateProcessorFactory" />
+  </updateRequestProcessorChain>
 
 </config>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -55,21 +55,12 @@
     <defaultQuery>*:*</defaultQuery>
   </admin>
 
-  <initParams path="/update/**">
-   <lst name="defaults">
-     <str name="update.chain">DocCentricVersioningOnDate</str>
-   </lst>
- </initParams>
-
   <updateHandler class="solr.DirectUpdateHandler2">
     <autoCommit>
       <maxDocs>1000000</maxDocs>
       <maxTime>900000</maxTime>
       <openSearcher>true</openSearcher>
     </autoCommit>
-    <updateLog>
-      <str name="dir">${solr.ulog.dir:}</str>
-    </updateLog>
   </updateHandler>
 
   <!-- SearchHandler
@@ -488,20 +479,5 @@
     <queryResultMaxDocsCached>500</queryResultMaxDocsCached>
     <slowQueryThresholdMillis>500</slowQueryThresholdMillis>
   </query>
-
-  <updateRequestProcessorChain name="DocCentricVersioningOnDate">
-    <processor class="solr.ParseDateFieldUpdateProcessorFactory">
-      <arr name="format">
-        <str>yyyy-MM-dd HH:mm:ss</str>
-      </arr>
-    </processor>
-    <processor class="solr.DocBasedVersionConstraintsProcessorFactory">
-      <str name="versionField">record_update_date</str>
-      <bool name="ignoreOldUpdates">false</bool>
-    </processor>
-    <processor class="solr.DistributedUpdateProcessorFactory" />
-    <processor class="solr.RunUpdateProcessorFactory" />
-    <processor class="solr.LogUpdateProcessorFactory" />
-  </updateRequestProcessorChain>
 
 </config>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -63,5 +63,14 @@ RSpec.describe CatalogController, type: :controller do
     end
   end
 
+  describe "Boundwith Host records should not have been indexed" do
+    render_views
+    let(:bwh) { JSON.parse(get(:index, params: { q: "22293201420003811" }, format: :json).body)["response"]["pages"]["total_count"] }
+
+    it "returns no results" do
+      expect(bwh).to eql 0
+    end
+  end
+
 
 end

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -28599,6 +28599,7 @@
     </datafield>
   </record>
   <record>
+<<<<<<< 2d5d2803ac7ba908918d908356fcd3d287af68bc
     <leader>05101cpcaa2200709Ia 4500</leader>
     <controlfield tag="005">20180315120829.0</controlfield>
     <controlfield tag="008">151116i20062012pau eng d</controlfield>
@@ -28842,4 +28843,12 @@
       <subfield code="f">SCRC</subfield>
     </datafield>
     </record>
+=======
+  <leader>01303crm a2200361Ii 4500</leader>
+    <controlfield tag="001">9910127566397038232311</controlfield>
+    <datafield ind1="0" ind2="0" tag="245">
+     <subfield code="a">Host bibliographic record for boundwith item barcode 1234567890</subfield>
+  </datafield>
+</record>
+>>>>>>> Make the Host record skipping safer
 </collection>

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -28599,7 +28599,6 @@
     </datafield>
   </record>
   <record>
-<<<<<<< 2d5d2803ac7ba908918d908356fcd3d287af68bc
     <leader>05101cpcaa2200709Ia 4500</leader>
     <controlfield tag="005">20180315120829.0</controlfield>
     <controlfield tag="008">151116i20062012pau eng d</controlfield>
@@ -28842,13 +28841,12 @@
       <subfield code="d">SCRC</subfield>
       <subfield code="f">SCRC</subfield>
     </datafield>
-    </record>
-=======
-  <leader>01303crm a2200361Ii 4500</leader>
+  </record>
+  <record>
+    <leader>01303crm a2200361Ii 4500</leader>
     <controlfield tag="001">9910127566397038232311</controlfield>
     <datafield ind1="0" ind2="0" tag="245">
-     <subfield code="a">Host bibliographic record for boundwith item barcode 1234567890</subfield>
-  </datafield>
-</record>
->>>>>>> Make the Host record skipping safer
+      <subfield code="a">Host bibliographic record for boundwith item barcode 1234567890</subfield>
+    </datafield>
+  </record>
 </collection>


### PR DESCRIPTION
This PR allows :wastebasket: :fire:  records, otherwise known as boundwith records, to have availability information displayed and be requested.

Did I mention they were a total :wastebasket: :fire: ?

It also adds logic to skip Host (parent) records so they are not skipped.

Whoever takes this on to review, I can send you the marc file with the required records that are created in a separate process

Just for good measure
:wastebasket: :fire: 
:wastebasket: :fire: 
:wastebasket: :fire: 
:wastebasket: :fire: 

Also a :garbagefire: