### PR TITLE
Add polyfill function to have javascript includes in ie 11

### DIFF
--- a/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
+++ b/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
@@ -370,3 +370,14 @@ var BlacklightAlma = function (options) {
          $(element).html("<span style='color: red'>No status available for this item</span>");
      });
  };
+
+ /** This is a polyfill to get rid of a console error in Internet Explorer 11
+ that is preventing the availability information from being shown
+ */
+ String.prototype.includes = function(value){
+   return this.indexOf(value)>-1
+ }
+
+ Array.prototype.includes = function(value){
+   return this.indexOf(value)>-1||!1
+ }


### PR DESCRIPTION
BL-585 Stimulus polyfill package doesn't handle the includes method
- add function to blacklight_alma to take care of include