### PR TITLE
BL-648 Use Worldcat API for citations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ gem "honeybadger"
 gem "browser"
 gem "blacklight-ris", git: "https://github.com/upenn-libraries/blacklight-ris.git"
 gem "bootstrap-select-rails"
+gem "httparty"
 
 group :production do
   gem "mysql2", "~> 0.4.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -503,6 +503,7 @@ DEPENDENCIES
   guard-shell
   hashie (~> 3.4.6)
   honeybadger
+  httparty
   jbuilder (~> 2.5)
   jquery-rails
   launchy

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,7 @@
 //= require blacklight_alma/blacklight_alma
 //= require bootstrap-select
 //= require bootstrap/alert
+//= require bootstrap/tab
 //= require bootstrap/dropdown
 // For blacklight_range_limit built-in JS, if you don't want it you don't need
 // this:

--- a/app/assets/stylesheets/tucob.scss.erb
+++ b/app/assets/stylesheets/tucob.scss.erb
@@ -509,6 +509,17 @@ ul.navbar-nav {
   color: #A50030;
 }
 
+.grouped-citations {
+  padding: 15px;
+}
+
+.citation-btn {
+  border: 0;
+  background-color: #f1efe7;
+  color: #A50030;
+  padding: 8px 12px;
+}
+
 /* === MEDIA QUERIES === */
 
 @media (min-width: 992px) {

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -136,4 +136,8 @@ module CatalogHelper
   def library_link
     Rails.configuration.library_link
   end
+
+  def grouped_citations(documents)
+    Citation.grouped_citations(documents.map(&:citations))
+  end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -140,7 +140,7 @@ module CatalogHelper
   def grouped_citations(documents)
     Citation.grouped_citations(documents.map(&:citations))
   end
-  
+
   def render_marc_view
     if @document.respond_to?(:to_marc)
       render "marc_view"

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+class Citation
+  def initialize(document, formats = [])
+    @document = document
+    @formats = formats
+  end
+
+  def citable?
+    field.present?
+  end
+
+  def citations
+    return null_citation if return_null_citation?
+    return all_citations if all_formats_requested?
+    all_citations.select do |format, _|
+      desired_formats.include?(format)
+    end
+  end
+
+  class << self
+    def grouped_citations(all_citations)
+      citations = all_citations.each_with_object({}) do |cites, hash|
+        cites.each do |format, citation|
+          hash[format] ||= []
+          hash[format] << citation
+        end
+      end
+    end
+  end
+
+  private
+
+    attr_reader :document, :formats
+
+    def return_null_citation?
+      all_citations.blank? || (field.blank? && all_citations.blank?)
+    end
+
+    def element_is_citation?(element)
+      element.attributes &&
+        element.attributes["class"] &&
+        element.attributes["class"].value =~ /^citation_style_/i
+    end
+
+    def all_formats_requested?
+      desired_formats == ["ALL"]
+    end
+
+    def all_citations
+      @all_citations ||= begin
+        citation_hash = {}
+        citation_hash.merge!(citations_from_oclc_response) if field.present?
+        citation_hash
+      end
+    end
+
+    def citations_from_oclc_response
+      Nokogiri::HTML(response).css("p").each_with_object({}) do |element, hash|
+        next unless element_is_citation?(element)
+        element.attributes["class"].value[/^citation_style_(.*)$/i]
+        hash[Regexp.last_match[1].upcase] = element.to_html.html_safe
+      end
+    end
+
+    def response
+      @response ||= begin
+        HTTParty.get(api_url)
+        rescue HTTParty::Error::ConnectionFailed, HTTParty::TimeoutError => e
+          Rails.logger.warn("HTTP GET for #{api_url} failed with #{e}")
+          ""
+      end
+    end
+
+    def api_url
+      "#{base_url}/#{field}?cformat=all&wskey=#{api_key}"
+    end
+
+    def field
+      field = Array(document["oclc_number_display"]).try(:first)
+    end
+
+    def desired_formats
+      return config["citation_formats"].map(&:upcase) unless formats.present?
+      formats.map(&:upcase)
+    end
+
+    def base_url
+      config["base_url"]
+    end
+
+    def api_key
+      config["apikey"]
+    end
+
+    def config
+      Rails.configuration.oclc
+    end
+
+    def null_citation
+      { "NULL" => "<p>No citation available for this record</p>".html_safe }
+    end
+end

--- a/app/models/concerns/citable.rb
+++ b/app/models/concerns/citable.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Simple concern mixed into classes to return citations
+module Citable
+  extend ActiveSupport::Concern
+
+  included do
+    delegate :citable?, :citations, to: :citation_object
+  end
+
+  private
+
+    def citation_object
+      @citation_object ||= Citation.new(self)
+    end
+end

--- a/app/models/primo_central_document.rb
+++ b/app/models/primo_central_document.rb
@@ -4,6 +4,7 @@ class PrimoCentralDocument
   require "blacklight/primo_central"
 
   include Blacklight::PrimoCentral::Document
+  include Citable
 
   # Email uses semantic field mappings below to generate the body of an email.
   self.unique_key = :pnxId

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -4,6 +4,7 @@ class SolrDocument
   include Blacklight::Solr::Document
   include Blacklight::Solr::Document::RisFields
   include AlmaDataHelper
+  include Citable
 
   use_extension(Blacklight::Solr::Document::RisExport)
 

--- a/app/views/bookmarks/_show_tools.html.erb
+++ b/app/views/bookmarks/_show_tools.html.erb
@@ -12,10 +12,15 @@
 <% @sendto = {} %>
       <ul id="tools-navbar">
         <%= render_show_doc_actions @document_list do |config, inner| %>
-
           <% @sendto[config.key] = inner %>
-
         <% end %>
+
+        <% if @documents.any? { |doc| doc.citable? } %>
+        <li>
+          <%= link_to t("blacklight.tools.cite_html"), citation_bookmark_path(:id => @documents), {:id => "citeLink", :data => {:ajax_modal => "trigger"}, :class => "citation-btn"} %>
+        </li>
+        <% end %>
+
         <li id="sendto-menu">
           <div id="bookmarks-sendto">
             <button class="sendto btn btn-default dropdown-toggle" data-toggle="dropdown">Send To <span class="caret"></span></button>

--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -1,27 +1,10 @@
 <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-hidden="true">×</button>
-
-<% @documents.each do |document| %>
-<div class="cite-modal">
-  <h3 class="modal-title"><%= document_heading(document) %></h3>
-
-<% if document.respond_to?(:export_as_mla_citation_txt) %>
-  <h4><%= t('blacklight.citation.mla') %></h4>
-  <%= document.send(:export_as_mla_citation_txt).html_safe %><br/><br/>
-<% end %>
-
-<% if document.respond_to?(:export_as_apa_citation_txt) %>
-  <h4><%= t('blacklight.citation.apa') %></h4>
-  <%= document.send(:export_as_apa_citation_txt).html_safe %><br/><br/>
-<% end %>
-
-<%- if document.respond_to?(:export_as_chicago_citation_txt) -%>
-  <h4><%= t('blacklight.citation.chicago') %></h4>
-  <%= document.send(:export_as_chicago_citation_txt).html_safe %>
-<%- end -%>
-</div>
+<% if @documents.one? %>
+  <%= render partial: "catalog/single_citation", locals: { document: @documents.first } %>
+<% else %>
+  <%= render "catalog/grouped_citations" %>
 <% end %>
 
 <div class="alert alert-warning">
   Remember to check citations for accuracy before including them in your work.
 </div>
-

--- a/app/views/catalog/_grouped_citations.html.erb
+++ b/app/views/catalog/_grouped_citations.html.erb
@@ -1,0 +1,31 @@
+
+<div class='grouped-citations'>
+  <ul class="nav nav-tabs" role="tablist">
+    <li role="presentation" class="active">
+      <a href="#titles" aria-controls="titles" role="tab" data-toggle="tab">By title</a>
+    </li>
+    <li role="presentation">
+      <a href="#biblio" aria-controls="biblio" role="tab" data-toggle="tab">By citation format</a>
+    </li>
+  </ul>
+
+
+  <div class="tab-content">
+    <div role="tabpanel" class="tab-pane active" id="titles">
+      <% @documents.each do |document| %>
+        <%= render partial: 'catalog/single_citation', locals: { document: document } %>
+      <% end %>
+    </div>
+    <div role="tabpanel" class="tab-pane" id="biblio">
+      <% grouped_citations(@documents).each do |format, citations| %>
+        <% unless format == 'NULL' %>
+          <h4><%= format %></h4>
+
+          <% citations.each do |citation| %>
+            <%= citation %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -11,10 +11,15 @@
 <% @sendto = {} %>
       <ul id="tools-navbar">
         <%= render_show_doc_actions @document do |config, inner| %>
-        <% if config.key == :citation || config.key == :bookmark %>
+        <% if config.key == :bookmark %>
           <li class="<%= config.key %>">
             <%= inner %>
           </li>
+          <% if @document.citable? %>
+          <li>
+            <%= link_to t("blacklight.tools.cite_html"), citation_solr_document_path(:id => @document), {:id => "citeLink", :data => {:ajax_modal => "trigger"}, :class => "citation"} %>
+          </li>
+          <% end %>
         <% else %>
 
           <% @sendto[config.key] = inner %>

--- a/app/views/catalog/_single_citation.html.erb
+++ b/app/views/catalog/_single_citation.html.erb
@@ -1,0 +1,9 @@
+<div class="cite-modal">
+  <h3 class="modal-title"><%= document_heading(document) %></h3>
+  <% document.citations.each do |format, citation| %>
+    <% unless format == "NULL" %>
+      <h4><%= format %></h4>
+    <% end %>
+    <%= citation %>
+  <% end %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,7 @@ module Tulcob
     config.locations = config_for(:locations).with_indifferent_access
     config.alma = config_for(:alma).with_indifferent_access
     config.bento = config_for(:bento).with_indifferent_access
+    config.oclc = config_for(:oclc).with_indifferent_access
     config.twilio = config_for(:twilio).with_indifferent_access
     config.devise = config_for(:devise).with_indifferent_access
     config.caches = config_for(:caches).with_indifferent_access

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -73,6 +73,7 @@ en:
     tools:
       sms: "Text"
       refworks: Refworks
+      cite_html: "Cite"
 
     requests:
       log_in: "Log in to see request options"

--- a/config/oclc.yml
+++ b/config/oclc.yml
@@ -1,0 +1,13 @@
+default: &default
+  apikey: <%= ENV['OCLC_WS_KEY'] || "ws_key" %>
+  base_url: http://www.worldcat.org/webservices/catalog/content/citations
+  citation_formats: ["all"]
+
+development:
+    <<: *default
+
+test:
+    <<: *default
+
+production:
+    <<: *default

--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -206,6 +206,7 @@ to_field "pub_no_display", extract_marc("028ab")
 to_field "sudoc_display", extract_marc("086|0*|a")
 to_field "diamond_id_display", extract_marc("907a")
 to_field "gpo_display", extract_marc("074a")
+to_field "oclc_number_display", extract_oclc_number
 to_field "alma_mms_display", extract_marc("001")
 
 # Preceding Entry fields

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -472,6 +472,21 @@ module Traject
         end
       end
 
+      def extract_oclc_number
+        lambda do |rec, acc|
+          rec.fields(["035", "979"]).each do |field|
+            unless field.nil?
+              unless field["a"].nil? || field["9"]&.include?("ExL")
+                if field["a"].include?("OCoLC") || field["a"].include?("ocn") || field["a"].include?("ocm") || field["a"].include?("on") || field["a"].include?("OCLC")
+                  subfield = field["a"].split(//).map { |x| x[/\d+/] }.compact.join("")
+                end
+                acc << subfield
+              end
+            end
+            acc.uniq!
+          end
+        end
+      end
 
       # In order to reduce the relevance of certain libraries, we need to boost every other library
       # Make sure we still boost records what have holdings in less relevant libraries and also in another library

--- a/spec/fixtures/marc_files/oclc.xml
+++ b/spec/fixtures/marc_files/oclc.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
+  <record>
+    <!-- 0. No OCLC info available -->
+  </record>
+  <record>
+    <!-- 1. 035 includes OCoLC -->
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)on1042418854</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 2. 979 includes OCoLC -->
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">(OCoLC)on1042418854</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 3. 979 and 035 fields include OCoLC -->
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)on1042418854</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">(OCoLC)on1042418854</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 4. 979 includes ocn -->
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocn986990990</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 5. 979 includes on -->
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">on1012488209</subfield>
+    </datafield>
+  </record>
+  <record>
+    <!-- 6. 979 and 035 fields have different numbers -->
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)938995310</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocn882543310</subfield>
+    </datafield>
+  </record>
+  <record>
+  <!-- 7. 035 has subfield 9 with ExL -->
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">on1012488209</subfield>
+      <subfield code="9">ExL</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe CatalogHelper, type: :helper do
       grouped_citations(documents)
     end
   end
