### PR TITLE
BL-649 Creates a new helper for subject links.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -329,7 +329,7 @@ class CatalogController < ApplicationController
     config.add_show_field "note_related_display", label: "Related Materials"
     config.add_show_field "note_accruals_display", label: "Additions to Collection"
     config.add_show_field "note_local_display", label: "Local Note"
-    config.add_show_field "subject_display", label: "Subject", helper_method: :list_with_links, multi: true
+    config.add_show_field "subject_display", label: "Subject", helper_method: :subject_links, multi: true
     config.add_show_field "collection_display", label: "Collection"
 
     # Preceeding Entry fields

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,9 +16,6 @@ module ApplicationHelper
 
   def get_search_params(field, query)
     case field
-    when "subject_display"
-
-      { search_field: "subject", q: query.gsub(/>|—/, ""), title: query }
     when "title_uniform_display", "title_addl_display"
       { search_field: "title", q: query }
     when "relation"
@@ -46,6 +43,14 @@ module ApplicationHelper
       creator = plain_text_subfields
     end
     creator
+  end
+
+  def subject_links(args)
+    subject_link = ""
+    args[:document][args[:field]].map do |subject|
+      subject_link = link_to(subject, "/?f[subject_facet][]=#{CGI.escape subject}")
+    end
+    subject_link
   end
 
   def has_one_electronic_resource?(document)

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -1280,7 +1280,7 @@ RSpec.feature "RecordPageFields" do
     scenario "Has list of subjects" do
       visit "catalog/#{subject_600['doc_id']}"
       within "dd.blacklight-subject_display" do
-        expect(page).to have_css("li.list_items")
+        expect(page).to have_selector("a")
       end
     end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -101,4 +101,40 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#subject_links(args)" do
+    context "links to exact subject facet string" do
+      let(:args) {
+          {
+            document:
+            {
+              subject_display: ["Middle East"]
+            },
+            field: :subject_display
+          }
+        }
+
+      it "includes link to exact subject" do
+        expect(subject_links(args)).to have_link("Middle East", href: "/?f[subject_facet][]=Middle+East")
+      end
+      it "does not link to only part of the subject" do
+        expect(subject_links(args)).to have_no_link("Middle East", href: "/?f[subject_facet][]=Middle")
+      end
+    end
+
+    context "links to subjects with special characters" do
+      let(:args) {
+          {
+            document:
+            {
+              subject_display: ["Regions & Countries - Asia & the Middle East"]
+            },
+            field: :subject_display
+          }
+        }
+      it "includes link to whole subject string" do
+        expect(subject_links(args)).to have_link("Regions & Countries - Asia & the Middle East", href: "/?f[subject_facet][]=Regions+%26+Countries+-+Asia+%26+the+Middle+East")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Our previous links were not functioning properly. Records were either linking to general subjects or displaying no results.  This methods makes sure that subject links are based on the facet and only search the exact match.