### PR TITLE
Align advanced submit buttons with search fields

### DIFF
--- a/app/assets/stylesheets/tucob.scss.erb
+++ b/app/assets/stylesheets/tucob.scss.erb
@@ -150,6 +150,11 @@ input[type="radio"] + label {
 .pub-date-separator {
   text-align:center;
   padding-top: 6px;
+  margin-left: 10px;
+}
+
+#range_pub_date_sort_end {
+  margin-left: 10px;
 }
 
 .advanced-search-start-over, .advanced-search-start-over a:hover, .advanced-search-start-over a:focus {
@@ -157,6 +162,11 @@ input[type="radio"] + label {
     color: #A50030 !important;
     border-color: #ccc;
     margin-left: 4px;
+
+}
+
+.submit-buttons {
+  margin-right: 95px;
 }
 
 #stimulus-warning {
@@ -256,9 +266,6 @@ div.physical-holding-panel {
   padding: 8px;
   border-collapse: inherit;
   margin: 0 !important;
-}
-
-.other_libraries {
 }
 
 .online-panel-body {
@@ -660,6 +667,15 @@ ul.navbar-nav {
     background-color: #A50030!important;
     /*border-bottom: solid #fff 2px;*/
   }
+  .pub-date-separator {
+    margin-left: 0;
+  }
+  #range_pub_date_sort_end {
+    margin-left: 0;
+  }
+  .submit-buttons {
+      margin-right: 0;
+  }
 }
 @media(max-width:485px) {
   #user-util-links ul.navbar-nav, #user-util-links ul.navbar-nav li a  {
@@ -667,6 +683,9 @@ ul.navbar-nav {
     clear: left;
     /*float: left;*/
     padding: 4px 0 0 2px;
+  }
+  .submit-buttons {
+      margin-top: 20px;
   }
 }
 

--- a/app/views/advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/advanced/_advanced_search_submit_btns.html.erb
@@ -1,12 +1,18 @@
-<div class="sort-buttons pull-left">
-  <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "control-label") %>
+<div class="row">
+  <div class="col-xs-12 col-sm-6">
+    <div class="sort-buttons pull-left">
+      <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "control-label") %>
 
-  <%= select_tag(:sort, options_for_select(sort_fields, h(current_sort_field && current_sort_field.key)), :class => "form-control sort-select") %>
-  <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
-</div>
+      <%= select_tag(:sort, options_for_select(sort_fields, h(current_sort_field && current_sort_field.key)), :class => "form-control sort-select") %>
+      <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
+    </div>
+  </div>
 
-<div class="submit-buttons pull-right">
-  <%= submit_tag t('blacklight_advanced_search.form.search_btn'), :class=>'btn btn-primary advanced-search-submit', :id => "advanced-search-submit" %>
+  <div class="col-xs-12 col-sm-6">
+    <div class="submit-buttons pull-right">
+      <%= submit_tag t('blacklight_advanced_search.form.search_btn'), :class=>'btn btn-primary advanced-search-submit', :id => "advanced-search-submit" %>
 
-  <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-default advanced-search-start-over" %>
+      <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-default advanced-search-start-over" %>
+    </div>
+  </div>
 </div>

--- a/app/views/primo_advanced/_advanced_search_fields.html.erb
+++ b/app/views/primo_advanced/_advanced_search_fields.html.erb
@@ -11,7 +11,7 @@
       <%= select_tag("operator_#{count}", options_for_select({"contains"=> :contains, "is (exact)" => :exact }.sort, operator_default(count)), :class => "form-control", :id =>"operator_#{count}") %>
     </div>
 
-    <div class="col-sm-3">
+    <div class="col-sm-4">
     <label for=<%= "q_#{count}" %> class="sr-only">Advanced search terms</label>
     <%= text_field_tag "q_#{count}", label_tag_default_for("q_#{count}"), :class => "form-control", autocorrect: "off", autocapitalize: "off", spellcheck: "false", "data-target": "primo.q#{count}" %>
     </div>

--- a/app/views/primo_advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/primo_advanced/_advanced_search_submit_btns.html.erb
@@ -1,4 +1,5 @@
-
+<div class="row">
+  <div class="col-xs-12 col-sm-6">
     <% if !sort_fields.empty? %>
     <div class="sort-buttons pull-left">
         <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "control-label") %>
@@ -6,11 +7,12 @@
         <%= select_tag(:sort, options_for_select(sort_fields, h(current_sort_field && current_sort_field.key)), :class => "form-control sort-select") %>
       </div>
     <% end %>
-
-      <div class="submit-buttons pull-right">
-        <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
-        <%= submit_tag t('blacklight_advanced_search.form.search_btn'), :class=>'btn btn-primary advanced-search-submit', :id => "advanced-search-submit", "data-action": "primo#advanced" %>
-        <%= link_to t('blacklight_advanced_search.form.start_over'), articles_advanced_search_path, :class =>"btn btn-default advanced-search-start-over" %>
-
-
-      </div>
+  </div>
+  <div class="col-xs-12 col-sm-6">
+    <div class="primo-submit-buttons pull-right">
+      <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
+      <%= submit_tag t('blacklight_advanced_search.form.search_btn'), :class=>'btn btn-primary advanced-search-submit', :id => "advanced-search-submit", "data-action": "primo#advanced" %>
+      <%= link_to t('blacklight_advanced_search.form.start_over'), articles_advanced_search_path, :class =>"btn btn-default advanced-search-start-over" %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
BL-637 More styling for the advanced catalog/article submit buttons
-buttons should be aligned with the ends of the search query inputs
![screen shot 2018-09-05 at 9 58 57 am](https://user-images.githubusercontent.com/15167238/45098123-55089480-b0f2-11e8-9474-6adb9be7418b.png)
