### PR TITLE
BL-691 Add breadcrumbs to record pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -308,4 +308,19 @@ module ApplicationHelper
       link_to(name, send(path, params.except(:controller, :action)), class: link_class)
     end
   end
+
+  def breadcrumb_links
+    case controller_name
+    when "books"
+      link_back_to_catalog(label: "Books & More")
+    when "primo_central"
+      link_back_to_catalog(label: "Articles")
+    when "catalog"
+      link_back_to_catalog(label: "More")
+    when "journals"
+      link_back_to_catalog(label: "Journals")
+    else
+      link_back_to_catalog(label: "More")
+    end
+  end
 end

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,3 +1,8 @@
+<ol class="breadcrumb">
+  <li><%= breadcrumb_links %></li>
+  <li class="active">Record</li>
+</ol>
+
 <div id="content" class="col-12">
   <%= render_document_main_content_partial %>
 </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -171,4 +171,28 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#breadcrumb_links" do
+    before(:each) {
+      allow(helper).to receive(:controller_name) { controller_name }
+      allow(helper).to receive(:link_back_to_catalog) {}
+      helper.breadcrumb_links
+    }
+
+    context "user entered page using a catalog search" do
+      let(:controller_name) { "catalog" }
+
+      it "has 'More' breadcrumb leading back to catalog search" do
+        expect(helper).to have_received(:link_back_to_catalog).with(label: "More")
+      end
+    end
+
+    context "user entered page using unknown controller" do
+      let(:controller_name) { "foo" }
+
+      it "has 'More' breadcrumb leading back to catalog search" do
+        expect(helper).to have_received(:link_back_to_catalog).with(label: "More")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Breadcrumb Labels should change depending on the user's current search context and should go back to their current search state