### PR TITLE
Fix advanced article search params clobbered.

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -34,11 +34,7 @@ module AdvancedHelper
     if !params["operator"]
       "contains"
     else
-      # Always select from last rows count of total values in operator[]
-      # @see BL-334
-      rows = params.select { |k| k.match(/^q_/) }
-      count_rows = rows.to_h.count
-      params["operator"][-count_rows + count - 1]
+      params["operator"]["q_#{count}"]
     end
   end
 

--- a/app/views/primo_advanced/_advanced_search_fields.html.erb
+++ b/app/views/primo_advanced/_advanced_search_fields.html.erb
@@ -2,13 +2,13 @@
   <% (1..advanced_search_config[:fields_row_count]).each do |count| %>
   <div class="row">
     <div class="col-sm-2">
-      <label for=<%= "f_#{count}" %> class="sr-only">Options for advanced search</label>
+      <label for="<%= "f_#{count}" %>" class="sr-only">Options for advanced search</label>
       <%= select_tag("f_#{count}", options_for_select(advanced_key_value, label_tag_default_for("f_#{count}")), :class=>"form-control") %>
     </div>
 
     <div class="col-sm-2">
-      <label for="<%= "operator_#{count}" %>" class="sr-only">Operator</label>
-      <%= select_tag("operator_#{count}", options_for_select({"contains"=> :contains, "is (exact)" => :exact }.sort, operator_default(count)), :class => "form-control", :id =>"operator_#{count}") %>
+      <label for="<%= "operator[q_#{count}]" %>" class="sr-only">Operator</label>
+      <%= select_tag("operator[q_#{count}]", options_for_select({"contains"=> :contains, "is (exact)" => :exact }.sort, operator_default(count)), :class => "form-control", :id =>"operator[q_#{count}}") %>
     </div>
 
     <div class="col-sm-4">

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -15,13 +15,12 @@ RSpec.describe BlacklightAdvancedSearch::RenderConstraintsOverride, type: :helpe
       expect(helper.operator_default(2)).to eq("contains")
     end
 
-    # REF BL-334
     example "two consecutive searches" do
       params = ActionController::Parameters.new(
         q_1: "james",
         q_2: "john",
         q_3: "david",
-        operator: [ "fizz", "fizz", "fizz", "foo", "bar", "bum" ]
+        operator: { "q_1" => "foo", "q_2" => "bar", "q_3" => "bum" }
       )
       allow(helper).to receive(:params).and_return(params)
 


### PR DESCRIPTION
REF BL-655

To test:

* Go to articles advanced search
* Search for `all_fields is home OR all_fields is work`
* After being redirected to search results return to advanced search.
* Verify that `is` is still selected as operator.