### PR TITLE
Update date fields to be MM-DD-YYYY

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -140,7 +140,7 @@ class AlmawsController < ApplicationController
 
     def date_or_nil(param)
       begin
-        date = Date.strptime(param, "%Y-%m-%d")
+        date = Date.strptime(param, "%m-%d-%Y")
       rescue
         date = nil
       end

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -16,7 +16,7 @@
         <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {class: "request-form form-control"}, {include_blank: true, required: true, "aria-required": true }) %>
       </div>
     </div>
-    
+
     <% if @description.present? %>
       <div class="form-group row">
         <div class="col-sm-4">
@@ -29,14 +29,15 @@
     <div class="row hold-form">
       <div class="col-sm-5">
         <%= form.label(:booking_start_date, "Booking Start Date:") %>
-        <%= date_field_tag :booking_start_date, "", min: Date.tomorrow, required: true, "aria-required": true %>
+        <%= date_field_tag :booking_start_date, "", min: Date.tomorrow, required: true, "aria-required": true, pattern:"[0-9]{2}-[0-9]{2}-[0-9]{4}" %>
       </div>
     </div>
 
     <div class="row hold-form">
       <div class="col-sm-5">
         <%= form.label(:booking_end_date, "Booking End Date:") %>
-        <%= date_field_tag :booking_end_date, "", required: true, "aria-required": true %>
+        <%= date_field_tag :booking_end_date, "", required: true, "aria-required": true, pattern:"[0-9]{2}-[0-9]{2}-[0-9]{4}" %>
+        <div class="invalid-field">Please use MM-DD-YYYY format.</div>
       </div>
     </div>
 

--- a/app/views/almaws/_digitization_request_form.html.erb
+++ b/app/views/almaws/_digitization_request_form.html.erb
@@ -46,8 +46,8 @@
     <div class="form-group row">
       <div class="col-sm-5">
         <%= form.label(:last_interest_date, "Not Needed After (optional):") %>
-        <%= date_field_tag :last_interest_date, Date.today() + 10, pattern:"[0-9]{4}-[0-9]{2}-[0-9]{2}", id: "digitization_date_field" %>
-        <div class="invalid-field">Please use YYYY-MM-DD format.</div>
+        <%= date_field_tag :last_interest_date, "MM-DD-YYYY", pattern:"[0-9]{2}-[0-9]{2}-[0-9]{4}", id: "digitization_date_field" %>
+        <div class="invalid-field">Please use MM-DD-YYYY format.</div>
       </div>
     </div>
 

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -38,8 +38,8 @@
     <div class="row hold-form">
       <div class="col-sm-5">
         <%= form.label(:not_needed, "Not Needed After (optional):") %>
-        <%= date_field_tag :last_interest_date, Date.today() + 10, pattern:"[0-9]{4}-[0-9]{2}-[0-9]{2}", id: "hold_date_field" %>
-        <div class="invalid-field">Please use YYYY-MM-DD format.</div>
+        <%= date_field_tag :last_interest_date, "MM-DD-YYYY", pattern:"[0-9]{2}-[0-9]{2}-[0-9]{4}", id: "hold_date_field" %>
+        <div class="invalid-field">Please use MM-DD-YYYY format.</div>
       </div>
     </div>
 

--- a/spec/controllers/almaws_controller_spec.rb
+++ b/spec/controllers/almaws_controller_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe AlmawsController, type: :controller do
   describe "#date_or_nil" do
 
     it "returns a formatted date when passed a YYYY-MM-DD string" do
-      expect(controller.send(:date_or_nil, "2018-10-18")).to be_a_kind_of Date
+      expect(controller.send(:date_or_nil, "10-18-2018")).to be_a_kind_of Date
     end
 
     it "returns nil when passed a string" do


### PR DESCRIPTION
Different browsers display the date field in different formats
- defaults to a "MM-DD-YYYY" string as the default value
- updates the regex patterns to use MM-DD-YYYY format