### PR TITLE
Override default date field refwork tag to be :Y1

### DIFF
--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -67,7 +67,7 @@ class PrimoCentralController < CatalogController
     config.add_show_field :contributor, label: "Contributor", helper_method: :browse_creator, multi: true, refwork_tag: :A2
     config.add_show_field :type, label: "Resource Type", helper_method: :doc_translate_resource_type_code
     config.add_show_field :publisher, label: "Published", refwork_tag: :PB
-    config.add_show_field :date, label: "Date", refwork_tag: :YR
+    config.add_show_field :date, label: "Date", refwork_tag: :Y1
     config.add_show_field :isPartOf, label: "Is Part of", refwork_tag: :JF
     config.add_show_field :relation, label: "Related Title", helper_method: "list_with_links"
     config.add_show_field :description, label: "Note", helper_method: :tags_strip, refwork_tag: :AB


### PR DESCRIPTION
REF BL-412

Although the current docs list :YR as the refwork for year, this does
not seem to work as expected.  Whereas years tagged with :Y1 do seem to
work.  This change updates the year tag to be :Y1 for articles refworks.