### PR TITLE
Update red-navbar header to new UI.

### DIFF
--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -192,3 +192,7 @@ nav ul.navbar li.nav-btn:hover a,
 nav ul.navbar li.nav-btn.active a {
   color: $white;
 }
+
+.red-navbar a#catalog_header {
+  text-decoration: underline;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -253,25 +253,6 @@ module ApplicationHelper
     link_to "direct link", url, remote: true
   end
 
-  def navigational_headers
-    if params[:controller] == "catalog" || params[:controller] == "advanced"
-      label = link_to("Catalog Search", search_catalog_path, id: "catalog_header")
-    elsif params[:controller] == "primo_central" || params[:controller] == "primo_advanced"
-      label = link_to("Articles Search", search_path, id: "articles_header")
-    end
-    # content_tag(:h1, label, class: "nav-header")
-  end
-
-  def navigational_links
-    if navigational_headers.present?
-      if navigational_headers.include?("Catalog Search")
-        link_to("Articles Search", search_path, class: "btn btn-primary nav-btn", id: "articles_button")
-      elsif navigational_headers.include?("Articles Search")
-        link_to("Catalog Search", search_catalog_path, class: "btn btn-primary nav-btn", id: "cataog_button")
-      end
-    end
-  end
-
   def render_online_only_checkbox
     online_articles = params.dig("f", "tlevel")&.include?("online_resources")
     online_catalog = params.dig("f", "availability_facet")&.include?("Online")

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -11,20 +11,14 @@
 
 <div id="user-util-links" class="row red-navbar ">
   <div class="<%= container_classes %>">
-    <% unless navigational_links.nil? %>
-      <div class="col-sm-12 col-md-4">
+    <div class="col-sm-12 col-md-4">
         <h1 class="nav-header">
-          <%= navigational_headers %>
+          <%= link_to("Library Search", everything_path, id: "catalog_header") %>
         </h1>
-    <% else %>
-      <div class="col-sm-12 col-md-4">
-        <%= navigational_headers %>
-    <% end %>
-      </div>
+    </div>
 
     <div class="col-sm-12 col-md-7 col-lg-8 offset-lg-1" id="user-util-collapse">
       <div class="navbar-right ">
-        <%= navigational_links %>
         <%= render partial: '/user_util_links' %>
       </div>
     </div>


### PR DESCRIPTION
REF BL-688

* Change header copy on all pages (id catalog_header, article_header,
etc.) to ‘Library Search’ and add an underline (like [Indiana’s
search|https://iucat.iu.edu/?utf8=%E2%9C%93&search_field=all_field&q=otters])
* Change ‘Library Search’ header link to go to
https://librarysearch.temple.edu/bento on all pages (the header link
will function as start over button)
* Remove all ‘Catalog Search’ and ‘Article Search’ buttons from all
pages