### PR TITLE
Normalize the bento search (everything) with nav bar.

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -14,7 +14,9 @@ class SearchController < CatalogController
     if params[:q]
       engines = %i( books articles journals more )
       searcher = BentoSearch::ConcurrentSearcher.new(*engines)
-      searcher.search(params[:q], per_page: @per_page, semantic_search_field: params[:field])
+      args = { semantic_search_field: params[:field], per_page: @per_page }
+        .merge(params.except(:controller, :action))
+      searcher.search(args)
       @results = split_more(searcher.results)
       @response = @results["resource_types"]&.first&.custom_data
     end

--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -8,12 +8,7 @@ module BentoSearch
     delegate :blacklight_config, to: CatalogController
 
     def search_implementation(args)
-      query = args.fetch(:query, "")
-      per_page = args.fetch(:per_page)
-
-      query = { q: query, per_page: per_page }
-
-      response = search_results(query, &proc_availability_facet_only).first
+      response = search_results(args, &proc_availability_facet_only).first
       results(response)
     end
 
@@ -52,7 +47,7 @@ module BentoSearch
     end
 
     def url(helper)
-      helper.search_catalog_path(q: helper.params[:q])
+      helper.search_catalog_path(helper.params.except(:controller, :action))
     end
 
     def view_link(total = nil, helper)

--- a/app/search_engines/bento_search/books_engine.rb
+++ b/app/search_engines/bento_search/books_engine.rb
@@ -5,8 +5,7 @@ module BentoSearch
     delegate :blacklight_config, to: BooksController
 
     def url(helper)
-      params = helper.params
-      helper.search_books_path(q: params[:q])
+      helper.search_books_path(helper.params.except(:controller, :action))
     end
 
     def view_link(total = nil, helper)

--- a/app/search_engines/bento_search/journals_engine.rb
+++ b/app/search_engines/bento_search/journals_engine.rb
@@ -5,8 +5,7 @@ module BentoSearch
     delegate :blacklight_config, to: JournalsController
 
     def url(helper)
-      params = helper.params
-      helper.search_journals_path(q: params[:q])
+      helper.search_journals_path(helper.params.except(:controller, :action))
     end
 
     def view_link(total = nil, helper)

--- a/app/search_engines/bento_search/more_engine.rb
+++ b/app/search_engines/bento_search/more_engine.rb
@@ -3,10 +3,7 @@
 module BentoSearch
   class MoreEngine < BlacklightEngine
     def search_implementation(args)
-      query = args.fetch(:query, "")
-      query = { q: query, per_page: 2 }
-
-      response = search_results(query, &proc_minus_books_journals).first
+      response = search_results(args.merge(per_page: 2), &proc_minus_books_journals).first
 
       item = BentoSearch::ResultItem.new(custom_data: response)
 

--- a/app/search_engines/bento_search/primo_engine.rb
+++ b/app/search_engines/bento_search/primo_engine.rb
@@ -5,14 +5,11 @@ module BentoSearch
     delegate :blacklight_config, to: PrimoCentralController
 
     def search_implementation(args)
-      query = args.fetch(:query, "")
-      per_page = args.fetch(:per_page)
-
       # Avoid making a costly call for no reason.
-      if query.empty?
+      if !args.present?
         response = { "docs" => [] }
       else
-        response = search_results(q: query, per_page: per_page).first
+        response = search_results(args).first
       end
 
       results(response)
@@ -28,8 +25,7 @@ module BentoSearch
     end
 
     def url(helper)
-      params = helper.params
-      helper.url_for(action: :index, controller: :primo_central, q: params[:q])
+      helper.search_path(helper.params.except(:controller, :action))
     end
 
     def view_link(total = nil, helper)


### PR DESCRIPTION
Currently the links and searches switching between everything and other
searches does not propogate.  This change propagates that search so that
flipping back and forth between a facted books search and everything
returns the same results (per example.)