### PR TITLE
Bl 580 truncate titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,11 @@ module ApplicationHelper
     render_location(value[:value].first)
   end
 
+  def truncated_link(document, field, opts = { counter: nil })
+    label = index_presenter(document).label(field, opts).truncate(300).html_safe
+    link_to label, url_for_document(document), document_link_params(document, opts)
+  end
+
   def get_search_params(field, query)
     case field
     when "subject_display"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
   end
 
   def truncated_link(document, field, opts = { counter: nil })
-    label = index_presenter(document).label(field, opts).truncate(300).html_safe
+    label = index_presenter(document).label(field, opts).truncate(300, separator: " ").html_safe
     link_to label, url_for_document(document), document_link_params(document, opts)
   end
 

--- a/app/views/catalog/_index_header_default.html.erb
+++ b/app/views/catalog/_index_header_default.html.erb
@@ -1,0 +1,22 @@
+<%# header bar for doc items in index view -%>
+<header class="documentHeader row">
+  <%# main title container for doc partial view
+      How many bootstrap columns need to be reserved
+      for bookmarks control depends on size.
+  -%>
+  <% document_actions = capture do %>
+    <% # bookmark functions for items/docs -%>
+    <%= render_index_doc_actions document, wrapping_class: "index-document-functions col-sm-3 col-lg-2" %>
+  <% end %>
+
+  <h3 class="index_title document-title-heading <%= document_actions.present? ? "col-sm-9 col-lg-10" : "col-md-12" %>">
+    <% if counter = document_counter_with_offset(document_counter) %>
+      <span class="document-counter">
+        <%= t('blacklight.search.documents.counter', counter: counter) %>
+      </span>
+    <% end %>
+    <%= truncated_link document, document_show_link_field(document), counter: counter %>
+  </h3>
+
+  <%= document_actions %>
+</header>

--- a/spec/fixtures/marc_fixture.xml
+++ b/spec/fixtures/marc_fixture.xml
@@ -28849,4 +28849,128 @@
       <subfield code="a">Host bibliographic record for boundwith item barcode 1234567890</subfield>
     </datafield>
   </record>
