### PR TITLE
Remove the default range facet on article searches.

### DIFF
--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -113,7 +113,10 @@ module Blacklight::PrimoCentral
       range = YearRange.new(min, max)
       primo_central_parameters[:range] = range
 
-      primo_central_parameters[:query][:q].date_range_facet(min: min, max: max)
+      # Adding the date range facet prematurely causes search discrepencies.
+      if (min || max)
+        primo_central_parameters[:query][:q].date_range_facet(min: min, max: max)
+      end
     end
 
     private

--- a/spec/models/primo_search_builder_spec.rb
+++ b/spec/models/primo_search_builder_spec.rb
@@ -170,8 +170,8 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
         expect(range.max).to be_nil
       end
 
-      it "adds a default range facet" do
-        expect(facets).to eq("facet_searchcreationdate,exact,[0 TO 9999]")
+      it "does not add a default range facet" do
+        expect(facets).to be_nil
       end
     end
 


### PR DESCRIPTION
REF BL-644

Adding a default range facet is causing major discrepancies between
libqa and librarysearch article searches.  This change removes adding
a premature range facet until a range search is actually done.