### PR TITLE
BL-641 Suppress missing, lost, and technical items

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -191,6 +191,9 @@ class CatalogController < ApplicationController
       bq: [
           "pub_date_tdt:[NOW/DAY-10YEAR TO NOW/DAY]^3500",
           "(library_based_boost_t:* -no_boost)^500"],
+      fq: %w[
+        -suppress_items_b:*
+      ] 
     }
 
     # solr path which will be added to solr base url before the other solr params.

--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -196,6 +196,7 @@ to_field "url_finding_aid_display", extract_url_finding_aid
 to_field "availability_facet", extract_availability
 to_field "location_display", extract_marc("HLDbc")
 to_field "holdings_with_no_items_display", extract_holdings_with_no_items
+to_field "suppress_items_b", suppress_items
 
 # Identifier fields
 to_field("isbn_display",  extract_marc("020a", separator: nil), &normalize_isbn)

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -460,6 +460,18 @@ module Traject
         end
       end
 
+      def suppress_items
+        lambda do |rec, acc|
+          lost = rec.fields("ITM").select { |field| field["u"] == "LOST_LOAN" }
+          missing = rec.fields("ITM").select { |field| field["u"] == "MISSING" }
+          technical = rec.fields("ITM").select { |field| field["u"] == "TECHNICAL" }
+          field = rec.fields("ITM").map { |field| field["u"] }.first
+          if rec.fields("ITM").length == 1 && (!lost.empty? || !missing.empty? || !technical.empty?)
+            acc.replace([true])
+          end
+        end
+      end
+
 
       # In order to reduce the relevance of certain libraries, we need to boost every other library
       # Make sure we still boost records what have holdings in less relevant libraries and also in another library

--- a/spec/fixtures/marc_files/lost_missing_technical.xml
+++ b/spec/fixtures/marc_files/lost_missing_technical.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
+  <record>
+    <!-- 0. Only 1 lost item -->
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22423620830003811</subfield>
+      <subfield code="b">0</subfield>
+      <subfield code="u">LOST_LOAN</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">stacks</subfield>
+      <subfield code="t">BOOK</subfield>
+      <subfield code="9">39074026623983</subfield>
+      <subfield code="e">stacks</subfield>
+      <subfield code="l">0</subfield>
+      <subfield code="8">23423620820003811</subfield>
+      <subfield code="j">0</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2018-04-26 14:44:39</subfield>
+      <subfield code="i">LB1033 .Y95 2018</subfield>
+      <subfield code="d">MAIN</subfield>
+      <subfield code="f">MAIN</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 1. Only 1 missing item -->
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22426566810003811</subfield>
+      <subfield code="b">0</subfield>
+      <subfield code="u">MISSING</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">stacks</subfield>
+      <subfield code="t">BOOK</subfield>
+      <subfield code="9">39074026633206</subfield>
+      <subfield code="e">stacks</subfield>
+      <subfield code="l">0</subfield>
+      <subfield code="8">23426566800003811</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2018-05-17 14:48:38</subfield>
+      <subfield code="i">BD175 .M67 2018</subfield>
+      <subfield code="d">MAIN</subfield>
+      <subfield code="f">MAIN</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 2. Only 1 technical item -->
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22337125590003811</subfield>
+      <subfield code="b">0</subfield>
+      <subfield code="u">TECHNICAL</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">BOOK</subfield>
+      <subfield code="9">39074012140778</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23337125580003811</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2017-06-20 15:12:23</subfield>
+      <subfield code="i">DS485.P17 G6</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 3. Multiple items with one lost -->
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22423620830003811</subfield>
+      <subfield code="b">0</subfield>
+      <subfield code="u">LOST_LOAN</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">stacks</subfield>
+      <subfield code="t">BOOK</subfield>
+      <subfield code="9">39074026623983</subfield>
+      <subfield code="e">stacks</subfield>
+      <subfield code="l">0</subfield>
+      <subfield code="8">23423620820003811</subfield>
+      <subfield code="j">0</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2018-04-26 14:44:39</subfield>
+      <subfield code="i">LB1033 .Y95 2018</subfield>
+      <subfield code="d">MAIN</subfield>
+      <subfield code="f">MAIN</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22399365310003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">stacks</subfield>
+      <subfield code="t">BOOK</subfield>
+      <subfield code="9">39074026674705</subfield>
+      <subfield code="e">stacks</subfield>
+      <subfield code="l">0</subfield>
+      <subfield code="8">23399365260003811</subfield>
+      <subfield code="j">0</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2017-08-11 15:47:40</subfield>
+      <subfield code="i">PS3608.U585 A6 2017</subfield>
+      <subfield code="d">MAIN</subfield>
+      <subfield code="f">MAIN</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -717,4 +717,41 @@ RSpec.describe Traject::Macros::Custom do
       end
     end
   end
+
+  describe "#suppress_items" do
+    let(:path) { "lost_missing_technical.xml" }
+
+    before do
+      subject.instance_eval do
+        to_field "suppress_items_b", suppress_items
+        settings do
+          provide "marc_source.type", "xml"
+        end
+      end
+    end
+
+    context "when a single item is lost" do
+      it "maps lost record" do
+        expect(subject.map_record(records[0])).to eq("suppress_items_b" => [true])
+      end
+    end
+
+    context "when a single item is missing" do
+      it "maps missing record" do
+        expect(subject.map_record(records[1])).to eq("suppress_items_b" => [true])
+      end
+    end
+
+    context "when a single item is technical" do
+      it "maps technical record" do
+        expect(subject.map_record(records[2])).to eq("suppress_items_b" => [true])
+      end
+    end
+
+    context "when there are multiple items and one of the records is lost" do
+      it "does not map to the field" do
+        expect(subject.map_record(records[3])).to eq({})
+      end
+    end
+  end
 end


### PR DESCRIPTION
Records that have only a single item with a process type of missing, lost, or tecnical should not displayed in the search results.
- Creates a method in traject to identify records  
- Suppresses them in a filter query at the solr level