### PR TITLE
Reorder the article search sort fields.

### DIFF
--- a/app/controllers/concerns/primo_fields_config.rb
+++ b/app/controllers/concerns/primo_fields_config.rb
@@ -51,9 +51,9 @@ module PrimoFieldsConfig
 
       # Sort fields
       config.add_sort_field :rank, label: "relevance"
-      config.add_sort_field :title, label: "title (A to Z)"
       config.add_sort_field :date, label: "date (new to old)"
       config.add_sort_field :author, label: "author/creator (A to Z)"
+      config.add_sort_field :title, label: "title (A to Z)"
     end
   end
 end


### PR DESCRIPTION
The sort options should appear in this order: relevance, date, author/creator, title.