### PR TITLE
Request the maximum allowed number of items from bib api.

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -79,7 +79,8 @@ class SolrDocument
   def materials_data
     Proc.new {
       @materials_data ||= alma_availability_mms_ids.map { |id|
-        Alma::BibItem.find(id).filter_missing_and_lost
+        # return maximum allowed item or lose items.
+        Alma::BibItem.find(id, limit: 100).filter_missing_and_lost
       }.first
     }
   end


### PR DESCRIPTION
REF BL-639

The Alma bib api has a default limit of 10 and a maximum limit of 100
items returned per query. This update makes sure that we are querying
for the maximum allowed number.