### PR TITLE
Add mirror URL to avoid network error.

### DIFF
--- a/lib/tasks/server.rake
+++ b/lib/tasks/server.rake
@@ -35,8 +35,9 @@ end
 
 def run_solr(environment, solr_params)
   url = "http://lib-solr-mirror.princeton.edu/dist/lucene/solr/6.6.1/solr-6.6.1.zip"
+  mirror_url = "http://lib-solr-mirror.princeton.edu/dist/"
   md5sum = "1c8da8ac0992ca40a33c3ebaf0c1c359"
-  solr_params.merge!(url: url, md5sum: md5sum)
+  solr_params.merge!(url: url, md5sum: md5sum, mirror_url: mirror_url)
   solr_dir = File.join(File.expand_path(".", File.dirname(__FILE__)), "../../", "solr")
   SolrWrapper.wrap(solr_params) do |solr|
     ENV["SOLR_TEST_PORT"] = solr.port


### PR DESCRIPTION
apache.org is throwing network errors when we attempt to download solr
from them using solr_wrapper. We are adding a mirror_url to avoid using
the default mirror that uses  apache.org instead of princeton.edu.