### PR TITLE
BL-650 Account page in internet explorer

### DIFF
--- a/app/javascript/packs/controllers/holds_controller.js
+++ b/app/javascript/packs/controllers/holds_controller.js
@@ -22,7 +22,7 @@ export default class extends Controller {
     })
       .then(response => response.text())
       .then(html => {
-        this.spinnerTarget.remove();
+        $(this.spinnerTarget).remove();
         this.tableTarget.innerHTML = html
       })
   }

--- a/app/javascript/packs/controllers/loans_controller.js
+++ b/app/javascript/packs/controllers/loans_controller.js
@@ -22,7 +22,7 @@ export default class extends Controller {
     })
       .then(response => response.text())
       .then(html => {
-        this.spinnerTarget.remove();
+        $(this.spinnerTarget).remove();
         this.tableTarget.innerHTML = html
       })
   }


### PR DESCRIPTION
Internet Explorer 11 does not support the javascript remove method, which causes a console error. 
-  Changes the remove methods to use jQuery, which is supported by ie 11