### PR TITLE
BL-649 Return list of all subjects

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,11 +46,9 @@ module ApplicationHelper
   end
 
   def subject_links(args)
-    subject_link = ""
     args[:document][args[:field]].map do |subject|
-      subject_link = link_to(subject, "/?f[subject_facet][]=#{CGI.escape subject}")
+      link_to(subject, "/?f[subject_facet][]=#{CGI.escape subject}")
     end
-    subject_link
   end
 
   def has_one_electronic_resource?(document)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -115,10 +115,10 @@ RSpec.describe ApplicationHelper, type: :helper do
         }
 
       it "includes link to exact subject" do
-        expect(subject_links(args)).to have_link("Middle East", href: "/?f[subject_facet][]=Middle+East")
+        expect(subject_links(args).first).to have_link("Middle East", href: "/?f[subject_facet][]=Middle+East")
       end
       it "does not link to only part of the subject" do
-        expect(subject_links(args)).to have_no_link("Middle East", href: "/?f[subject_facet][]=Middle")
+        expect(subject_links(args).first).to have_no_link("Middle East", href: "/?f[subject_facet][]=Middle")
       end
     end
 
@@ -133,7 +133,7 @@ RSpec.describe ApplicationHelper, type: :helper do
           }
         }
       it "includes link to whole subject string" do
-        expect(subject_links(args)).to have_link("Regions & Countries - Asia & the Middle East", href: "/?f[subject_facet][]=Regions+%26+Countries+-+Asia+%26+the+Middle+East")
+        expect(subject_links(args).first).to have_link("Regions & Countries - Asia & the Middle East", href: "/?f[subject_facet][]=Regions+%26+Countries+-+Asia+%26+the+Middle+East")
       end
     end
   end


### PR DESCRIPTION
The previous work on this issue was only returning one subject.  This refactors the code to return all of them.