### PR TITLE
Don't allow an array with an empty string in booking request descr

### DIFF
--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -80,7 +80,7 @@ module CobAlma
           desc
         end
       end
-      descriptions
+      descriptions unless descriptions == [""]
     end
 
     def self.booking_location(items_list)

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -16,8 +16,7 @@
         <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {class: "request-form form-control"}, {include_blank: true, required: true, "aria-required": true }) %>
       </div>
     </div>
-
-    <% if @description.present? %>
+    <% if @description.present? && @description != [""] %>
       <div class="form-group row">
         <div class="col-sm-4">
           <%= form.label(:description, "Description:") %>

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -16,6 +16,7 @@
         <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {class: "request-form form-control"}, {include_blank: true, required: true, "aria-required": true }) %>
       </div>
     </div>
+    
     <% if @description.present? %>
       <div class="form-group row">
         <div class="col-sm-4">

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -16,7 +16,7 @@
         <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {class: "request-form form-control"}, {include_blank: true, required: true, "aria-required": true }) %>
       </div>
     </div>
-    <% if @description.present? && @description != [""] %>
+    <% if @description.present? %>
       <div class="form-group row">
         <div class="col-sm-4">
           <%= form.label(:description, "Description:") %>


### PR DESCRIPTION
The description field is displaying when it only includes an empty string.  This adds more logic to filter those results out.