### PR TITLE
Force reload of referer if user gets auth error.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,9 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  rescue_from ActionController::InvalidAuthenticityToken,
+    with: :redirect_to_referer
+
   # Rails 5.1 and above requires permitted params to be defined in the Controller
   # BL doesn't do that, but might in the future. This allows us to use the pre 5.1
   # behavior until we can define all possible param  in the future.
@@ -46,6 +49,11 @@ class ApplicationController < ActionController::Base
     response.total <= spell_check_max &&
       !response.spelling.nil? &&
       response.spelling.words.any?
+  end
+
+  def redirect_to_referer
+    flash[:notice] = "Please try again."
+    redirect_to request.referer
   end
 
   protected


### PR DESCRIPTION
REF BL-576

There is a cross-site-request-forgery session token that gets added
to pages.  If a user signs in and then signs out and then tries to go
back (without reloading page) the same token appears and this causes
rails to raise an authentication exception if the user tries to follow
a link.

There are tricks to get around this involving updating the token using
javascript but this approach seems too risky since it's essentially
trying to circumvent a security measure by poking holes in it.

The best solution I could find that has no security issues is to simply
force a reload of the page the user is trying to work with.