### PR TITLE
Move librarian view logic to a helper function.

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -136,4 +136,12 @@ module CatalogHelper
   def library_link
     Rails.configuration.library_link
   end
+
+  def render_marc_view
+    if @document.respond_to?(:to_marc)
+      render "marc_view"
+    else
+      t("blacklight.search.librarian_view.empty")
+    end
+  end
 end

--- a/app/views/catalog/librarian_view.html.erb
+++ b/app/views/catalog/librarian_view.html.erb
@@ -2,8 +2,5 @@
   <%= link_to t("blacklight.search.back"), "../#{@document.id}", :class =>"pull-right" %>
   <h3 class="modal-title"><%= t('blacklight.search.librarian_view.title') %></h3>
 </div>
-<%- if @document.respond_to?(:to_marc) -%>
-  <%= render "marc_view" %>
-<%- else %>
-  <%= t('blacklight.search.librarian_view.empty') %>
-<%- end -%>
+
+<%= render_marc_view %>

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -36,4 +36,30 @@ RSpec.describe CatalogHelper, type: :helper do
       end
     end
   end
+
+  describe "#render_marc_view" do
+    let(:doc) { OpenStruct.new(to_marc: "foo") }
+
+    before(:each) {
+      helper.instance_variable_set(:@document, doc)
+      allow(helper).to receive(:render) {}
+      helper.render_marc_view
+    }
+
+    context "document responds to to_marc" do
+      it "renders the marc_view template" do
+        expect(helper).to have_received(:render).with("marc_view")
+      end
+    end
+
+    context "document does not respond to to_marc" do
+      let(:doc) { double }
+
+      it "renders a default no_marc ouput" do
+        expect(helper).to_not have_received(:render)
+        expect(helper.render_marc_view).to eq(helper.t("blacklight.search.librarian_view.empty"))
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
Moves the librarian_view logic from the template to a tested helper
function.