### PR TITLE
Update advanced search facet field names.

### DIFF
--- a/app/views/primo_advanced/_advanced_search_facets.html.erb
+++ b/app/views/primo_advanced/_advanced_search_facets.html.erb
@@ -6,7 +6,7 @@
     <% end %>
     <div class="col-sm-5">
       <%= content_tag(:select, multiple: true,
-        name: "f_inclusive[#{display_facet.name}][]",
+        name: "f[#{display_facet.name}][]",
         id: display_facet.name.parameterize,
         class: "form-control custom-select selectpicker",
         data: { "live-search": "true", placeholder: "Type or select #{facet_field_label(display_facet.name).downcase.pluralize}"}) do %>


### PR DESCRIPTION
BL-659

Appending "_inclusive" to the facet field name in PCI advanced search
makes search fail to apply the facet.  This change updates the name to
simply be `f[field_name]`.