### PR TITLE
Adds a way for admins to experiment with query tweaks.

### DIFF
--- a/app/helpers/tweak_query_helper.rb
+++ b/app/helpers/tweak_query_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module TweakQueryHelper
+  def render_solr_search_tweaks
+    if ENV["SOLR_SEARCH_TWEAK_ENABLE"] != "on" ||
+        blacklight_config.document_model != SolrDocument
+      return
+    end
+
+    fields = blacklight_config.default_solr_params
+      .merge(params.to_h.inject({}) { |acc, (k, v)| acc[k.to_sym] = v; acc })
+      .select { |name, value| name.match?(/(qf$|pf$)/) }
+
+    render partial: "tweak_solr_query_form", locals: { fields: fields }
+  end
+
+  def titleize_field(name)
+    "#{name}".titleize
+      .gsub("Qf", "Query Fields (qf)")
+      .gsub("Pf", "Phrase Fields (pf)")
+  end
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -14,6 +14,10 @@ class SearchBuilder < Blacklight::SearchBuilder
         add_advanced_search_to_solr
         limit_facets ]
 
+  if ENV["SOLR_SEARCH_TWEAK_ENABLE"] == "on"
+    self.default_processor_chain += %i[ tweak_query ]
+  end
+
   def limit_facets(solr_parameters)
     path = "#{blacklight_params["controller"]}/#{blacklight_params["action"]}"
     count = blacklight_params.keys.count
@@ -26,6 +30,10 @@ class SearchBuilder < Blacklight::SearchBuilder
     elsif path == "catalog/range_limit" || path == "catalog/advanced"
       solr_parameters["facet.field"] = []
     end
+  end
+
+  def tweak_query(solr_parameters)
+    solr_parameters.merge!(blacklight_params.select { |name, value| name.match?(/(qf$|pf$)/) })
   end
 
   # Overrides Blacklight::SearchBuilder#blacklight_params

--- a/app/views/advanced/_search_form.html.erb
+++ b/app/views/advanced/_search_form.html.erb
@@ -1,0 +1,1 @@
+<%= render_solr_search_tweaks %>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -20,6 +20,9 @@
       </button>
     </span>
   </div>
+
+  <%= render_solr_search_tweaks %>
+
 <% end %>
 
 <%= render "advanced_search_link" %>

--- a/app/views/catalog/_tweak_solr_query_form.html.erb
+++ b/app/views/catalog/_tweak_solr_query_form.html.erb
@@ -1,0 +1,25 @@
+<button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseTweaks" aria-expanded="false" aria-controls="collapseTweaks">
+  Tweak Solr Query Fields
+</button>
+
+<div class="collapse" id="collapseTweaks">
+  <div class="accordion" id="queryTweakAccordion">
+    <% fields.each do |name, value| %>
+      <div class="car">
+        <div class="card-header" id="heading-<%= "#{name}" %>">
+          <h5 class="mb-0">
+            <button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapse-<%= "#{name}" %>" aria-expanded="false" aria-controls="collapse-<%= "#{name}" %>">
+              <%= "#{titleize_field name}" %>
+            </button>
+          </h5>
+        </div>
+        <div id="collapse-<%= "#{name}" %>" class="collapse" aria-labelledby="heading-<%= "#{name}" %>" data-parent="#queryTweakAccordion">
+          <div class="card-body">
+            <textarea name="<%= "#{name}" %>" cols="100" rows="7"><%= "#{value}" %></textarea>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     ports:
       - "3000"
     environment:
+      SOLR_SEARCH_TWEAK_ENABLE: "on"
       SOLR_URL: "http://solr:8983/solr/blacklight"
       LC_ALL: "C.UTF-8"
     labels:

