### PR TITLE
Add sorting fields to articles.

### DIFF
--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -75,6 +75,7 @@ class PrimoCentralController < CatalogController
     config.add_sort_field :rank, label: "relevance"
     config.add_sort_field :title, label: "title (A to Z)"
     config.add_sort_field :date, label: "date (new to old)"
+    config.add_sort_field :author, label: "author/creator (A to Z)"
   end
 
   def browse_creator(args)

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -70,6 +70,11 @@ class PrimoCentralController < CatalogController
     config.add_show_field :lccn, label: "LCCN"
     config.add_show_field :doi, label: "DOI"
     config.add_show_field :languageId, label: "Language", multi: true, helper_method: :doc_translate_language_code
+
+    # Sort fields
+    config.add_sort_field :rank, label: "relevance"
+    config.add_sort_field :title, label: "title (A to Z)"
+    config.add_sort_field :date, label: "date (new to old)"
   end
 
   def browse_creator(args)

--- a/app/models/blacklight/primo_central/search_builder.rb
+++ b/app/models/blacklight/primo_central/search_builder.rb
@@ -8,7 +8,6 @@ module Blacklight::PrimoCentral
     self.default_processor_chain = [
       :add_query_to_primo_central,
       :set_query_field,
-      :set_query_sort_order,
       :process_advanced_search,
       :previous_and_next_document,
       :add_query_facets,

--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -19,6 +19,7 @@ module Blacklight::PrimoCentral
           primo_central_parameters[:query] = {
             limit: per_page,
             offset:  offset,
+            sort: params[:sort],
             q: { value: queries },
           }
         else
@@ -55,9 +56,6 @@ module Blacklight::PrimoCentral
       if  @rows
         primo_central_parameters[:query][:limit] = @rows
       end
-    end
-
-    def set_query_sort_order(primo_central_parameters)
     end
 
     def process_advanced_search(primo_central_parameters)

--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -8,6 +8,7 @@ module Blacklight::PrimoCentral
       per_page = (blacklight_params["per_page"] || blacklight_config.default_per_page).to_i
       page = (blacklight_params["page"] || 1).to_i
       offset = (per_page * page) - per_page
+      sort = blacklight_params["sort"] || "rank"
 
       value = blacklight_params[:q]
       value = "*" if value.nil? || value.empty?
@@ -19,7 +20,7 @@ module Blacklight::PrimoCentral
           primo_central_parameters[:query] = {
             limit: per_page,
             offset:  offset,
-            sort: params[:sort],
+            sort: sort,
             q: { value: queries },
           }
         else
@@ -38,6 +39,7 @@ module Blacklight::PrimoCentral
         primo_central_parameters[:query] = {
           limit: per_page,
           offset:  offset,
+          sort: sort,
           q: { value: value }
         }
       end

--- a/spec/models/primo_search_builder_spec.rb
+++ b/spec/models/primo_search_builder_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
       it "sets the default offset to zero" do
         expect(primo_central_parameters["query"]["offset"]).to eq(0)
       end
+
+      it "sets a default sort field" do
+        expect(primo_central_parameters["query"]["sort"]).to eq("rank")
+      end
+    end
+
+    context "with sort param override" do
+      let(:params) { ActionController::Parameters.new(q: "foo", sort: "bar") }
+
+      it "overrides the default sort field" do
+        expect(primo_central_parameters["query"]["sort"]).to eq("bar")
+      end
     end
 
     context "param :id is searched" do


### PR DESCRIPTION
REF BL-514

Adds sorting to article searches.  The fields used are the same as what
is currently available in the catalog search.

Neither `creator` nor `date2` sorting is working.  We might need to
bring it up with Exlibris.

Depends on #626