### PR TITLE
Update limit on article OR queries.

### DIFF
--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -15,8 +15,8 @@ module Blacklight::PrimoCentral
 
       if value.is_a? Hash
         if value["pnxId"]&.is_a? Array
-          # limit ids to 9 or API returns 0 results
-          queries = to_primo_id_queries(value["pnxId"][0, 9])
+          # limit ids to 13 or API returns 0 results
+          queries = to_primo_id_queries(value["pnxId"][0, 13])
           primo_central_parameters[:query] = {
             limit: per_page,
             offset:  offset,

--- a/app/search_engines/primo_central_bookmark_search.rb
+++ b/app/search_engines/primo_central_bookmark_search.rb
@@ -5,10 +5,10 @@ class PrimoCentralBookmarkSearch < PrimoCentralController
   include BookmarksConfig
 
   def fetch(primo_doc_ids)
-    # Primo cannot string more than 9 OR queries.
+    # Primo cannot string more than 13 OR queries.
     documents = []
 
-    primo_doc_ids.each_slice(9) do |ids|
+    primo_doc_ids.each_slice(13) do |ids|
       @response, docs = super(ids)
       documents.append(*docs)
       documents.append(*docs_not_found(docs, ids))


### PR DESCRIPTION
The new api has a limit of 13 vs 9 OR queries. This change reflects that
change.