### PR TITLE
BL-649 Add root_path to subject links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,7 +47,7 @@ module ApplicationHelper
 
   def subject_links(args)
     args[:document][args[:field]].map do |subject|
-      link_to(subject, "/?f[subject_facet][]=#{CGI.escape subject}")
+      link_to(subject, "#{root_path}?f[subject_facet][]=#{CGI.escape subject}")
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -115,10 +115,10 @@ RSpec.describe ApplicationHelper, type: :helper do
         }
 
       it "includes link to exact subject" do
-        expect(subject_links(args).first).to have_link("Middle East", href: "/?f[subject_facet][]=Middle+East")
+        expect(subject_links(args).first).to have_link("Middle East", href: "#{root_path}?f[subject_facet][]=Middle+East")
       end
       it "does not link to only part of the subject" do
-        expect(subject_links(args).first).to have_no_link("Middle East", href: "/?f[subject_facet][]=Middle")
+        expect(subject_links(args).first).to have_no_link("Middle East", href: "#{root_path}?f[subject_facet][]=Middle")
       end
     end
 
@@ -133,7 +133,7 @@ RSpec.describe ApplicationHelper, type: :helper do
           }
         }
       it "includes link to whole subject string" do
-        expect(subject_links(args).first).to have_link("Regions & Countries - Asia & the Middle East", href: "/?f[subject_facet][]=Regions+%26+Countries+-+Asia+%26+the+Middle+East")
+        expect(subject_links(args).first).to have_link("Regions & Countries - Asia & the Middle East", href: "#{root_path}?f[subject_facet][]=Regions+%26+Countries+-+Asia+%26+the+Middle+East")
       end
     end
   end


### PR DESCRIPTION
Subject links are not working on LibQA because they don't have the /catalog portion of the link.  Add root_path to allow it to work in all instances.