### PR TITLE
Allow export of articles in Refworks tagged format.

### DIFF
--- a/app/controllers/concerns/primo_fields_config.rb
+++ b/app/controllers/concerns/primo_fields_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Shared bookmark configuration across bookmarks behaviors.
 module PrimoFieldsConfig
   extend ActiveSupport::Concern

--- a/app/controllers/concerns/primo_fields_config.rb
+++ b/app/controllers/concerns/primo_fields_config.rb
@@ -1,0 +1,51 @@
+# Shared bookmark configuration across bookmarks behaviors.
+module PrimoFieldsConfig
+  extend ActiveSupport::Concern
+
+  included do
+    blacklight_config.configure do |config|
+      # Search fields
+      config.add_search_field :any, label: "All Fields"
+      config.add_search_field :title
+      config.add_search_field :creator, label: "Author/Creator"
+      config.add_search_field :sub, label: "Subject"
+      config.add_search_field(:description, label: "Description") do |field|
+        field.include_in_simple_select = false
+      end
+      config.add_search_field :isbn, label: "ISBN"
+      config.add_search_field :issn, label: "ISSN"
+
+      # Index fields
+      config.add_index_field :isPartOf, label: "Is Part Of"
+      config.add_index_field :creator, label: "Author/Creator", multi: true
+      config.add_index_field :type, label: "Resource Type", raw: true, helper_method: :index_translate_resource_type_code
+      config.add_index_field :date, label: "Year"
+      config.add_index_field :availability
+
+      # Facet fields
+      config.add_facet_field :tlevel, label: "Article Search Settings", collapse: false, home: true, helper_method: :translate_availability_code
+      config.add_facet_field :rtype, label: "Resource Type", limit: true, show: true, home: true, helper_method: :translate_resource_type_code
+      config.add_facet_field :creator, label: "Author/Creator"
+      config.add_facet_field :topic, label: "Topic"
+      config.add_facet_field :lang, label: "Language", limit: true, show: true, helper_method: :translate_language_code
+
+      # Show fields
+      # See for refwork tag definitions:
+      # https://www.refworks.com/refworks/help/refworks_tagged_format.htm
+      config.add_show_field :creator, label: "Author/Creator", helper_method: :browse_creator, multi: true, refwork_tag: :A1
+      config.add_show_field :contributor, label: "Contributor", helper_method: :browse_creator, multi: true, refwork_tag: :A2
+      config.add_show_field :type, label: "Resource Type", helper_method: :doc_translate_resource_type_code, refwork_tag: :RT
+      config.add_show_field :publisher, label: "Published", refwork_tag: :PB
+      config.add_show_field :date, label: "Date", refwork_tag: :YR
+      config.add_show_field :isPartOf, label: "Is Part of", refwork_tag: :JF
+      config.add_show_field :relation, label: "Related Title", helper_method: "list_with_links"
+      config.add_show_field :description, label: "Note", helper_method: :tags_strip, refwork_tag: :AB
+      config.add_show_field :subject, helper_method: :list_with_links, multi: true, refwork_tag: :K1
+      config.add_show_field :isbn, label: "ISBN", refwork_tag: :SN
+      config.add_show_field :issn, label: "ISSN", refwork_tag: :SN
+      config.add_show_field :lccn, label: "LCCN", refwork_tag: :SN
+      config.add_show_field :doi, label: "DOI"
+      config.add_show_field :languageId, label: "Language", multi: true, helper_method: :doc_translate_language_code, refwork_tag: :LA
+    end
+  end
+end

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -3,12 +3,15 @@
 class PrimoCentralController < CatalogController
   include Blacklight::Catalog
   include CatalogConfigReinit
+  include Blacklight::Document::Export
+  include PrimoFieldsConfig
 
   helper_method :browse_creator
   helper_method :tags_strip
 
   # We are not including the default configuration by default until we are sure all features work with Primo.
   add_show_tools_partial(:bookmark, partial: "bookmark_control")
+  add_show_tools_partial(:refworks, partial: "tagged_refworks", modal: false)
   add_nav_action(:bookmark, partial: "blacklight/nav/bookmark")
   add_results_document_tool(:bookmark, partial: "bookmark_control")
 
