### PR TITLE
Move javascript_pack_tag before include_tag

### DIFF
--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -20,8 +20,8 @@
     <%= opensearch_description_tag application_name, opensearch_catalog_url(:format => 'xml') %>
     <%= favicon_link_tag %>
     <%= stylesheet_link_tag "application", media: "all" %>
-    <%= javascript_include_tag "application" %>
     <%= javascript_pack_tag 'application' %>
+    <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
     <%= analytics_init if GoogleAnalytics.valid_tracker? %>


### PR DESCRIPTION
BL-585 The stimulus polyfills are not working because the blacklight_alma javascript errors before stimulus is loaded
- Puts the Webpacker javascript before the javascript_include_tag to see if the polyfills are loaded first and work for blacklight_alma javascript too