### PR TITLE
Bl 639 email updates

### DIFF
--- a/app/models/concerns/blacklight/document/email.rb
+++ b/app/models/concerns/blacklight/document/email.rb
@@ -2,6 +2,7 @@
 
 # This module provides the body of an email export based on the document's semantic values
 module Blacklight::Document::Email
+  include ApplicationHelper
   # Return a text string that will be the body of the email
   # Overridden in order to add our own custom fields to email text.
   def to_email_text
@@ -15,7 +16,12 @@ module Blacklight::Document::Email
         body << I18n.t(label, value: value.join("; ").gsub("|", "; "))
       end
     end
-
+    body << add_holdings_information
     return body.join("\n") unless body.empty?
+  end
+
+  def add_holdings_information
+    holdings = materials.collect { |material| material["library"] + " - " + material["location"] + " - " + material["call_number"] }
+    I18n.t("blacklight.email.text.location", value: "\n" + holdings.join("\n"))
   end
 end

--- a/app/models/concerns/blacklight/document/email.rb
+++ b/app/models/concerns/blacklight/document/email.rb
@@ -22,6 +22,6 @@ module Blacklight::Document::Email
 
   def add_holdings_information
     holdings = materials.collect { |material| material["library"] + " - " + material["location"] + " - " + material["call_number"] }
-    I18n.t("blacklight.email.text.location", value: "\n" + holdings.join("\n"))
+    return I18n.t("blacklight.email.text.location", value: "\n" + holdings.join("\n"))
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -17,8 +17,7 @@ class SolrDocument
     issn: "issn_display",
     language: "language_display",
     format: "format",
-    alma_mms: "alma_mms_display",
-    location: "location_display",
+    alma_mms: "alma_mms_display"
   )
 
   # Email uses the semantic field mappings below to generate the body of an email.

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -40,6 +40,7 @@ en:
         issn: "ISSN: %{value}"
         isbn: "ISBN: %{value}"
         alma_mms: "Catalog Record ID: %{value}"
+        location: "Located at: %{value}"
         part_of: "Is Part Of: %{value}"
         date: "Date: %{value}"
         doi: "DOI"


### PR DESCRIPTION
- Adds the library name, location and call number for each holding to the 
email message text.
- Adds conditional statement so that translation string is not returned for empty holdings