### PR TITLE
Add documentation about why almaws controller exists.

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# This controller is implemented to get information about a document's
+# availability because the alma api is currently too slow to load this at the
+# document level.
 class AlmawsController < ApplicationController
   layout proc { |controller| false if request.xhr? }
 


### PR DESCRIPTION
Coming across the almaws_controller can be confusing at first if you
don't know that alma api is too slow to use to get field information
when the document is first fetched.