### PR TITLE
Remove id processor that causes multi returns.

### DIFF
--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -122,7 +122,6 @@ module Blacklight::PrimoCentral
           .gsub("-dot-", ".")
           .gsub("-slash-", "/")
           .gsub("-semicolon-", ";")
-          .gsub("-", " ")
           }'"
       end
 


### PR DESCRIPTION
REF BL-600

I'm not sure why I added the processor in the first place.  But testing
many types of ids I have not found a case where replacing dashes with
spaces makes a difference other than in potentially increasing the
number of results since value becomes multi-valued.