### PR TITLE
Add browser validations for date field

### DIFF
--- a/app/javascript/packs/controllers/form_controller.js
+++ b/app/javascript/packs/controllers/form_controller.js
@@ -5,6 +5,7 @@ export default class extends Controller {
 
   connect() {
     this.booking_end_date()
+    this.message()
   }
 
   initialize() {
@@ -29,5 +30,10 @@ export default class extends Controller {
       $('#booking_end_date').prop('min', $('#booking_start_date').val());
       $('#booking_end_date').prop('max', end);
     });
+  }
+
+  message() {
+    document.getElementById('hold_date_field').setCustomValidity("Please write date in YYYY-MM-DD format.");
+    document.getElementById('digitization_date_field').setCustomValidity("Please write date in YYYY-MM-DD format.");
   }
 }

--- a/app/views/almaws/_digitization_request_form.html.erb
+++ b/app/views/almaws/_digitization_request_form.html.erb
@@ -46,7 +46,7 @@
     <div class="form-group row">
       <div class="col-sm-5">
         <%= form.label(:last_interest_date, "Not Needed After (optional):") %>
-        <%= date_field_tag :last_interest_date, Date.today() + 10 %>
+        <%= date_field_tag :last_interest_date, Date.today() + 10, pattern:"[0-9]{4}-[0-9]{2}-[0-9]{2}", id: "digitization_date_field" %>
       </div>
     </div>
 

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -38,7 +38,7 @@
     <div class="row hold-form">
       <div class="col-sm-5">
         <%= form.label(:not_needed, "Not Needed After (optional):") %>
-        <%= date_field_tag :last_interest_date, Date.today() + 10 %>
+        <%= date_field_tag :last_interest_date, Date.today() + 10, pattern:"[0-9]{4}-[0-9]{2}-[0-9]{2}", id: "hold_date_field" %>
       </div>
     </div>
 


### PR DESCRIPTION
Some browsers allow text input for date fields
- add pattern to include only numbers
- set custom validation message to alert the correct format to the user