### PR TITLE
Do not process non query values.

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -94,7 +94,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
       # Do not process non query values
       ops = params.fetch("operator", "q" => "default")
-        .select { |key, value| key.match(/^q/) }
+        .select { |key, value| key.match?(/^q/) }
 
       # query_key are like "q_1", "q_2"..., etc.
       # op is like "contains", "begins_with"..., etc.

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -92,7 +92,9 @@ class SearchBuilder < Blacklight::SearchBuilder
       procedures ||= []
       params["processed"] = true
 
+      # Do not process non query values
       ops = params.fetch("operator", "q" => "default")
+        .select { |key, value| key.match(/^q/) }
 
       # query_key are like "q_1", "q_2"..., etc.
       # op is like "contains", "begins_with"..., etc.

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -165,6 +165,16 @@ RSpec.describe SearchBuilder , type: :model do
       subject.send(:process_params!, params, nil)
       expect(params["processed"]).to be true
     end
+
+    context "operator has non query keys" do
+      let(:params) { { "operator" => { "f_1" => "foo" }, "f_1" => "buzz" } }
+
+      it "does not affect non query values" do
+        subject.send(:process_params!, params, [:proc1, :proc2, :proc3])
+        expect(params["f_1"]).to eq("buzz")
+      end
+    end
+
   end
 
   describe BentoSearchBuilderBehavior do


### PR DESCRIPTION
I'm getting an error locally and on libqa when I go directly to
http://localhost/catalog/991026950679703811

The issue is caused because the operator param is getting passed with
non query keys (which is unexpected).

This commit fixes the issue by making sure we don't process non query
values.