+  <record>
+    <leader>06322cam a2200373 4500</leader>
+    <controlfield tag="005">20180315163713.0</controlfield>
+    <controlfield tag="006">m | j |</controlfield>
+    <controlfield tag="007">cr||n||||||||n</controlfield>
+    <controlfield tag="008">900228s1769 enk|||| s 00| ||eng c</controlfield>
+    <controlfield tag="001">991004250539703811</controlfield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(PPT)b4359203x-01tuli_inst</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(CU-RivES)T199095</subfield>
+      <subfield code="9">ExL</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(Uk-ES)006293668</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">Uk-ES</subfield>
+      <subfield code="c">Uk-ES</subfield>
+      <subfield code="d">CU-RivES</subfield>
+      <subfield code="d">CStRLIN</subfield>
+      <subfield code="d">Cengage Gale</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Maitland, William,</subfield>
+      <subfield code="d">1693?-1757.</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="0" tag="240">
+      <subfield code="a">History of London.</subfield>
+      <subfield code="k">Prospectus</subfield>
+    </datafield>
+    <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">By the King's authority. Proposals for printing by subscription, in weekly numbers, price six-pence each, embellished with upwards of one hundred and twenty copper-plates, the third edition, (dedicated to the Right Honourable samuel turner esq; Lord-Mayor the court of aldermsn, and common-council.) The History and survey of London, Westminster, Southwark, and their environs. By William Maitland, F.R.S. and others</subfield>
+      <subfield code="h">[electronic resource] :</subfield>
+      <subfield code="b">Containing, I. The original constitution of London and Westminster the ancient and present state of the several wards, districts, liberties, pariches and churches, and the most curious sepulchral monuments; accounts of all the religious foundations therein before the reformation, and the uses to which they were converted after their dissolution: the names of all the streets, squares, courts, lanes, alleys, rents, rows,. With curious calculations touching the number of inhabitants; whereby it will appear, that the number of inhabitants in London are more than in any one city in the world, and almost equal to those of the cities of Paris, Amsterdam, and Rome together. II. The political, ecclesiastical, civil and military government,in all their branches; and the chartered liberties, privileges and immunities, granted from time to time by the crown, and confirmed to the citizens by act of Parliament. III. Accounts of the several incorporations of mechant-adventurers, public trading companies, and of all arts and mysteries; shewing their original institution, and the constitution of those companies and corporations respectively, and their ancient rights, privileges and franchises. IV. The city courts, and the manner of proceeding in each of them; and the laws enacted both by Common-Council and Parliament, for the citizens conduct at elections, both in the Common-Hall and in wardmotes.V. The present state of learning, colleges,inns of court, and public schools. VI. The public buildings, palaces, public offices, and meeting-houses of every denomination; and full and particular accounts of all the hospitals, almshouses, and other charitable foundations, and bridges. VII. Both Houses of Parliament, the courts of law at Westminster, the British Musŭm, and the ancient and present state and curiosities of the Tower of London and Westminster-Abbey. Improved with a great variety of authentic pieces, relative to the alterations in the political, ecclesiastical, and commercial state, since the first foundation of this metropolis; which, by the surprizing increase of buildings and inhabitants, carries the appearance of a large county. To which will be added, a continuation of the history down to the year 1770; and an accurate survey and description of all the alterations, additions and improvements made, by authority of Parliament, in the buildings, streets, roads, in and about this great metropolis: and so managed, that the purchasers of the former editions of this capital book (which, for its merit, is presented at the city's expence to every new alderman) may be supplied with them separate. to complete their books. In two volumes. Extracted from original recors preserved in the Tower, Rolls, Paper-Office, and Guildball; from acts of Parliament and acts of Common-Council, historians, ancient law-books, and many authentic pieces communicated by the learned in history, antiquities and municipal laws, to the editors of this work only. Conditions. I. This work (a great part of which is already printed) will be comprised in One Hundred and Twenty-three numbers, at Six-pence each, stitched in blue paper. II. That every number shall contain three sheets of letter-press, and one folio or broad-sheet plate, engraven by the best hands. III. That the first number will be published on Saturday the 28th of January, and continued regularly every Saturday till the whole is finished, and delivered at the Houses of Subscribers. Subscriptions are taken in, and proposals delivered, by J. Wilkie, in St. Paul's Church-yard; T. Lowndes, in Fleet-Street; G. Kearsly, in Ludgate-Street; and S. Bladon, in Pater-noster-Row; and by all the news-carriers in town and country. Of whom may be had, this work complete, in two volumes, folio, neatly bound in Calf and letter'd, Price 3l. 10s.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">[London :</subfield>
+      <subfield code="b">s.n.,</subfield>
+      <subfield code="c">1769]</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">[2]p. ;</subfield>
+      <subfield code="c">1/2⁰.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Dated at head: London, January 24, 1769.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Subscriptions were "taken in, and proposals delivered, by J. Wilkie; T. Lowndes; G. Kearsly; and S. Bladon".</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="509">
+      <subfield code="a">DNB records a 3rd ed. of 'The history' which was published in 1760 and a 4th ed. which appeared in 1769. An edition of the work "considerably enlarged" by the Rev. John Entick appeared in 1775. Is this the prospectus for the 4th ed. or for the Entick work?</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="533">
+      <subfield code="a">Electronic reproduction.</subfield>
+      <subfield code="b">Farmington Hills, Mich. :</subfield>
+      <subfield code="c">Cengage Gale,</subfield>
+      <subfield code="d">2009.</subfield>
+      <subfield code="n">Available via the World Wide Web.</subfield>
+      <subfield code="n">Access limited by licensing agreements.</subfield>
+      <subfield code="7">s2009 miunns</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="510">
+      <subfield code="a">English Short Title Catalog,</subfield>
+      <subfield code="c">T199095.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Reproduction of original from Bodleian Library (Oxford).</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="590">
+      <subfield code="a">Access is available to the Temple Community through use of a networked computer with a Temple IP address</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="651">
+      <subfield code="a">London (England)</subfield>
+      <subfield code="x">History</subfield>
+      <subfield code="v">Early works to 1800.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="7" tag="655">
+      <subfield code="a">Prospectuses.</subfield>
+      <subfield code="2">rbgenr</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="752">
+      <subfield code="a">Great Britain</subfield>
+      <subfield code="b">England</subfield>
+      <subfield code="d">London.</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="773">
+      <subfield code="t">Eighteenth century collections online</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="907">
+      <subfield code="a">.b4359203x</subfield>
+      <subfield code="b">w</subfield>
+      <subfield code="c">-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">w</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="b">1</subfield>
+      <subfield code="c">100703</subfield>
+      <subfield code="d">m</subfield>
+      <subfield code="e">@</subfield>
+      <subfield code="f">-</subfield>
+      <subfield code="g">0</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ADM">
+      <subfield code="b">2018-03-15 20:37:13</subfield>
+      <subfield code="e">b4359203x-01tuli_inst</subfield>
+      <subfield code="d">ILS</subfield>
+      <subfield code="a">2017-06-20 11:45:18</subfield>
+      <subfield code="c">false</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="PRT">
+      <subfield code="a">53377224580003811</subfield>
+      <subfield code="f">Full text online</subfield>
+      <subfield code="9">Available</subfield>
+      <subfield code="d">MAIN</subfield>
+      <subfield code="c">Eighteenth Century collections online</subfield>
+      <subfield code="8">53377224580003811</subfield>
+    </datafield>
+  </record>
 </collection>


### PR DESCRIPTION
Shortens titles in the search results to 300 characters
- see 991004250539703811 in the marc_fixture.xml file for an example
![screen shot 2018-08-16 at 9 05 20 am](https://user-images.githubusercontent.com/15167238/44210089-86b1bf80-a133-11e8-8899-7b039c1e6ba9.png)
