### PR TITLE
Check whether aeon button is present

### DIFF
--- a/app/views/almaws/request_options.html.erb
+++ b/app/views/almaws/request_options.html.erb
@@ -68,8 +68,8 @@
           </div>
         <% end %>
 
-        <% if !@request_options.hold_allowed? && !@request_options.digitization_allowed? && !@request_options.booking_allowed? && !aeon_request_button(@items)  %>
-          <p>There are no request options available.</p>
+        <% if !@request_options.hold_allowed? && !@request_options.digitization_allowed? && !@request_options.booking_allowed? && !aeon_request_button(@items).present?  %>
+          <p>This item cannot be requested from other Temple campuses.</p>
         <% end %>
 
         </div>


### PR DESCRIPTION
Text was not displaying when there were no request options
- adds .present to aeon_button
- changes message to users