-  
+
   describe "#render_marc_view" do
     let(:doc) { OpenStruct.new(to_marc: "foo") }
 

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -12,6 +12,7 @@ require "rails_helper"
 #     end
 #   end
 # end
+
 RSpec.describe CatalogHelper, type: :helper do
   describe "#isbn_data_attribute" do
     context "document contains an isbn" do
@@ -28,12 +29,22 @@ RSpec.describe CatalogHelper, type: :helper do
       end
     end
 
-
     context "document contains an isbn" do
       let(:document) { {} }
       it "returns the data-isbn string" do
         expect(isbn_data_attribute(document)).to be_nil
       end
+    end
+  end
+
+  describe "#grouped_citations" do
+    it "sends all the given document citations to the grouped_citations method of the Citation class" do
+      documents = [
+        double("Document", citations: :abc),
+        double("Document", citations: :def)
+      ]
+      expect(Citation).to receive(:grouped_citations).with([:abc, :def])
+      grouped_citations(documents)
     end
   end
 end

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -754,4 +754,65 @@ RSpec.describe Traject::Macros::Custom do
       end
     end
   end
+
+  describe "#extract_oclc_number" do
+    let(:path) { "oclc.xml" }
+
+    before do
+      subject.instance_eval do
+        to_field "oclc_number_display", extract_oclc_number
+        settings do
+          provide "marc_source.type", "xml"
+        end
+      end
+    end
+
+    context "when there is no 035 or 979 field" do
+      it "does not map record" do
+        expect(subject.map_record(records[0])).to eq({})
+      end
+    end
+
+    context "when 035 field includes OCoLC" do
+      it "maps record" do
+        expect(subject.map_record(records[1])).to eq("oclc_number_display" => ["1042418854"])
+      end
+    end
+
+    context "when 979 field includes OCoLC" do
+      it "maps record" do
+        expect(subject.map_record(records[2])).to eq("oclc_number_display" => ["1042418854"])
+      end
+    end
+
+    context "when 979 field and 035 field includes OCoLC" do
+      it "maps record" do
+        expect(subject.map_record(records[3])).to eq("oclc_number_display" => ["1042418854"])
+      end
+    end
+
+    context "when 979 field includes ocn" do
+      it "maps record" do
+        expect(subject.map_record(records[4])).to eq("oclc_number_display" => ["986990990"])
+      end
+    end
+
+    context "when 979 field includes on" do
+      it "maps record" do
+        expect(subject.map_record(records[5])).to eq("oclc_number_display" => ["1012488209"])
+      end
+    end
+
+    context "when 979 field and 035 field have different OCLC numbers" do
+      it "maps record" do
+        expect(subject.map_record(records[6])).to eq("oclc_number_display" => ["938995310", "882543310"])
+      end
+    end
+
+    context "when 035 field includes subfield 9 with ExL" do
+      it "does not map record" do
+        expect(subject.map_record(records[7])).to eq({})
+      end
+    end
+  end
 end

