### PR TITLE
BL-652 Try auto for availability scroll bars

### DIFF
--- a/app/assets/stylesheets/tucob.scss.erb
+++ b/app/assets/stylesheets/tucob.scss.erb
@@ -338,7 +338,12 @@ table.border-bottom {
   td[headers*="status"] {
     padding-right:4px;
     width: 20%;
+    border-right: solid #CFC7B0 1px;
   }
+}
+
+table.other_libraries td:last-child  {
+  border-right: solid #CFC7B0 1px;
 }
 
 .table-heading {
@@ -349,7 +354,7 @@ table.border-bottom {
   border: none;
   display: block;
   max-height: 300px;
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   margin-right: -10px;
   margin-bottom: 0 !important;


### PR DESCRIPTION
Internet Explorer is always displaying a scroll bar, even when the content fits inside the container.  Try using overflow: auto to fix this.