### PR TITLE
Move field display alternative to config.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -363,7 +363,7 @@ class CatalogController < ApplicationController
     config.add_show_field "alma_mms_display", label: "Catalog Record ID"
     config.add_show_field "language_display", label: "Language"
     config.add_show_field "url_more_links_display", label: "Other Links", helper_method: :check_for_full_http_link
-    config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :check_for_full_http_link
+    config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :check_for_full_http_link, if: false
 
     config.add_show_field "bound_with_ids", display: false
 

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -10,7 +10,6 @@
     <dl class="dl-horizontal  dl-invert">
       <% document_show_fields(document).each do |field_name, field| %>
         <% if should_render_show_field? document, field %>
-        <% unless field_name == "electronic_resource_display"  %>
           <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
           <% if document[field_name].length == 1 || !document[field_name].is_a?(Array) %>
                 <% valdir = Array(document[field_name]).first %>
@@ -39,7 +38,6 @@
                   </ul>
                 </dd>
               <% end %>
-            <% end %>
         <% end -%>
       <% end -%>
     </dl>


### PR DESCRIPTION
Removes the unless field is name check in template and adds an explicit display config to the field.