### PR TITLE
Adds back javascript testing.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": [
+    "es2015",
     ["env", {
       "modules": false,
       "targets": {

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
 script:
 - bundle exec rubocop
 - RELEVANCE=y bundle exec rake ci
+- yarn test
 notifications:
   slack:
     secure: "VTX5ZONrylHfzfd4B1AGWvCmUrRYNJ87/ZEQccBI/dYeQnTZUgGBB6rFaqHqGFgNZJNTiU31cwPULlFr4hUgXeO6sGBrjF9Q4n4WyJxXbdjp7TjJiAeOUsjGyhRa341SNi6FUVKUIusgSIVS3IwZO+nUMVIpajepGDn+E+ia29IglzC6ZyVCBohBwiHZ3cO24K0uB+gNwoe7Ff/93JUsl7VCv+dtBDSYzron2rjNN7vnp8xJ7EDeHW4QToVUCulOpQnlZcjXEdS91BhZFlEo7QE34I7P+1nmrnvIUGmAdMXwclLjbs7T+yT/2Xcw+UM7R88CJ6LB9EXtsXhYyG9cDMOcOMQsmRZikTJKLAZLY+d4pjwLmMPzrLA/mr/TNBNAQHkUlmfxx6YRvE7D2sndeJSf3GBvb+qd6wkqsUiZL88jdyOpQFgC1T2I61uJkmulx2IriLu/udb91c+zuSDG29gMXCv3eo1bXT4WyrGi/a0+nZvAN6dXx7vqz8ivXE3iAnb+sx/tjdc9rb7U4QCe5bgJbZT2vg2gh8lk/8Q2pNACdw9VWd+0ENxW7jO7pNmKVzM6/qX5jC2OtkPYWfzij4ghOwec2xs+ZL31WLfOfyRKcU+nIAhoq5+6icRh5Z5NG07/I6Qu6Jw6h+XWsiPn8MGxKe9K1ifDuDJJhyGdBHg="

--- a/package.json
+++ b/package.json
@@ -2,12 +2,36 @@
   "dependencies": {
     "@rails/webpacker": "^3.3.1",
     "@stimulus/polyfills": "^1.1.0",
+    "babel-preset-es2015": "^6.24.1",
     "npm": "^6.4.0",
     "stimulus": "^1.1.0",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
+    "jest": "^23.5.0",
+    "jest-fetch-mock": "^1.6.5",
+    "jquery": "^3.3.1",
+    "mutationobserver-shim": "^0.3.2",
     "webpack-cli": "^2.0.11",
     "webpack-dev-server": "^2.11.1"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "verbose": false,
+    "roots": [
+      "spec/javascript"
+    ],
+    "moduleDirectories": [
+      "node_modules",
+      "app/javascript",
+      "app/javascript/packs"
+    ],
+    "setupFiles": [
+      "<rootDir>/spec/javascript/setup/mutation-observer.js",
+      "<rootDir>/spec/javascript/setup/jquery.js",
+      "<rootDir>/spec/javascript/setup/fetch-mock.js"
+    ]
   }
 }

--- a/spec/javascript/README.md
+++ b/spec/javascript/README.md
@@ -1,0 +1,123 @@
+Testing with Jest
+===
+
+Jest is a testing framework developed by Facebook to test React applications in
+a headless environment.  However, the framework is project agnostic. Jest does
+not currently run in a browser.  Instead Jest runs in a dom emulator inside of
+a NodeJs server.  The DOM environment is provided by [jsdom][1].
+
+Unfortunately jsdom does not have support for [Mutation Observers][2] out of
+the box, which is a requirement for running and testing [Stimulus][3]
+applications. Fortunately there are [polyfills][4] that can serve as a stop-gap
+until jsdom adds them.
+
+## Initialization
+Download new framework and dependencies:
+```
+yarn
+```
+
+## Use and Configuration
+Run the test with the following command:
+```
+yard test
+```
+
+To view environment settings and configurations run:
+```
+yard test --debug
+```
+
+One of Jests most exalted features is that it requires no setup or
+configuration.  However, this is only true if we were to create a new React
+application as the setup is done by the React project generator.
+
+There isn't too much to set up beyond listing the locations for where Jest can
+find the modules to test or import, and setting the root path to test
+locations.
+
+Well, that and we'll want to add the polyfill for the MutationObserver we
+mentioned earlier, as well as load JQuery into the dom and have a way to mock
+the fetch method as well as ajax calls. Then we'll be all set to test all of our
+JS code using Jest. For this step, Jest has a configuration called `setupFiles`
+which is a list of all the files that we want to run before the tests are run:
+```json
+  "jest": {
+    "roots": [
+      "spec/javascript"
+    ],
+    "moduleDirectories": [
+      "node_modules",
+      "app/javascript",
+      "app/javascript/packs"
+    ],
+    "setupFiles": [
+      "<rootDir>/spec/javascript/setup/mutation-observer.js",
+      "<rootDir>/spec/javascript/setup/jquery.js",
+      "<rootDir>/spec/javascript/setup/fetch-mock.js"
+    ]
+  }
+```
+
+## Writing Tests
+
+Jest's API is similar to rspecs so it should be relatively straight forward for most tests.  However there are some considereations.
+
+
+### Modules
+Jest seems to be designed primarily for testing of modern JS that is
+encapsuluated within modules.  Thus for are non module code the easiest way to
+test it will be to reafctor it into modules.  Then testing is done the usual
+way.
+```javascript
+import exported from 'mymodule'
+
+// test exported
+```
+
+However there are ways to get around this if we want to, but it's hacky.
+
+
+### Testing side effecting code.
+A lot of the JavaScript code that we write is side effecty (i.e. click this and something changes in the dom).  There are a couple of ways to test this but they essentially boild down to:
+
+* Set up the dom with something to interact with:
+```javascript
+document.body.innerHTML = `<div id="foo">hello world</div><button id="a"></button>`
+```
+
+* Trigger the function or an event that makes your code run
+```javascript
+$('button#a').click()
+```
+
+* Then test for an expected outcome. 
+
+### Testing code that requires a bit of time between trigger and expectations:
+Sometimes you may need to add a delay between a trigger and the expecation to give domjs time to resolve. So to do that you can wrap your expectation inside of a promise that execute a timeout.
+```javascript
+await  new Promise(resolve => {
+  setTimeout(() => {
+    const els = document.getElementsByClassName('spinner')
+    expect(els.length).toEqual(0)
+    resolve(true);
+  }, 10);
+});
+```
+(This procedure can be avoided if you setup and trigger before running the test)
+
+### Testing regular pure functions
+If you can avoid side effecty stuff than you are golden.  Write your tests and expectations in the usual mannter:
+
+```javascript
+describe('Math.pow(n, m)', () => {
+  it('returns base m raised to power of m ', () => {
+    expect(Math.pow(2, 0)).toEqual(1)
+  })
+});
+```
+
+[1]: https://github.com/jsdom/jsdom
+[2]: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+[3]: https://github.com/stimulusjs/stimulus/issues/130#issuecomment-375298389
+[4]: https://github.com/megawac/MutationObserver.js

--- a/spec/javascript/packs/controllers/availability_controller.spec.js
+++ b/spec/javascript/packs/controllers/availability_controller.spec.js
@@ -1,0 +1,85 @@
+import { Application } from 'stimulus';
+import AvailabilityController from 'controllers/availability_controller'
+
+describe('AvailabilityController', () => {
+  const controller = `
+    <div data-controller="availability" data-availability-url="http://localhost:32770/almaws/item/991030169919703811?redirect_to=http%3A%2F%2Flocalhost%3A32770%2F%3Ff%255Bavailability_facet%255D%255B%255D%3DAt%2Bthe%2BLibrary">
+      <div class="controls">
+        <button data-action="availability#item" data-availability-ids="991030169919703811" class="btn btn-sm btn-default availability-toggle-details" data-toggle="collapse" data-target="#physical-document-1, availability.button" id="available_button-1">
+          <span role="spin" aria-expanded="false">Loading...</span>
+        </button>
+        <div data-target="availability.spinner" class="spinner">
+          <span class="glyphicon glyphicon-refresh glyphicon-spin"></span>
+          Loading Availability
+        </div>
+
+        <div id="requests-container-991030169919703811" class="hidden requests-container" data-controller="requests" data-target="show.request, availability.request">
+            <a data-ajax-modal="trigger" class="log-in-link" href="/users/sign_in?redirect_to=http%3A%2F%2Flocalhost%3A32770%2F%3Ff%255Bavailability_facet%255D%255B%255D%3DAt%2Bthe%2BLibrary">Log in to see request options</a>
+        </div>
+      </div>
+
+      <div data-availability-ids="991030169919703811" id="physical-document-1" class="collapse panel-content avail-container index-avail-container">
+        <div class="table-wrapper hidden">
+          <div data-target="availability.panel"></div>
+          <div></div>
+        </div>
+      </div>
+    </div>
+  `;
+
+  document.body.innerHTML = controller
+  document.head.innerHTML = `<meta name="csrf-token" content="foo">`
+
+  const application = Application.start()
+  application.register('availability', AvailabilityController);
+
+  describe('#item', () => {
+    it('s a smoke test', () => {
+      expect(true).toBeTruthy();
+    })
+
+    test('the spinner target is removed', async () => {
+      fetch.mockResponseOnce("Hello World")
+      $('button#available_button-1').click()
+
+      await  new Promise(resolve => {
+        setTimeout(() => {
+          const els = document.getElementsByClassName('spinner')
+          expect(els.length).toEqual(0)
+          resolve(true);
+        }, 10);
+      });
+    });
+
+    test('repsone text is added to panel target', () => {
+      const response = $('div[data-target="availability.panel"]').text()
+      expect(response).toEqual("Hello World")
+    });
+
+    test('clicked is added to button class', () => {
+      let clicked = $('button#available_button-1').hasClass("clicked")
+      expect(clicked).toEqual(true)
+    });
+
+    test('panel target unhidden', () => {
+      let hidden = $('div[data-target="availability.panel"]')
+      .parent().hasClass("hidden")
+
+      expect(hidden).toEqual(false)
+    });
+
+    test('request target is unhidden', () => {
+      let hidden = $('#requests-container-991030169919703811')
+      .hasClass("hidden")
+
+      expect(hidden).toEqual(false)
+    });
+
+    test('request target gets tagged with search-results-request-btn', () => {
+      let tagged = $('#requests-container-991030169919703811')
+      .hasClass('search-results-request-btn')
+
+      expect(tagged).toEqual(true)
+    });
+  });
+});

--- a/spec/javascript/setup.test.js
+++ b/spec/javascript/setup.test.js
@@ -1,0 +1,18 @@
+describe('jQuery setup', () => {
+  test('$ is available as a global', () => {
+    expect(global.$).toBeTruthy()
+    expect(global.jQuery).toBeTruthy()
+  });
+
+  test('jQuery behaves the way we expect', () => {
+    document.body.innerHTML = "<body><div id=foo></div></body>"
+
+    expect($('#foo').length).toEqual(1)
+  });
+});
+
+describe('MutationObserver setup', () => {
+  test('MutationObserver is set', () => {
+    expect(global.MutationObserver).toBeTruthy()
+  })
+});

--- a/spec/javascript/setup/fetch-mock.js
+++ b/spec/javascript/setup/fetch-mock.js
@@ -1,0 +1,1 @@
+global.fetch = require('jest-fetch-mock')

--- a/spec/javascript/setup/jquery.js
+++ b/spec/javascript/setup/jquery.js
@@ -1,0 +1,3 @@
+import jQuery from 'jquery'
+
+global.$ = global.jQuery = jQuery

--- a/spec/javascript/setup/mutation-observer.js
+++ b/spec/javascript/setup/mutation-observer.js
@@ -1,0 +1,2 @@
+require('mutationobserver-shim');
+global.MutationObserver = window.MutationObserver;


### PR DESCRIPTION
Adds back javascript testing but fixes `rake assets:precompile` command
fails.

The reason that `rake assets:precompile` command was failing is that it
essentially reruns yarn install and removes presets that were only
available in development mode.  By moving that dependency out of dev
then it's available if required for preprocessing javascript files.