--- a/spec/models/citation_spec.rb
+++ b/spec/models/citation_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Citation, type: :model do
+  subject { described_class.new(document, formats) }
+  let(:citations) do
+    [
+      "<p class='citation_style_MLA'>MLA Citation</p>",
+      "<p class='citation_style_APA'>APA Citation</p>"
+    ]
+  end
+
+  describe "#citable?" do
+    context "when there is no oclc number" do
+      let(:formats) { [] }
+      let(:document) { SolrDocument.new(subject_display: "No OCLC") }
+      it "is false" do
+        expect(subject).to_not be_citable
+      end
+    end
+
+    context "when there is an oclc number" do
+      let(:formats) { [] }
+      let(:document) { SolrDocument.new(oclc_number_display: "12345") }
+      it "is true" do
+        expect(subject).to be_citable
+      end
+    end
+  end
+
+  describe "#citations" do
+    context "when there is no data returned from OCLC" do
+      let(:formats) { [] }
+      let(:document) { SolrDocument.new(oclc_number_display: "") }
+
+      it "returns the NULL citation" do
+        expect(subject.citations["NULL"]).to eq "<p>No citation available for this record</p>"
+      end
+    end
+
+    context "when all formats are requested" do
+      let(:document) { SolrDocument.new(oclc_number_display: "12345") }
+      let(:formats) { ["ALL"] }
+
+      it "all formats from the OCLC response are returned" do
+        expect(subject.citations["MLA"]).to match "<p class=\"citation_style_MLA\">Woodson, Thomas. <i>Twentieth Century Interpretations of the Fall of the House of Usher: A Collection of Critical Essays</i>. , 1969. Print. </p>"
+        expect(subject.citations["APA"]).to match "<p class=\"citation_style_APA\">Woodson, T. (1969). <i>Twentieth century interpretations of The fall of the house of Usher: A collection of critical essays</i>. </p>\n"
+      end
+    end
+  end
+
+  describe "#api_url" do
+    let(:formats) { ["ALL"] }
+    let(:document) { SolrDocument.new(oclc_number_display: "12345") }
+    it "returns a URL with the given document field" do
+      expect(subject.send(:api_url)).to match %r{/citations/12345\?cformat=all}
+    end
+  end
+
+  describe ".grouped_citations" do
+    it "groups the citations based on their format" do
+      citations = [
+        { "APA" => "APA Citation1" },
+        { "MLA" => "MLA Citation1" },
+        { "APA" => "APA Citation2" }
+      ]
+
+      grouped_citations = described_class.grouped_citations(citations)
+      expect(grouped_citations.keys.length).to eq 2
+      expect(grouped_citations["APA"]).to eq ["APA Citation1", "APA Citation2"]
+      expect(grouped_citations["MLA"]).to eq ["MLA Citation1"]
+    end
+  end
+end


### PR DESCRIPTION
- Citations are now coming from the worldcat API based on OCLC numbers
- Right now this work handles catalog items and bookmarks
- Bookmark citations can be filtered by title or citation format
- Requires a reindex for the marc fields that include OCLC numbers
- Do not merge until the apikey has been added to the Ansible playbook