### PR TITLE
Fix rake assets:precompile fails.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,13 @@
 {
   "presets": [
-    "es2015",
-    ["env", {
+    "es2015", {
       "modules": false,
       "targets": {
         "browsers": "> 1%",
         "uglify": true
       },
       "useBuiltIns": true
-    }]
+    }
   ],
 
   "plugins": [


### PR DESCRIPTION
I think this is what is causing libqa to fail to render css assets.