### PR TITLE
Fix bento search books + journal urls.

### DIFF
--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -9,9 +9,11 @@ module BentoSearch
 
     def search_implementation(args)
       query = args.fetch(:query, "")
+      per_page = args.fetch(:per_page)
 
-      results = BentoSearch::Results.new
-      response = search_results(q: query, &proc_availability_facet_only).first
+      query = { q: query, per_page: per_page }
+
+      response = search_results(query, &proc_availability_facet_only).first
       results(response)
     end
 

--- a/app/search_engines/bento_search/books_engine.rb
+++ b/app/search_engines/bento_search/books_engine.rb
@@ -2,18 +2,11 @@
 
 module BentoSearch
   class BooksEngine < BlacklightEngine
-    def search_implementation(args)
-      query = args.fetch(:query, "")
-      per_page = args.fetch(:per_page)
-      query = { q: query, per_page: per_page, f: { format: ["Book"] } }
-
-      response = search_results(query, &proc_availability_facet_only).first
-      results(response)
-    end
+    delegate :blacklight_config, to: BooksController
 
     def url(helper)
       params = helper.params
-      helper.search_catalog_path(q: params[:q], f: { format: ["Book"] })
+      helper.search_books_path(q: params[:q])
     end
 
     def view_link(total = nil, helper)

--- a/app/search_engines/bento_search/journals_engine.rb
+++ b/app/search_engines/bento_search/journals_engine.rb
@@ -2,19 +2,11 @@
 
 module BentoSearch
   class JournalsEngine < BlacklightEngine
-    def search_implementation(args)
-      query = args.fetch(:query, "")
-      per_page = args.fetch(:per_page)
-
-      query = { q: query, per_page: per_page, f: { format: ["Journal/Periodical"] } }
-
-      response = search_results(query, &proc_availability_facet_only).first
-      results(response)
-    end
+    delegate :blacklight_config, to: JournalsController
 
     def url(helper)
       params = helper.params
-      helper.search_catalog_path(q: params[:q], f: { format: ["Journal/Periodical"] })
+      helper.search_journals_path(q: params[:q])
     end
 
     def view_link(total = nil, helper)


### PR DESCRIPTION
Followup on BL-685 and BL-690

Now that we have a books and journals controllers we need to delegate
books and journal searches to them instead of to the catalog controller.

We also need to make sure that we use the new corresponding paths to the
controllers.