### PR TITLE
Add process type to table and set default message

### DIFF
--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -20,7 +20,7 @@ module AlmaDataHelper
 
   def unavailable_items(item)
     if item.has_process_type?
-      process_type = Rails.configuration.process_types[item.process_type]
+      process_type = Rails.configuration.process_types[item.process_type] || "Checked out or currently unavailable"
       content_tag(:span, "", class: "close-icon") + process_type
     else
       content_tag(:span, "", class: "close-icon") + "Checked out or currently unavailable"

--- a/config/process_types.yml
+++ b/config/process_types.yml
@@ -11,6 +11,7 @@ default: &default
   REQUESTED: Requested
   TECHNICAL: Unavailable - technical issue
   TRANSIT: In transit
+  WORK_ORDER_DEPARTMENT: In process
 
 test:
   <<: *default

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe AlmaDataHelper, type: :helper do
         expect(availability_status(item)).to eq "<span class=\"close-icon\"></span>At another institution"
       end
     end
+
+
   end
 
   describe "#unavailable_items(item)" do
@@ -64,6 +66,20 @@ RSpec.describe AlmaDataHelper, type: :helper do
       end
       it "displays process type" do
         expect(unavailable_items(item)).to eq "<span class=\"close-icon\"></span>At another institution"
+      end
+    end
+
+    context "item includes process_type not found in mappings" do
+      let(:item) do
+        Alma::BibItem.new("item_data" =>
+           { "base_status" =>
+             { "value" => "0" },
+             "process_type" => { "value" => "Sample" }
+           }
+         )
+      end
+      it "displays default message" do
+        expect(unavailable_items(item)).to eq "<span class=\"close-icon\"></span>Checked out or currently unavailable"
       end
     end
 


### PR DESCRIPTION
BL-640 Some items were displaying blank information when unavailable
- Add WORK_ORDER_DEPARTMENT to mappings 
- Set default text in case other mappings are missing