### PR TITLE
Bl 609 aeon requests

### DIFF
--- a/app/assets/stylesheets/tucob.scss.erb
+++ b/app/assets/stylesheets/tucob.scss.erb
@@ -49,8 +49,20 @@ h1.advanced.page-header a {
 
 /* === AEON REQUESTS === */
 
-.special-collections {
-  padding-top: 5px;
+.aeon-wrapper {
+  border-bottom: 1px solid #CFC7B0;
+  border-left: 1px solid #CFC7B0;
+  border-top: none;
+  display: table;
+  width: 100%;
+}
+
+.aeon-request {
+  margin: 10px;
+}
+
+.aeon-text {
+  display: table-cell;
 }
 
 /* === REQUESTS === */
@@ -319,6 +331,7 @@ table.border-bottom {
 }
 
 .table-wrapper {
+  border: none;
   display: block;
   max-height: 300px;
   overflow-y: scroll;

--- a/app/assets/stylesheets/tucob.scss.erb
+++ b/app/assets/stylesheets/tucob.scss.erb
@@ -49,16 +49,8 @@ h1.advanced.page-header a {
 
 /* === AEON REQUESTS === */
 
-.aeon-wrapper {
-  border-bottom: 1px solid #CFC7B0;
-  border-left: 1px solid #CFC7B0;
-  border-top: none;
-  display: table;
-  width: 100%;
-}
-
 .aeon-request {
-  margin: 10px;
+  margin-top: -20px;
 }
 
 .aeon-text {
@@ -289,7 +281,6 @@ div.physical-holding-panel {
 
 /* ALMA DATA TABLE */
 .border-bottom td, .border-bottom th {
-  border-bottom: 1px solid #CFC7B0;
   /*border: solid red 1px;*/
 }
 

--- a/app/assets/stylesheets/tucob.scss.erb
+++ b/app/assets/stylesheets/tucob.scss.erb
@@ -50,7 +50,12 @@ h1.advanced.page-header a {
 /* === AEON REQUESTS === */
 
 .aeon-request {
+  float: right;
   margin-top: -20px;
+}
+
+.index-avail-container .aeon-request {
+  margin-top: -35px;
 }
 
 .aeon-text {
@@ -528,6 +533,10 @@ ul.navbar-nav {
     clear: both;
     padding-top: 14px;
     padding-right: 0;
+  }
+  .aeon-request {
+    float: none;
+    margin-top: 0 !important;
   }
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -168,11 +168,11 @@ module ApplicationHelper
     publisher_const = item.item.dig("bib_data", "publisher_const") || ""
     date_of_publication = item.item.dig("bib_data", "date_of_publication") || ""
     form_fields = {
-         ItemTitle: item.item.dig("bib_data", "title"),
+         ItemTitle: (item.item.dig("bib_data", "title") || ""),
          ItemPlace: place_of_publication + publisher_const + date_of_publication,
-         ReferenceNumber: item.item.dig("bib_data", "mms_id"),
-         CallNumber: item.call_number,
-         ItemAuthor: item.item.dig("bib_data", "author")
+         ReferenceNumber: (item.item.dig("bib_data", "mms_id") || ""),
+         CallNumber: item.call_number || "",
+         ItemAuthor: (item.item.dig("bib_data", "author") || "")
      }
 
     openurl_field_values = form_fields.map { |k, v|

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -175,7 +175,7 @@ module ApplicationHelper
     openurl_field_values = form_fields.map { |k, k2|
       [k, document[k2].to_s.delete('[]""')] }.to_h
 
-      URI::HTTPS.build(
+    URI::HTTPS.build(
       host:  "temple.aeon.atlas-sys.com",
       path: "/aeon/aeon.dll/OpenURL",
       query: openurl_field_values.to_query).to_s
@@ -183,7 +183,7 @@ module ApplicationHelper
 
   def aeon_request_button(document)
     if document.fetch("location_display", []).include?("SCRC rarestacks") && document["library_facet"].include?("Special Collections Research Center")
-      button_to("Request to View in Reading Room", aeon_request_url(document), class:"aeon-request btn btn-primary") +
+      button_to("Request to View in Reading Room", aeon_request_url(document), class: "aeon-request btn btn-primary") +
       content_tag(:p, "For materials from the Special Collections Research Center only", class: "aeon-text")
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -164,9 +164,12 @@ module ApplicationHelper
   end
 
   def aeon_request_url(item)
+    place_of_publication = item.item.dig("bib_data", "place_of_publication") || ""
+    publisher_const = item.item.dig("bib_data", "publisher_const") || ""
+    date_of_publication = item.item.dig("bib_data", "date_of_publication") || ""
     form_fields = {
          ItemTitle: item.item.dig("bib_data", "title"),
-         ItemPlace: item.item.dig("bib_data", "place_of_publication") + " " + item.item.dig("bib_data", "publisher_const") + " " + item.item.dig("bib_data", "date_of_publication"),
+         ItemPlace: place_of_publication + publisher_const + date_of_publication,
          ReferenceNumber: item.item.dig("bib_data", "mms_id"),
          CallNumber: item.call_number,
          ItemAuthor: item.item.dig("bib_data", "author")
@@ -188,7 +191,7 @@ module ApplicationHelper
   def aeon_request_button(items)
     raw items.map { |item|
       if item.library.include?("SCRC") && item.location.include?("rarestacks")
-        button_to("Request to View in Reading Room", aeon_request_url(item), class: "aeon-request btn btn-sm btn-primary pull-right")
+        button_to("Request to View in Reading Room", aeon_request_url(item), class: "aeon-request btn btn-sm btn-primary")
         #content_tag(:p, "For materials from the Special Collections Research Center only", class: "aeon-text")
       end
     }.join

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -163,34 +163,29 @@ module ApplicationHelper
     end
   end
 
-  def aeon_request_url(item)
+  def aeon_request_url(document)
     form_fields = {
-         ItemTitle: (item.item.dig("bib_data", "title") || ""),
-         ItemPlace: (item.item.dig("bib_data", "place_of_publication") || "") + " " + (item.item.dig("bib_data", "publisher_const") || "") + " " + (item.item.dig("bib_data", "date_of_publication") || ""),
-         ReferenceNumber: (item.item.dig("bib_data", "mms_id") || ""),
-         CallNumber: item.call_number || "",
-         ItemAuthor: (item.item.dig("bib_data", "author") || "")
+         ItemTitle: "title_statement_display",
+         ItemPlace: "imprint_display",
+         ReferenceNumber: "alma_mms_display",
+         CallNumber: "call_number_display",
+         ItemAuthor: "creator_display"
      }
 
-    openurl_field_values = form_fields.map { |k, v|
-      [k, v.to_s.delete('[]""')] }.to_h
+    openurl_field_values = form_fields.map { |k, k2|
+      [k, document[k2].to_s.delete('[]""')] }.to_h
 
-    openurl_field_values["Action"] = 10
-    openurl_field_values["Form"] = 30
-
-
-    URI::HTTPS.build(
+      URI::HTTPS.build(
       host:  "temple.aeon.atlas-sys.com",
-      path: "/Logon/",
+      path: "/aeon/aeon.dll/OpenURL",
       query: openurl_field_values.to_query).to_s
   end
 
-  def aeon_request_button(items)
-    raw items.map { |item|
-      if item.library.include?("SCRC") && item.location.include?("rarestacks")
-        link_to("Request to View in Reading Room", aeon_request_url(item), class: "accordian-toggle")
-      end
-    }.join
+  def aeon_request_button(document)
+    if document.fetch("location_display", []).include?("SCRC rarestacks") && document["library_facet"].include?("Special Collections Research Center")
+      button_to("Request to View in Reading Room", aeon_request_url(document), class:"aeon-request btn btn-primary") +
+      content_tag(:p, "For materials from the Special Collections Research Center only", class: "aeon-text")
+    end
   end
 
   def total_items(results)

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -16,7 +16,10 @@
     </thead>
     <tbody >
       <tr class="table-heading">
-        <th id="<%= key %>" scope="colgroup" colspan="7"><%= library_name_from_short_code(key) %></th>
+        <th id="<%= key %>" scope="colgroup" colspan="7">
+          <%= library_name_from_short_code(key) %>
+          <%= aeon_request_button(items) %>
+        </th>
       </tr>
       <% items.each do |item| %>
         <tr>

--- a/app/views/almaws/request_options.html.erb
+++ b/app/views/almaws/request_options.html.erb
@@ -59,16 +59,7 @@
           </div>
         <% end %>
 
-        <% if aeon_request_button(@items).present? %>
-          <div class="panel panel-default request-heading">
-            <div class="panel-heading">
-              <h4 class="panel-title"><%= aeon_request_button(@items) %></h4>
-              <p class="special-collections">(Special Collections Research Center materials only)</p>
-            </div>
-          </div>
-        <% end %>
-
-        <% if !@request_options.hold_allowed? && !@request_options.digitization_allowed? && !@request_options.booking_allowed? && !aeon_request_button(@items).present?  %>
+        <% if !@request_options.hold_allowed? && !@request_options.digitization_allowed? && !@request_options.booking_allowed? %>
           <p>This item cannot be requested from other Temple campuses.</p>
         <% end %>
 

--- a/app/views/catalog/_aeon_request.html.erb
+++ b/app/views/catalog/_aeon_request.html.erb
@@ -1,0 +1,3 @@
+<div class="aeon-wrapper">
+  <%= aeon_request_button(document) %>
+</div>

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -23,7 +23,7 @@
         <span class="glyphicon glyphicon-refresh glyphicon-spin"></span>
         Loading Availability
       </div>
-      <div  data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" id="physical-document-<%= document_counter %>" class="collapse panel-content avail-container">
+      <div  data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" id="physical-document-<%= document_counter %>" class="collapse panel-content avail-container index-avail-container">
         <div class="table-wrapper hidden">
           <div data-target="availability.panel"></div>
           <div><%= render "check_holdings", document: document, document_counter: document_counter %></div>

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -31,8 +31,6 @@
           <div>
             <%= render "check_holdings", document: document %>
           </div>
-          <%= render "aeon_request", :document => document %>
-
       </div>
       </div>
   <% end %>

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -31,8 +31,11 @@
           <div>
             <%= render "check_holdings", document: document %>
           </div>
+          <%= render "aeon_request", :document => document %>
+
       </div>
       </div>
   <% end %>
   </div>
+
 </div>


### PR DESCRIPTION
This moves the aeon button back into the availability panel
- Button should display only for SCRC materials and will be on the same row as the library name
<img width="749" alt="screen shot 2018-08-24 at 2 00 13 pm" src="https://user-images.githubusercontent.com/15167238/44600035-0e3ba600-a7a6-11e8-8b7d-9d537c789b2e.png">
