### PR TITLE
BL-667 Prepends empty value to item level pickup locations

### DIFF
--- a/app/javascript/packs/controllers/form_controller.js
+++ b/app/javascript/packs/controllers/form_controller.js
@@ -31,7 +31,8 @@ export default class extends Controller {
 
     let description = $("#description option:selected").text();
     let date = new Date();
-    let options = $(window.item_level_pickup_locations).filter(`optgroup[label='${description}']`).html();
+    let emptyOption = $('<option />').attr('value', '');
+    let options = $(window.item_level_pickup_locations).filter(`optgroup[label='${description}']`).prepend(emptyOption).html();
     if(options) {
       $(this.pickupsTarget).html(options);
     } else {


### PR DESCRIPTION
Adding an empty value stops the select from automatically selecting the first option when filtered