### PR TITLE
Fix attempt to use unknown field :advanced.

### DIFF
--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -127,6 +127,7 @@ module Blacklight::PrimoCentral
       def to_primo_field(field)
         {
           all_fields: :any,
+          advanced: :any,
           creator_t: :creator,
           isbn_t: :isbn,
           issn_t: :issn,

--- a/spec/models/primo_search_builder_spec.rb
+++ b/spec/models/primo_search_builder_spec.rb
@@ -121,6 +121,14 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
       end
     end
 
+    context "search_field is set to advanced" do
+      let(:params) { ActionController::Parameters.new(search_field: :advanced) }
+
+      it "advanced transforms to :any" do
+        expect(primo_central_parameters["query"]["q"]["field"]).to eq(:any)
+      end
+    end
+
     context "search_field is not tranformable" do
       let(:params) { ActionController::Parameters.new(search_field: "foo") }
 


### PR DESCRIPTION
REF BL-587
REF
https://app.honeybadger.io/projects/56250/faults/39100209/29996d82-a095-11e8-98d0-ca2cc93f1c04

Under certain conditions field type can be set to :advanced by the app.
We force :advanced to be set to :any when passed to primo.