### PR TITLE
Normalize the primo/pnxs id.

### DIFF
--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -20,6 +20,9 @@ module Blacklight::PrimoCentral::Document
     doc["pnxId"] = doc["pnxId"]&.gsub("/", "-slash-")
     doc["pnxId"] = doc["pnxId"]&.gsub(";", "-semicolon-")
 
+    # Normalizes the primos/pnxs id to the primo/search id
+    doc["pnxId"] = doc["pnxId"]&.gsub(/^TN_/, "")
+
     doc["description"] ||= doc.dig("pnx", "search", "description")&.first
     doc["subject"] ||= doc.dig("pnx", "search", "subject")
 

--- a/app/search_engines/primo_central_bookmark_search.rb
+++ b/app/search_engines/primo_central_bookmark_search.rb
@@ -19,7 +19,11 @@ class PrimoCentralBookmarkSearch < PrimoCentralController
 
   private
     def docs_not_found(docs, ids)
-      (ids - docs.map { |doc| doc["pnxId"] })
-        .map { |id| PrimoCentralDocument.new("pnxId" => id, "ajax" => true) }
+      if docs.length == ids.length
+        []
+      else
+        (ids - docs.map { |doc| doc["pnxId"] })
+          .map { |id| PrimoCentralDocument.new("pnxId" => id, "ajax" => true) }
+      end
     end
 end

--- a/spec/models/primo_central_document_spec.rb
+++ b/spec/models/primo_central_document_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe PrimoCentralDocument, type: :model do
     expect(doc_config.index_fields).to eql(config.index_fields)
   end
 
+  context "a pnxs object is loaded" do
+    let(:doc) { { "pnxId" => "TN_fizzfuzz" } }
+    it "removes TN_ from beginning of id" do
+      expect(subject.id).to eq("fizzfuzz")
+    end
+  end
+
   describe "#export_as_refworks" do
     context "simple document" do
       it "exports a refworks tagged formatted string" do


### PR DESCRIPTION
REF BL-571

Unfortunately we are currently using two separate APIs for the primo
search functionality and they are not entirely comparable.  Thus when an
article is loaded in the show view its id is different than when we see
it in the index view.

Also, when we bookmark an article we use its id to bookmark it.
Therefore the id saved when we bookmark an article from the index view
must be the same as when we bookmark the same article from the show
view. Currently these ids are not the same.

Fortunately the id for the primo/pnxs and primo/search APIs seem to only
differ in that the latter do not have TN_ in the beginning of the id.

This commit normalizes the id that is used for the record document so
that regardless of whether the item is bookmarked from the index view or
the show view it will be the same as for the primo/search id.

This change also adds a short circuit to the code that determines what
items need to be loaded via ajax.