### PR TITLE
BL-667 pickup locations by item

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -27,6 +27,7 @@ class AlmawsController < ApplicationController
     @item_pid = CobAlma::Requests.item_pid(@items)
     @author = @items.map { |item| item["bib_data"]["author"].to_s }.first
     @description = CobAlma::Requests.descriptions(@items)
+    @item_level_locations = CobAlma::Requests.item_level_locations(@items)
     @equipment = CobAlma::Requests.equipment(@items)
     @booking_location = CobAlma::Requests.booking_location(@items)
     @material_types = CobAlma::Requests.physical_material_type(@items)

--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -95,4 +95,12 @@ module AlmaDataHelper
       render template: "almaws/_availability_status", locals: { availability: availability }
     end
   end
+
+  def item_level_library_name(location_hash)
+    location_hash.transform_values do |v|
+      v.reduce({}) { |acc, lib|
+        acc.merge!(library_name_from_short_code(lib) => lib)
+      }
+    end
+  end
 end

--- a/app/javascript/packs/controllers/fines_controller.js
+++ b/app/javascript/packs/controllers/fines_controller.js
@@ -6,7 +6,7 @@ import { Controller } from "stimulus"
   }
 
 export default class extends Controller {
-  static targets = [ "table", "spinner"]
+  static targets = [ "table", "spinner" ]
 
 
   initialize() {

--- a/app/javascript/packs/controllers/form_controller.js
+++ b/app/javascript/packs/controllers/form_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = [ ]
+  static targets = [ "pickups" ]
 
   connect() {
     this.booking_end_date()
@@ -9,17 +9,33 @@ export default class extends Controller {
   }
 
   to_page() {
-    $('#to_page').change(function() {
-      $('#to_page').prop('min', $('#from_page').val());
+    $("#to_page").change(function() {
+      $("#to_page").prop("min", $("#from_page").val());
     });  }
 
   booking_end_date() {
-    $('#booking_start_date').change(function() {
-      let dt = new Date($('#booking_start_date').val());
+    $("#booking_start_date").change(function() {
+      let dt = new Date($("#booking_start_date").val());
       dt.setDate(dt.getDate() + 8);
       let end = dt.toISOString().split("T")[0]
-      $('#booking_end_date').prop('min', $('#booking_start_date').val());
-      $('#booking_end_date').prop('max', end);
+      $("#booking_end_date").prop("min", $("#booking_start_date").val());
+      $("#booking_end_date").prop("max", end);
     });
+  }
+
+  select() {
+    // We need this variable to be global so that it doesn't mutate in multiple uses
+    if (typeof window.item_level_pickup_locations == "undefined") {
+       window.item_level_pickup_locations = $(this.pickupsTarget).html();
+    }
+
+    let description = $("#description option:selected").text();
+    let date = new Date();
+    let options = $(window.item_level_pickup_locations).filter(`optgroup[label='${description}']`).html();
+    if(options) {
+      $(this.pickupsTarget).html(options);
+    } else {
+      $(this.pickupsTarget).empty();
+    }
   }
 }

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -7,11 +7,11 @@
     <%= form.hidden_field :user_id, value: @user_id %>
     <%= form.hidden_field :request_level, value: @request_level %>
 
-    <% if @equipment.empty? %>
+    <% if @equipment.empty? && @request_level == "bib" %>
       <div class="row">
         <div class="col-sm-4 hold-form">
           <%= label("", :pickup_location, "Pickup Location: *") %>
-          <%= select("", :pickup_location, @pickup_locations.collect { |lib| [ lib.values.first, lib.keys.first ] }, {class: "request-form form-control"}, {include_blank: true, required: true, "aria-required": true }) %>
+          <%= select("", :pickup_location, @pickup_locations.collect { |lib| [ lib.values.first, lib.keys.first ] }, {class: "request-form form-control"}, { include_blank: true, required: true, "aria-required": true }) %>
         </div>
       </div>
     <% end %>
@@ -30,9 +30,17 @@
       <div class="form-group row">
         <div class="col-sm-4">
           <%= form.label(:description, "Description: *") %>
-          <%= select_tag(:description, options_for_select(@description), class: "request-form form-control", include_blank: true, required: true, "aria-required": true) %>
+          <%= select_tag(:description, options_for_select(@description), { data: { "action": "form#select" }, class: "request-form form-control", include_blank: true, required: true, "aria-required": true } ) %>
         </div>
       </div>
+
+      <div class="row">
+        <div class="col-sm-4 hold-form">
+          <%= label("", :pickup_location, "Pickup Location: *") %>
+          <%= select_tag(:pickup_location, grouped_options_for_select(item_level_library_name(@item_level_locations)), { data: { "target": "form.pickups" },  class: "request-form form-control", include_blank: true, required: true, "aria-required": true }) %>
+        </div>
+      </div>
+
     <% end %>
 
     <div class="row hold-form">

--- a/spec/fixtures/requests/desc_with_multiple_libraries.json
+++ b/spec/fixtures/requests/desc_with_multiple_libraries.json
@@ -1,0 +1,258 @@
+{
+    "item": [
+        {
+            "bib_data": {
+                "mms_id": "991011751099703811",
+                "title": "Glass.",
+                "author": null,
+                "issn": "0147-8427",
+                "isbn": null,
+                "complete_edition": "",
+                "network_number": [
+                    "(OCLC)ocm03232351",
+                    "ocm03232351",
+                    "PATG83-S00785",
+                    "ocn471172590",
+                    "(PPT)b12397386-01tuli_inst"
+                ],
+                "place_of_publication": "[Lake Oswego, Or., etc.,",
+                "publisher_const": "Publication Development inc etc",
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991011751099703811"
+            },
+            "holding_data": {
+                "holding_id": "22243511430003811",
+                "call_number_type": {
+                    "value": "0",
+                    "desc": "Library of Congress classification"
+                },
+                "call_number": "NK5100.G534x",
+                "accession_number": "",
+                "copy_id": "1",
+                "in_temp_location": false,
+                "temp_library": {
+                    "value": null,
+                    "desc": null
+                },
+                "temp_location": {
+                    "value": null,
+                    "desc": null
+                },
+                "temp_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "temp_call_number": "",
+                "temp_policy": {
+                    "value": "",
+                    "desc": null
+                },
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991011751099703811/holdings/22243511430003811"
+            },
+            "item_data": {
+                "pid": "23243511380003811",
+                "barcode": "39074016860413",
+                "creation_date": "2017-06-20Z",
+                "modification_date": "2017-06-20Z",
+                "base_status": {
+                    "value": "1",
+                    "desc": "Item in place"
+                },
+                "physical_material_type": {
+                    "value": "ISSUE",
+                    "desc": "Issue"
+                },
+                "policy": {
+                    "value": "2",
+                    "desc": "Bound Journal"
+                },
+                "provenance": {
+                    "value": "",
+                    "desc": null
+                },
+                "po_line": "",
+                "is_magnetic": false,
+                "arrival_date": "2008-10-17Z",
+                "year_of_issue": "",
+                "enumeration_a": "",
+                "enumeration_b": "",
+                "enumeration_c": "",
+                "enumeration_d": "",
+                "enumeration_e": "",
+                "enumeration_f": "",
+                "enumeration_g": "",
+                "enumeration_h": "",
+                "chronology_i": "",
+                "chronology_j": "",
+                "chronology_k": "",
+                "chronology_l": "",
+                "chronology_m": "",
+                "description": "v.2 (1974)",
+                "receiving_operator": "import",
+                "process_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "library": {
+                    "value": "MAIN",
+                    "desc": "Paley Library"
+                },
+                "location": {
+                    "value": "p_remote",
+                    "desc": "Paley Remote Stacks"
+                },
+                "alternative_call_number": "",
+                "alternative_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "storage_location_id": "",
+                "pages": "",
+                "pieces": "$0.00",
+                "public_note": "",
+                "fulfillment_note": "MESSAGE(ITEM): Fri Oct 17 2008 02:44PM: IN TRANSIT from amosher to kstk",
+                "internal_note_1": "Status: o - LIB USE ONLY",
+                "internal_note_2": "",
+                "internal_note_3": "ITEM LOC: kstk",
+                "statistics_note_1": "TOT RENEW: 0",
+                "statistics_note_2": "LYCIRC: 0",
+                "statistics_note_3": "",
+                "requested": null,
+                "edition": null,
+                "imprint": null,
+                "language": null,
+                "physical_condition": {
+                    "value": null,
+                    "desc": null
+                }
+            },
+            "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991011751099703811/holdings/22243511430003811/items/23243511380003811"
+      },
+      {
+          "bib_data": {
+              "mms_id": "991011751099703811",
+              "title": "Glass.",
+              "author": null,
+              "issn": "0147-8427",
+              "isbn": null,
+              "complete_edition": "",
+              "network_number": [
+                  "(OCLC)ocm03232351",
+                  "ocm03232351",
+                  "PATG83-S00785",
+                  "ocn471172590",
+                  "(PPT)b12397386-01tuli_inst"
+              ],
+              "place_of_publication": "[Lake Oswego, Or., etc.,",
+              "publisher_const": "Publication Development inc etc",
+              "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991011751099703811"
+          },
+          "holding_data": {
+              "holding_id": "22243511430003811",
+              "call_number_type": {
+                  "value": "0",
+                  "desc": "Library of Congress classification"
+              },
+              "call_number": "NK5100.G534x",
+              "accession_number": "",
+              "copy_id": "1",
+              "in_temp_location": false,
+              "temp_library": {
+                  "value": null,
+                  "desc": null
+              },
+              "temp_location": {
+                  "value": null,
+                  "desc": null
+              },
+              "temp_call_number_type": {
+                  "value": "",
+                  "desc": null
+              },
+              "temp_call_number": "",
+              "temp_policy": {
+                  "value": "",
+                  "desc": null
+              },
+              "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991011751099703811/holdings/22243511430003811"
+          },
+          "item_data": {
+              "pid": "23243511380003811",
+              "barcode": "39074016860413",
+              "creation_date": "2017-06-20Z",
+              "modification_date": "2017-06-20Z",
+              "base_status": {
+                  "value": "1",
+                  "desc": "Item in place"
+              },
+              "physical_material_type": {
+                  "value": "ISSUE",
+                  "desc": "Issue"
+              },
+              "policy": {
+                  "value": "2",
+                  "desc": "Bound Journal"
+              },
+              "provenance": {
+                  "value": "",
+                  "desc": null
+              },
+              "po_line": "",
+              "is_magnetic": false,
+              "arrival_date": "2008-10-17Z",
+              "year_of_issue": "",
+              "enumeration_a": "",
+              "enumeration_b": "",
+              "enumeration_c": "",
+              "enumeration_d": "",
+              "enumeration_e": "",
+              "enumeration_f": "",
+              "enumeration_g": "",
+              "enumeration_h": "",
+              "chronology_i": "",
+              "chronology_j": "",
+              "chronology_k": "",
+              "chronology_l": "",
+              "chronology_m": "",
+              "description": "v.2 (1974)",
+              "receiving_operator": "import",
+              "process_type": {
+                  "value": "",
+                  "desc": null
+              },
+              "library": {
+                  "value": "AMBLER",
+                  "desc": "Ambler Library"
+              },
+              "location": {
+                  "value": "p_remote",
+                  "desc": "Paley Remote Stacks"
+              },
+              "alternative_call_number": "",
+              "alternative_call_number_type": {
+                  "value": "",
+                  "desc": null
+              },
+              "storage_location_id": "",
+              "pages": "",
+              "pieces": "$0.00",
+              "public_note": "",
+              "fulfillment_note": "MESSAGE(ITEM): Fri Oct 17 2008 02:44PM: IN TRANSIT from amosher to kstk",
+              "internal_note_1": "Status: o - LIB USE ONLY",
+              "internal_note_2": "",
+              "internal_note_3": "ITEM LOC: kstk",
+              "statistics_note_1": "TOT RENEW: 0",
+              "statistics_note_2": "LYCIRC: 0",
+              "statistics_note_3": "",
+              "requested": null,
+              "edition": null,
+              "imprint": null,
+              "language": null,
+              "physical_condition": {
+                  "value": null,
+                  "desc": null
+              }
+          },
+          "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991011751099703811/holdings/22243511430003811/items/23243511380003811"
+    }
+    ]
+  }

--- a/spec/fixtures/requests/desc_with_no_libraries.json
+++ b/spec/fixtures/requests/desc_with_no_libraries.json
@@ -1,0 +1,131 @@
+{
+    "item": [
+        {
+            "bib_data": {
+                "mms_id": "991011751099703811",
+                "title": "Glass.",
+                "author": null,
+                "issn": "0147-8427",
+                "isbn": null,
+                "complete_edition": "",
+                "network_number": [
+                    "(OCLC)ocm03232351",
+                    "ocm03232351",
+                    "PATG83-S00785",
+                    "ocn471172590",
+                    "(PPT)b12397386-01tuli_inst"
+                ],
+                "place_of_publication": "[Lake Oswego, Or., etc.,",
+                "publisher_const": "Publication Development inc etc",
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991011751099703811"
+            },
+            "holding_data": {
+                "holding_id": "22243511430003811",
+                "call_number_type": {
+                    "value": "0",
+                    "desc": "Library of Congress classification"
+                },
+                "call_number": "NK5100.G534x",
+                "accession_number": "",
+                "copy_id": "1",
+                "in_temp_location": false,
+                "temp_library": {
+                    "value": null,
+                    "desc": null
+                },
+                "temp_location": {
+                    "value": null,
+                    "desc": null
+                },
+                "temp_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "temp_call_number": "",
+                "temp_policy": {
+                    "value": "",
+                    "desc": null
+                },
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991011751099703811/holdings/22243511430003811"
+            },
+            "item_data": {
+                "pid": "23243511380003811",
+                "barcode": "39074016860413",
+                "creation_date": "2017-06-20Z",
+                "modification_date": "2017-06-20Z",
+                "base_status": {
+                    "value": "1",
+                    "desc": "Item in place"
+                },
+                "physical_material_type": {
+                    "value": "ISSUE",
+                    "desc": "Issue"
+                },
+                "policy": {
+                    "value": "2",
+                    "desc": "Bound Journal"
+                },
+                "provenance": {
+                    "value": "",
+                    "desc": null
+                },
+                "po_line": "",
+                "is_magnetic": false,
+                "arrival_date": "2008-10-17Z",
+                "year_of_issue": "",
+                "enumeration_a": "",
+                "enumeration_b": "",
+                "enumeration_c": "",
+                "enumeration_d": "",
+                "enumeration_e": "",
+                "enumeration_f": "",
+                "enumeration_g": "",
+                "enumeration_h": "",
+                "chronology_i": "",
+                "chronology_j": "",
+                "chronology_k": "",
+                "chronology_l": "",
+                "chronology_m": "",
+                "description": "v.2 (1974)",
+                "receiving_operator": "import",
+                "process_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "library": {
+                    "value": "",
+                    "desc": ""
+                },
+                "location": {
+                    "value": "p_remote",
+                    "desc": "Paley Remote Stacks"
+                },
+                "alternative_call_number": "",
+                "alternative_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "storage_location_id": "",
+                "pages": "",
+                "pieces": "$0.00",
+                "public_note": "",
+                "fulfillment_note": "MESSAGE(ITEM): Fri Oct 17 2008 02:44PM: IN TRANSIT from amosher to kstk",
+                "internal_note_1": "Status: o - LIB USE ONLY",
+                "internal_note_2": "",
+                "internal_note_3": "ITEM LOC: kstk",
+                "statistics_note_1": "TOT RENEW: 0",
+                "statistics_note_2": "LYCIRC: 0",
+                "statistics_note_3": "",
+                "requested": null,
+                "edition": null,
+                "imprint": null,
+                "language": null,
+                "physical_condition": {
+                    "value": null,
+                    "desc": null
+                }
+            },
+            "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991011751099703811/holdings/22243511430003811/items/23243511380003811"
+      }
+    ]
+  }

--- a/spec/fixtures/requests/paley_reserves_and_remote_storage.json
+++ b/spec/fixtures/requests/paley_reserves_and_remote_storage.json
@@ -87,7 +87,7 @@
                 "chronology_k": "",
                 "chronology_l": "",
                 "chronology_m": "",
-                "description": "",
+                "description": "v.4 (1976)",
                 "receiving_operator": "import",
                 "process_type": {
                     "value": "",
@@ -215,7 +215,7 @@
                 "chronology_k": "",
                 "chronology_l": "",
                 "chronology_m": "",
-                "description": "",
+                "description": "v.5 (1977)",
                 "receiving_operator": "import",
                 "process_type": {
                     "value": "",

--- a/spec/lib/cob_alma/requests.rb
+++ b/spec/lib/cob_alma/requests.rb
@@ -66,4 +66,42 @@ RSpec.describe CobAlma::Requests do
       expect(described_class.reserve_or_reference(both_reserve)).not_to include "MAIN"
     end
   end
+
+  describe "#item_level_locations" do
+    let(:items_list) { {} }
+    let(:subject) { described_class.item_level_locations(items_list) }
+
+    context "empty hash" do
+      it "returns an empty hash" do
+        expect(subject).to eq({})
+      end
+    end
+
+    context "one description includes no libraries" do
+      let(:items_list) { Alma::BibItem.find("desc_with_no_libraries") }
+
+      it "returns a hash with all the campuses" do
+        expect(subject).to eq("v.2 (1974)" => ["MAIN", "MEDIA", "AMBLER", "GINSBURG", "PODIATRY", "HARRISBURG"])
+      end
+    end
+
+    context "two descriptions each at one library" do
+      let(:items_list) { Alma::BibItem.find("paley_reserves_and_remote_storage") }
+
+      it "returns a hash with all the campuses" do
+        expect(subject).to eq("v.4 (1976)" => ["AMBLER", "GINSBURG", "PODIATRY", "HARRISBURG"],
+                               "v.5 (1977)" => ["MAIN", "MEDIA", "AMBLER", "GINSBURG", "PODIATRY", "HARRISBURG"])
+      end
+    end
+
+    context "one description at multiple libraries" do
+      let(:items_list) { Alma::BibItem.find("desc_with_multiple_libraries") }
+
+      it "returns a hash with all the campuses" do
+        expect(subject).to eq("v.2 (1974)" => ["GINSBURG", "PODIATRY", "HARRISBURG"])
+      end
+    end
+
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,6 +79,14 @@ RSpec.configure do |config|
         to_return(status: 200,
         body: File.open(SPEC_ROOT + "/fixtures/requests/both_reserve.json"))
 
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/desc_with_no_libraries\/holdings\/.*\/items/).
+        to_return(status: 200,
+        body: File.open(SPEC_ROOT + "/fixtures/requests/desc_with_no_libraries.json"))
+
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/desc_with_multiple_libraries\/holdings\/.*\/items/).
+        to_return(status: 200,
+        body: File.open(SPEC_ROOT + "/fixtures/requests/desc_with_multiple_libraries.json"))
+
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs/).
         with(query: hash_including(expand: "p_avail,e_avail,d_avail", mms_id: "1,2")).
         to_return(status: 200,


### PR DESCRIPTION
Our former logic was only working at the bib level, so patrons could not request a specific volume that was not available at their library.  
- Refines the current valid pickup locations method to get rid of a bug that was 
including locations that shouldn't be there  
- Adds logic to filter pickup locations by description at the item level.