### PR TITLE
Replace using barcode with pid.

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -113,7 +113,7 @@ class SolrDocument
 
   private
     def barcode(item)
-      item["item_data"]["barcode"]
+      item["item_data"]["pid"]
     end
 
     def availability_status(item)

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SolrDocument, type: :model do
     "bib_data" => { "title" => "Hello World" },
     "item_data" => {
       "physical_material_type" => { "value" => "ANY" },
-      "barcode" => "FOOBAR",
+      "pid" => "FOOBAR",
     },
     "holding_data" => { "calling_number" => "CALL ME" }
   ) }


### PR DESCRIPTION
Although barcodes are unique they are not always present.  This change
updates to code to internally use the pid (which is always present and
unique per item) instead of the barcode.