@@ -29,47 +32,6 @@ class PrimoCentralController < CatalogController
 
     # Pagination handler
     config.facet_paginator_class = Blacklight::PrimoCentral::FacetPaginator
-
-    # Search fields
-    config.add_search_field :any, label: "All Fields"
-    config.add_search_field :title
-    config.add_search_field :creator, label: "Author/Creator"
-    config.add_search_field :sub, label: "Subject"
-    config.add_search_field(:description, label: "Description") do |field|
-      field.include_in_simple_select = false
-    end
-    config.add_search_field :isbn, label: "ISBN"
-    config.add_search_field :issn, label: "ISSN"
-
-    # Index fields
-    config.add_index_field :isPartOf, label: "Is Part Of"
-    config.add_index_field :creator, label: "Author/Creator", multi: true
-    config.add_index_field :type, label: "Resource Type", raw: true, helper_method: :index_translate_resource_type_code
-    config.add_index_field :date, label: "Year"
-    config.add_index_field :availability
-
-    # Facet fields
-    config.add_facet_field :tlevel, label: "Article Search Settings", collapse: false, home: true, helper_method: :translate_availability_code
-    config.add_facet_field :rtype, label: "Resource Type", limit: true, show: true, home: true, helper_method: :translate_resource_type_code
-    config.add_facet_field :creator, label: "Author/Creator"
-    config.add_facet_field :topic, label: "Topic"
-    config.add_facet_field :lang, label: "Language", limit: true, show: true, helper_method: :translate_language_code
-
-    # Show fields
-    config.add_show_field :creator, label: "Author/Creator", helper_method: :browse_creator, multi: true
-    config.add_show_field :contributor, label: "Contributor", helper_method: :browse_creator, multi: true
-    config.add_show_field :type, label: "Resource Type", helper_method: :doc_translate_resource_type_code
-    config.add_show_field :publisher, label: "Published"
-    config.add_show_field :date, label: "Date"
-    config.add_show_field :isPartOf, label: "Is Part of"
-    config.add_show_field :relation, label: "Related Title", helper_method: "list_with_links"
-    config.add_show_field :description, label: "Note", helper_method: :tags_strip
-    config.add_show_field :subject, helper_method: :list_with_links, multi: true
-    config.add_show_field :isbn, label: "ISBN"
-    config.add_show_field :issn, label: "ISSN"
-    config.add_show_field :lccn, label: "LCCN"
-    config.add_show_field :doi, label: "DOI"
-    config.add_show_field :languageId, label: "Language", multi: true, helper_method: :doc_translate_language_code
   end
 
   def browse_creator(args)

--- a/app/models/blacklight/primo_central/document_export.rb
+++ b/app/models/blacklight/primo_central/document_export.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Blacklight::PrimoCentral::DocumentExport
+  include Blacklight::Configurable
+
+  def self.extended(document)
+    document.will_export_as(:refworks, "text/plain")
+  end
+
+  def export_as_refworks
+    tags = []
+    to_refworks.each { |t, value|
+      if value.is_a? Array
+        value.each { |v| tags << "#{t} #{v}" }
+      else
+        tags << "#{t} #{value}"
+      end
+    }
+    tags.join("\n")
+  end
+
+
+  private
+    def to_refworks
+      self.select { |f, v| refwork_tags.keys.include? f }
+        .select { |f, v| !v.nil? && !v.empty? }
+        .map { |f, v| [refwork_tags[f], v] }
+    end
+
+    def refwork_tags
+      config_tags = blacklight_config
+        .show_fields.select { |k, v| v[:refwork_tag] }
+        .map { |k, v| [k, v[:refwork_tag]] }.to_h
+
+      { "title" => :P1, "pnxId" => :ID }
+        .merge(config_tags)
+    end
+end

--- a/app/models/blacklight/primo_central/document_export.rb
+++ b/app/models/blacklight/primo_central/document_export.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module Blacklight::PrimoCentral::DocumentExport
-  include Blacklight::Configurable
-
   def self.extended(document)
     document.will_export_as(:refworks, "text/plain")
   end

--- a/app/models/blacklight/primo_central/document_export.rb
+++ b/app/models/blacklight/primo_central/document_export.rb
@@ -30,7 +30,7 @@ module Blacklight::PrimoCentral::DocumentExport
         .show_fields.select { |k, v| v[:refwork_tag] }
         .map { |k, v| [k, v[:refwork_tag]] }.to_h
 