--- a/spec/helpers/tweak_query_helper_spec.rb
+++ b/spec/helpers/tweak_query_helper_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TweakQueryHelper, type: :helper do
+  describe "#render_solr_search_tweaks"  do
+    let(:solr_tweak_enable) { "on" }
+    let(:config) { OpenStruct.new(default_solr_params: {}, document_model: SolrDocument) }
+    let(:params) { {} }
+
+    before(:each) {
+      ENV["SOLR_SEARCH_TWEAK_ENABLE"] = solr_tweak_enable
+      allow(helper).to receive(:render) {}
+      allow(helper).to receive(:params) { params }
+      allow(helper).to receive(:controller) { controller }
+
+      without_partial_double_verification do
+        allow(helper).to receive(:blacklight_config) { config }
+      end
+
+      helper.render_solr_search_tweaks
+    }
+
+    after(:each) do
+      ENV["SOLR_SEARCH_TWEAK_ENABLE"] = "off"
+    end
+
+    context "feature not enabled" do
+      let(:solr_tweak_enable) { "off" }
+
+      it "does not render" do
+        expect(helper).to_not have_received(:render).with("tweak_solr_query_form")
+      end
+    end
+
+    context "document model is not SolrDocument" do
+      let(:config) { OpenStruct.new(document_model: Object) }
+
+      it "does not render" do
+        expect(helper).to_not have_received(:render).with("tweak_solr_query_form")
+      end
+    end
+
+    context "feature is enabled" do
+      it "should render the query tweak form" do
+        expect(helper).to have_received(:render).with(partial: "tweak_solr_query_form", locals: { fields: {} })
+      end
+
+    end
+
+    context "default solr params are provided" do
+      let(:config) { OpenStruct.new(
+        default_solr_params: { qf: "foo", title_pf: "bar", ignore_me: "WHA!" },
+        document_model: SolrDocument
+      )}
+
+      it "filters out query and phrase fields" do
+        expect(helper).to have_received(:render).with(partial: "tweak_solr_query_form", locals: { fields: { qf: "foo", title_pf: "bar" } })
+      end
+    end
+
+    context "overrides are passed via params" do
+      let(:config) { OpenStruct.new(
+        default_solr_params: { qf: "foo", title_pf: "bar" },
+        document_model: SolrDocument
+      )}
+
+      let (:params) { { qf: "buzz" } }
+
+      it "overrides default params with passed in params" do
+        expect(helper).to have_received(:render).with(partial: "tweak_solr_query_form", locals: { fields: { qf: "buzz", title_pf: "bar" } })
+      end
+    end
+  end
+
+  describe "#titleize_field" do
+    it "transposes qf to Query Fields (qf)" do
+      expect(helper.titleize_field "qf").to eq("Query Fields (qf)")
+    end
+
+    it "transposes pf to Phrase Fields (pf)" do
+      expect(helper.titleize_field "pf").to eq("Phrase Fields (pf)")
+    end
+
+    it "titleizes" do
+      expect(helper.titleize_field "hello_world").to eq("Hello World")
+    end
+  end
+end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe SearchBuilder , type: :model do
   subject { search_builder }
 
   describe "#limit_facets" do
-    before(:example) do
-      allow(search_builder).to receive(:blacklight_params).and_return(params)
-    end
-
     let(:solr_parameters) {
       sp = Blacklight::Solr::Request.new
       # I can't figure out the "right" way to add my test facet fields.
@@ -23,6 +19,7 @@ RSpec.describe SearchBuilder , type: :model do
     }
 
     before(:example) do
+      allow(search_builder).to receive(:blacklight_params).and_return(params)
       subject.limit_facets(solr_parameters)
     end
 
@@ -62,6 +59,35 @@ RSpec.describe SearchBuilder , type: :model do
 
       it "limits the facet field to an empty set" do
         expect(solr_parameters["facet.field"]).to eq([])
+      end
+    end
+  end
+
+  describe "#tweak_query" do
+    let(:solr_parameters) {
+      sp = Blacklight::Solr::Request.new
+      sp["qf"] = "foo"
+      sp
+    }
+
+    before(:example) do
+      allow(search_builder).to receive(:blacklight_params).and_return(params)
+      subject.tweak_query(solr_parameters)
+    end
+
+    context "no overriding query parameter is passed" do
+      it "does not override the qf param" do
+        expect(solr_parameters["qf"]).to eq("foo")
+      end
+    end
+
+    context "overriding query parameter is passed" do
+      let(:params) { ActionController::Parameters.new(
+        qf: "bar"
+      ) }
+
+      it "does override the qf param" do
+        expect(solr_parameters["qf"]).to eq("bar")
       end
     end
   end


### PR DESCRIPTION
REF BL-660

This is an experimental feature that toggles on by setting the
SOLR_SEARCH_TWEAK_ENABLE environment variable to "on". When enabled this
adds a link to the solr search forms named "Tweak Solr Query Fields".

When clicked, the link expands a set of links that each can be clicked
to reveal a textarea with the value for the field that will be passed to
solr.

Updates to any field value will affect the current search and all other
searches until a completely new search is started (i.e. start over is
clicked)

This is a relatively bare bones feature.  Enhancements may be added in
the future if it proves useful.

Depends on: tulibraries/tul_cob_playbook#23