### PR TITLE
Fix bookmark tools not rendering all actions.

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -5,4 +5,8 @@ class BookmarksController < CatalogController
   include Blacklight::Bookmarks
   include MultiSourceBookmarks
   include BookmarksConfig
+
+  configure_blacklight do |config|
+    add_show_tools_partial(:ris, label: "RIS File", modal: false, path: :ris_path)
+  end
 end

--- a/app/views/bookmarks/_show_tools.html.erb
+++ b/app/views/bookmarks/_show_tools.html.erb
@@ -11,7 +11,7 @@
 <% if show_doc_actions? %>
 <% @sendto = {} %>
       <ul id="tools-navbar">
-        <%= render_show_doc_actions @document do |config, inner| %>
+        <%= render_show_doc_actions @document_list do |config, inner| %>
 
           <% @sendto[config.key] = inner %>
 
@@ -23,10 +23,6 @@
               <% @sendto.each do |key,value| %>
                 <li class="sendto-item">
                   <%= value %>
-                </li>
-                <li>
-                  <% # Temporarily disable ris %>
-                  <% #link_to("RIS File", ris_path, class: "sendto-item") %>
                 </li>
               <% end %>
             </ul>


### PR DESCRIPTION
Because we are passing @document instead of @document_list to
the `render_show_actions` method in the bookmarks context, not all
actions can be added via configuration.

This change updates the bookmarks action template to pass @document_list to
`render_show_actions` and removes adding RIS action via the template and
instead adds that via configuration as would be expected.