-      { "title" => :P1, "pnxId" => :ID }
+      { "title" => :T1, "pnxId" => :ID }
         .merge(config_tags)
     end
 end

--- a/app/models/primo_central_document.rb
+++ b/app/models/primo_central_document.rb
@@ -4,7 +4,10 @@ class PrimoCentralDocument
   require "blacklight/primo_central"
 
   include Blacklight::PrimoCentral::Document
+  include Blacklight::Configurable
+  include PrimoFieldsConfig
 
+  # Email uses semantic field mappings below to generate the body of an email.
   self.unique_key = :pnxId
   field_semantics.merge!(
     title: "title" ,
@@ -17,8 +20,7 @@ class PrimoCentralDocument
     doi: "doi",
   )
 
-  # Email uses the semantic field mappings below to generate the body of an email.
-  PrimoCentralDocument.use_extension(Blacklight::Document::ArticleEmail)
-
-  PrimoCentralDocument.use_extension(Blacklight::Document::Sms)
+  use_extension Blacklight::PrimoCentral::DocumentExport
+  use_extension Blacklight::Document::ArticleEmail
+  use_extension Blacklight::Document::Sms
 end

--- a/app/views/primo_central/_tagged_refworks.erb
+++ b/app/views/primo_central/_tagged_refworks.erb
@@ -1,0 +1,1 @@
+<%= link_to t('blacklight.tools.refworks'), refworks_export_url(url: primo_central_document_url(format: :refworks), filter: "RefWorks Tagged Format"), id: "refworksLink" %>

--- a/spec/controllers/primo_central_controller_spec.rb
+++ b/spec/controllers/primo_central_controller_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe PrimoCentralController, type: :controller do
   let(:doc) { Hash.new }
   let(:document) { PrimoCentralDocument.new(doc) }
   let(:helpers) { double("helper", base_path: "/") }
+  let(:mock_response) { instance_double(Blacklight::PrimoCentral::Response) }
 
   before(:each) do
     allow(controller).to receive(:helpers).and_return(helpers)
+    allow(controller).to receive_messages fetch: [mock_response, document]
   end
 
   describe "#browse_creator" do
@@ -30,6 +32,13 @@ RSpec.describe PrimoCentralController, type: :controller do
           "<a href=\"/?search_field=creator&amp;q=Hello%2C%20World\">Hello, World</a>",
         ])
       end
+    end
+  end
+
+  describe "show action" do
+    it "gets refwork format" do
+      get :show, params: { id: 1, format: "refworks" }
+      expect(response).to be_success
     end
   end
 end

--- a/spec/models/primo_central_document_spec.rb
+++ b/spec/models/primo_central_document_spec.rb
@@ -4,6 +4,27 @@ require "rails_helper"
 
 RSpec.describe PrimoCentralDocument, type: :model do
   let (:subject) { PrimoCentralDocument.new(doc, nil) }
+  let(:doc) { Hash.new }
+
+  it "is configurable" do
+    expect(subject.blacklight_config).to_not be_nil
+  end
+
+  it "shares field configurations with the primo controller" do
+    doc_config = subject.blacklight_config
+    controller_config = (PrimoCentralController.new).blacklight_config
+
+    expect(doc_config.show_fields).to eql(controller_config.show_fields)
+    expect(doc_config.index_fields).to eql(controller_config.index_fields)
+  end
+
+  describe "#export_as_refworks" do
+    context "simple document" do
+      it "exports a refworks tagged formatted string" do
+        expect(subject.export_as_refworks).to eql("RT unknown")
+      end
+    end
+  end
 
   describe "#has_direct_link?" do
     context "document is completely empty" do


### PR DESCRIPTION
REF BL-412

This cannot be tested locally, but I set up a gist to show that the outputed format imports as expected:

http://www.refworks.com/express/expressimport.asp?vendor=Library+Search&filter=RefWorks+Tagged+Format&encoding=65001&url=https%253A%252F%252Fgist.githubusercontent.com%252Fdkinzer%252F2690c9e7cec861015b89c542ca7b7a07%252Fraw%252Ff23b391fe8261866d6a75f76b3532327e10add83%252Ftul_cob_refwork