### PR TITLE
Rescue from URI.parse exception.

### DIFF
--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -73,7 +73,7 @@ module Blacklight::PrimoCentral::Document
 
 
     def url_query
-      query = URI.parse(@url).query
+      query = (URI.parse(@url).query rescue nil)
       if (query)
         q = CGI.parse(query) || {}
         q.select { |k, v| v && !v.empty? && v != [""] }


### PR DESCRIPTION
REF BL-584
REF https://app.honeybadger.io/projects/56250/faults/39105905

Rescue from exception thrown when paring a URI.

(This time around the issue was caused because URI string had a newline
at end, but any number of things can ultimately cause this issue so it's
better just to rescue than to try to catch them all.)