### PR TITLE
Do not try pass unknown fields.

### DIFF
--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -47,6 +47,12 @@ module Blacklight::PrimoCentral
 
     def set_query_field(primo_central_parameters)
       field = to_primo_field(blacklight_params[:search_field])
+
+      # blacklight_range_limit can usurp this field for evil.
+      if !blacklight_config.search_fields.keys.include?(field.to_s)
+        field = "any"
+      end
+
       primo_central_parameters[:query][:q][:field] = field
     end
 

--- a/spec/models/primo_search_builder_spec.rb
+++ b/spec/models/primo_search_builder_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
   let(:search_builder) { Blacklight::PrimoCentral::SearchBuilder.new(context) }
   let(:rows) { false }
   let(:start) { false }
+  let(:config)  { PrimoCentralController.blacklight_config }
 
   subject { search_builder }
 
   before(:example) do
     allow(search_builder).to receive(:blacklight_params).and_return(params)
+    allow(search_builder).to receive(:blacklight_config).and_return(config)
   end
 
   let(:primo_central_parameters) { Blacklight::PrimoCentral::Request.new }
@@ -141,11 +143,11 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
       end
     end
 
-    context "search_field is not tranformable" do
+    context "search_field is set to unknown field" do
       let(:params) { ActionController::Parameters.new(search_field: "foo") }
 
-      it "the field is passed as is" do
-        expect(primo_central_parameters["query"]["q"]["field"]).to eq("foo")
+      it "should always transform unknown search_fields to any" do
+        expect(primo_central_parameters["query"]["q"]["field"]).to eq("any")
       end
     end
   end


### PR DESCRIPTION
REF BL-698

blacklight_range_limit will usurp the search_field value under certain
circumstances.  When we pass this value to primo, then the primo server
throws an error because that field is unknown. This change vets the
fields that are submitted and only allows those that have been
configured via blacklight_config.