### PR TITLE
Fix undefined use of reference to ga.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -155,11 +155,3 @@ function toggleOnlineOnly() {
     online_facet.click()
   }
 }
-
-function handleEventClicks(event) {
-  ga('send', 'event', {
-    eventCategory: 'Click Event',
-    eventAction: 'click',
-    eventLabel: event
-  });
-}

--- a/app/assets/javascripts/listeners.js
+++ b/app/assets/javascripts/listeners.js
@@ -37,6 +37,16 @@ $(document).ready(function(){
 		{id: "available_button", category: "search-results"}
 	];
 
+  function handleEventClicks(event) {
+    if (typeof ga != "undefined") {
+      ga('send', 'event', {
+        eventCategory: 'Click Event',
+        eventAction: 'click',
+        eventLabel: event
+      });
+    }
+  }
+
 	tracks.forEach(function(track) {
 		if (el = document.getElementById(track.id)) {
 			el.addEventListener("click", function(){


### PR DESCRIPTION
On our locals `GoogleAnalytics.valid_tracker?` returns false so the `ga`
libraries will never get loaded.  However, we have some click event
listeners that use `ga`.

This change updates the event listener code in two ways:
* It moves a handler function closer to where it is actually being used
* It adds a check to make sure `ga` has been defined.