### PR TITLE
Only show date format message for unsupported browsers

### DIFF
--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -16,7 +16,7 @@
         <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {class: "request-form form-control"}, {include_blank: true, required: true, "aria-required": true }) %>
       </div>
     </div>
-    
+
     <% if @description.present? %>
       <div class="form-group row">
         <div class="col-sm-4">
@@ -37,6 +37,10 @@
       <div class="col-sm-5">
         <%= form.label(:booking_end_date, "Booking End Date:") %>
         <%= date_field_tag :booking_end_date, "", required: true, "aria-required": true %>
+        <% if browser.ie? || browser.safari? %>
+          </br>
+          <small class="invalid-field">Please use YYYY-MM-DD format.</small>
+        <% end %>
       </div>
     </div>
 

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -37,10 +37,7 @@
       <div class="col-sm-5">
         <%= form.label(:booking_end_date, "Booking End Date:") %>
         <%= date_field_tag :booking_end_date, "", required: true, "aria-required": true %>
-        <% if browser.ie? || browser.safari? %>
-          </br>
-          <small class="invalid-field">Please use YYYY-MM-DD format.</small>
-        <% end %>
+        <%= render "format_date_message" %>
       </div>
     </div>
 

--- a/app/views/almaws/_digitization_request_form.html.erb
+++ b/app/views/almaws/_digitization_request_form.html.erb
@@ -47,7 +47,10 @@
       <div class="col-sm-5">
         <%= form.label(:last_interest_date, "Not Needed After (optional):") %>
         <%= date_field_tag :last_interest_date, Date.today() + 10, pattern:"[0-9]{4}-[0-9]{2}-[0-9]{2}", id: "digitization_date_field" %>
-        <div class="invalid-field">Please use YYYY-MM-DD format.</div>
+        <% if browser.ie? || browser.safari? %>
+          </br>
+          <small class="invalid-field">Please use YYYY-MM-DD format.</small>
+        <% end %>
       </div>
     </div>
 

--- a/app/views/almaws/_digitization_request_form.html.erb
+++ b/app/views/almaws/_digitization_request_form.html.erb
@@ -47,10 +47,7 @@
       <div class="col-sm-5">
         <%= form.label(:last_interest_date, "Not Needed After (optional):") %>
         <%= date_field_tag :last_interest_date, Date.today() + 10, pattern:"[0-9]{4}-[0-9]{2}-[0-9]{2}", id: "digitization_date_field" %>
-        <% if browser.ie? || browser.safari? %>
-          </br>
-          <small class="invalid-field">Please use YYYY-MM-DD format.</small>
-        <% end %>
+        <%= render "format_date_message" %>
       </div>
     </div>
 

--- a/app/views/almaws/_format_date_message.html.erb
+++ b/app/views/almaws/_format_date_message.html.erb
@@ -1,0 +1,4 @@
+<% if browser.ie? || browser.safari? %>
+  </br>
+  <small class="invalid-field">Please use YYYY-MM-DD format.</small>
+<% end %>

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -39,7 +39,10 @@
       <div class="col-sm-5">
         <%= form.label(:not_needed, "Not Needed After (optional):") %>
         <%= date_field_tag :last_interest_date, Date.today() + 10, pattern:"[0-9]{4}-[0-9]{2}-[0-9]{2}", id: "hold_date_field" %>
-        <div class="invalid-field">Please use YYYY-MM-DD format.</div>
+        <% if browser.ie? || browser.safari? %>
+          </br>
+          <small class="invalid-field">Please use YYYY-MM-DD format.</small>
+        <% end %>
       </div>
     </div>
 

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -39,10 +39,7 @@
       <div class="col-sm-5">
         <%= form.label(:not_needed, "Not Needed After (optional):") %>
         <%= date_field_tag :last_interest_date, Date.today() + 10, pattern:"[0-9]{4}-[0-9]{2}-[0-9]{2}", id: "hold_date_field" %>
-        <% if browser.ie? || browser.safari? %>
-          </br>
-          <small class="invalid-field">Please use YYYY-MM-DD format.</small>
-        <% end %>
+        <%= render "format_date_message" %>
       </div>
     </div>
 


### PR DESCRIPTION
BL-608 The format date message could be confusing for users that see the date presented in a different format
- limit the message to only browsers that don't support the date field (safari and internet explorer)
-safari view 
![screen shot 2018-08-27 at 9 49 11 am](https://user-images.githubusercontent.com/15167238/44663419-81c7f800-a9de-11e8-94d4-65c384820ca9.png)
- chrome view 
![screen shot 2018-08-27 at 9 50 05 am](https://user-images.githubusercontent.com/15167238/44663454-97d5b880-a9de-11e8-9032-55712bc3d426.png)

