### PR TITLE
Temporarily disable catalog number search.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -465,6 +465,8 @@ class CatalogController < ApplicationController
     end
 
     config.add_search_field("call_number_t", label: "Call Number") do |field|
+      # Temporarily disable catalog search
+      field.include_in_advanced_search = false
       field.include_in_simple_select = false
       field.solr_local_parameters = {
         qf: "call_number_t",


### PR DESCRIPTION
REF BL-697

Removes catalog number search until we can run a full re-index.