### PR TITLE
Add advanced books and journals forms.

### DIFF
--- a/app/controllers/books_advanced_controller.rb
+++ b/app/controllers/books_advanced_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class BooksAdvancedController < AdvancedController
+  copy_blacklight_config_from(BooksController)
+
+  protected
+    def search_action_url(options = {})
+      books_advanced_search_path(options.merge(action: "index"))
+    end
+end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "twilio-ruby"
-
 class BooksController < CatalogController
   configure_blacklight do |config|
     config.search_builder_class = BooksSearchBuilder

--- a/app/controllers/journals_advanced_controller.rb
+++ b/app/controllers/journals_advanced_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class JournalsAdvancedController < AdvancedController
+  copy_blacklight_config_from(JournalsController)
+
+  protected
+    def search_action_url(options = {})
+      journals_advanced_search_path(options.merge(action: "index"))
+    end
+end

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -61,12 +61,50 @@ module AdvancedHelper
   end
 
   def render_advanced_search_link
-    if !current_page? blacklight_advanced_search_engine.advanced_search_path
-      query = params.except(:controller, :action).to_h
-      url = blacklight_advanced_search_engine.advanced_search_path(query)
-      link_to "Advanced Catalog Search", url, class: "advanced_search", id: "advanced_search"
+    query = params.except(:controller, :action).to_h
+
+    if current_page? search_catalog_path
+      id = :catalog_advanced_search
+      url = advanced_search_path(query)
+    elsif current_page? search_books_path
+      id = :books_advanced_search
+      url = books_advanced_search_path(query)
+    elsif current_page? search_journals_path
+      id = :journals_advanced_search
+      url = journals_advanced_search_path(query)
+    elsif current_page? search_path
+      id = :articles_advanced_search
+      url = articles_advanced_search_path(query)
+    end
+
+    link_to(t(id), url, class: "advanced_search", id: id) if id
+  end
+
+  def basic_search_path
+    if current_page? advanced_search_path
+      search_catalog_path
+    elsif current_page? books_advanced_search_path
+      search_books_path
+    elsif current_page? journals_advanced_search_path
+      search_journals_path
+    elsif current_page? articles_advanced_search_path
+      search_path
     else
-      link_to "Basic Search", root_path, class: "advanced_search", id: "basic_search"
+      search_catalog_path
+    end
+  end
+
+  def advanced_search_form_title
+    if current_page? advanced_search_path
+      t(:catalog_advanced_search)
+    elsif current_page? books_advanced_search_path
+      t(:books_advanced_search)
+    elsif current_page? journals_advanced_search_path
+      t(:journals_advanced_search)
+    elsif current_page? articles_advanced_search_path
+      t(:articles_advanced_search)
+    else
+      t(:catalog_advanced_search)
     end
   end
 end

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag search_catalog_path, :class => 'advanced form-horizontal', :method => :get do  %>
+<%= form_tag basic_search_path, :class => 'advanced form-horizontal', :method => :get do  %>
 
 
   <% unless (search_context_str = render_search_to_s( advanced_search_context)).blank? %>

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -1,9 +1,9 @@
-<% @page_title = "Catalog Advanced Search - #{application_name}" %>
+<% @page_title = "#{ advanced_search_form_title } - #{application_name}" %>
 
 <div class="advanced-search-form col-sm-12">
 
     <h2 class="advanced page-header">
-        <%= t('blacklight_advanced_search.catalog_title') %>
+        <%= advanced_search_form_title %>
     </h2>
 
     <div class="row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,10 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  catalog_advanced_search: "Advanced Catalog Search"
+  books_advanced_search: "Advanced Books Search"
+  journals_advanced_search: "Advanced Journals Search"
+  articles_advanced_search: "Advanced Articles Search"
   ask_librarian: "Ask a Librarian"
   bento_search:
     no_results:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,12 @@
 Rails.application.routes.draw do
   root to: "search#index"
 
+  # advanced forms
+  match "/books/advanced", to: "books_advanced#index", as: "books_advanced_search", via: [:get, :post]
+  match "journals/advanced", to: "journals_advanced#index", as: "journals_advanced_search", via: [:get, :post]
+  match "articles/advanced", to: "primo_advanced#index", as: "articles_advanced_search", via: [:get, :post]
+  match "catalog/advanced", to: "advanced#index", as: "advanced_search", via: [:get, :post]
+
   # concerns
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   concern :searchable, Blacklight::Routes::Searchable.new
@@ -91,7 +97,7 @@ Rails.application.routes.draw do
   get "bento" => "search#index", :as => "multi_search"
   get "everything" => "search#index", :as => "everything"
   get "catalog/:id/staff_view", to: "catalog#librarian_view", as: "staff_view"
-  get "articles_advanced", to: "primo_advanced#index", as: "articles_advanced_search"
+  get "articles_advanced", to: "primo_advanced#index", as: "legacy_articles_advanced_search"
 
   get "catalog/:id/index_item", to: "catalog#index_item", as: "index_item"
   get "book/:id/index_item", to: "books#index_item", as: "book_item"

--- a/spec/controllers/books_advanced_controller_spec.rb
+++ b/spec/controllers/books_advanced_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BooksAdvancedController, type: :controller do
+
+  it "overrides the catalog Search Builder" do
+    expect(controller.blacklight_config.search_builder_class).to eq(BooksSearchBuilder)
+  end
+
+  it "overrides the document model" do
+    expect(controller.blacklight_config.document_model).to eq(SolrBookDocument)
+  end
+
+  it "overrides the search_action_url" do
+    expect(controller.send(:search_action_url)).to eq("/books/advanced")
+  end
+end

--- a/spec/controllers/journals_advanced_controller_spec.rb
+++ b/spec/controllers/journals_advanced_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe JournalsAdvancedController, type: :controller do
+
+  it "overrides the catalog Search Builder" do
+    expect(controller.blacklight_config.search_builder_class).to eq(JournalsSearchBuilder)
+  end
+
+  it "overrides the document model" do
+    expect(controller.blacklight_config.document_model).to eq(SolrJournalDocument)
+  end
+
+  it "overrides the search_action_url" do
+    expect(controller.send(:search_action_url)).to eq("/journals/advanced")
+  end
+end

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -47,21 +47,130 @@ RSpec.describe AdvancedHelper, type: :helper do
 
   describe "#render_advanced_search_link" do
     before(:each) do
+      allow(helper).to receive(:current_page?).with("/catalog") { false }
+      allow(helper).to receive(:current_page?).with("/books") { false }
+      allow(helper).to receive(:current_page?).with("/journals") { false }
+      allow(helper).to receive(:current_page?).with("/articles") { false }
       allow(helper).to receive(:params) { { q: "foo", controller: "bar" } }
     end
 
-    context "not on advanced page" do
+    context "on the catalog search page" do
       it "renders the link to the advanced form" do
-        link = "<a class=\"advanced_search\" id=\"advanced_search\" href=\"/advanced?q=foo\">Advanced Catalog Search</a>"
+        allow(helper).to receive(:current_page?).with("/catalog") { true }
+        link = "<a class=\"advanced_search\" id=\"catalog_advanced_search\" href=\"/catalog/advanced?q=foo\">Advanced Catalog Search</a>"
         expect(helper.render_advanced_search_link).to eq(link)
       end
     end
 
-    context "on the advanced page" do
-      it "renders a link to the basic search page" do
-        allow(helper).to receive(:current_page?) { true }
-        link = "<a class=\"advanced_search\" id=\"basic_search\" href=\"/\">Basic Search</a>"
+    context "on the books search page" do
+      it "renders the link to the advanced books form" do
+        allow(helper).to receive(:current_page?).with("/books") { true }
+        link = "<a class=\"advanced_search\" id=\"books_advanced_search\" href=\"/books/advanced?q=foo\">Advanced Books Search</a>"
         expect(helper.render_advanced_search_link).to eq(link)
+      end
+    end
+
+    context "on the journals search page" do
+      it "renders the link to the advanced journals form" do
+        allow(helper).to receive(:current_page?).with("/journals") { true }
+        link = "<a class=\"advanced_search\" id=\"journals_advanced_search\" href=\"/journals/advanced?q=foo\">Advanced Journals Search</a>"
+        expect(helper.render_advanced_search_link).to eq(link)
+      end
+    end
+
+    context "on the articles serch page" do
+      it "renders the link to the advanced articles form" do
+        allow(helper).to receive(:current_page?).with("/articles") { true }
+        link = "<a class=\"advanced_search\" id=\"articles_advanced_search\" href=\"/articles/advanced?q=foo\">Advanced Articles Search</a>"
+        expect(helper.render_advanced_search_link).to eq(link)
+      end
+    end
+  end
+
+  describe "#basic_search_path" do
+    before(:each) do
+      allow(helper).to receive(:current_page?).with("/catalog/advanced") { false }
+      allow(helper).to receive(:current_page?).with("/books/advanced") { false }
+      allow(helper).to receive(:current_page?).with("/journals/advanced") { false }
+      allow(helper).to receive(:current_page?).with("/articles/advanced") { false }
+    end
+
+    context "on the advanced catalog search page" do
+      it "renders the link to the catalog search" do
+        allow(helper).to receive(:current_page?).with("/catalog/advanced") { true }
+        expect(helper.basic_search_path).to eq("/catalog")
+      end
+    end
+
+    context "on the advanced books search page" do
+      it "renders the link to the books search" do
+        allow(helper).to receive(:current_page?).with("/books/advanced") { true }
+        expect(helper.basic_search_path).to eq("/books")
+      end
+    end
+
+    context "on the advanced journals search page" do
+      it "renders the link to the journals search" do
+        allow(helper).to receive(:current_page?).with("/journals/advanced") { true }
+        expect(helper.basic_search_path).to eq("/journals")
+      end
+    end
+
+    context "on the advanced articles page" do
+      it "renders the link to the articles search" do
+        allow(helper).to receive(:current_page?).with("/articles/advanced") { true }
+        expect(helper.basic_search_path).to eq("/articles")
+      end
+    end
+
+    context "on some unknown page" do
+      it "renders the link to the everything search" do
+        allow(helper).to receive(:current_page?).with("/foo/advanced") { true }
+        expect(helper.basic_search_path).to eq("/catalog")
+      end
+    end
+  end
+
+  describe "#advanced_search_form_title" do
+    before(:each) do
+      allow(helper).to receive(:current_page?).with("/catalog/advanced") { false }
+      allow(helper).to receive(:current_page?).with("/books/advanced") { false }
+      allow(helper).to receive(:current_page?).with("/journals/advanced") { false }
+      allow(helper).to receive(:current_page?).with("/articles/advanced") { false }
+    end
+
+    context "on the advanced catalog search page" do
+      it "renders the link to the catalog search" do
+        allow(helper).to receive(:current_page?).with("/catalog/advanced") { true }
+        expect(helper.advanced_search_form_title).to eq("Advanced Catalog Search")
+      end
+    end
+
+    context "on the advanced books search page" do
+      it "renders the link to the books search" do
+        allow(helper).to receive(:current_page?).with("/books/advanced") { true }
+        expect(helper.advanced_search_form_title).to eq("Advanced Books Search")
+      end
+    end
+
+    context "on the advanced journals search page" do
+      it "renders the link to the journals search" do
+        allow(helper).to receive(:current_page?).with("/journals/advanced") { true }
+        expect(helper.advanced_search_form_title).to eq("Advanced Journals Search")
+      end
+    end
+
+    context "on the advanced articles page" do
+      it "renders the link to the articles search" do
+        allow(helper).to receive(:current_page?).with("/articles/advanced") { true }
+        expect(helper.advanced_search_form_title).to eq("Advanced Articles Search")
+      end
+    end
+
+    context "on some unknown page" do
+      it "renders the link to the everything search" do
+        allow(helper).to receive(:current_page?).with("/foo/advanced") { true }
+        expect(helper.advanced_search_form_title).to eq("Advanced Catalog Search")
       end
     end
   end

--- a/spec/helpers/primo_advanced_helper_spec.rb
+++ b/spec/helpers/primo_advanced_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PrimoAdvancedHelper, type: :helper do
 
     context "not on advanced page" do
       it "renders the link to the advanced form" do
-        link = "<a class=\"advanced_search\" id=\"articles_advanced_search\" href=\"/articles_advanced?q=foo\">Advanced Articles Search</a>"
+        link = "<a class=\"advanced_search\" id=\"articles_advanced_search\" href=\"/articles/advanced?q=foo\">Advanced Articles Search</a>"
         expect(helper.articles_advanced_search_link).to eq(link)
       end
     end


### PR DESCRIPTION
REF BL-704

* Adds two new advanced forms (journals, books)
* Updates routes to allow form access via:
  /catalog/advanced
  /articles/advanced
  /books/advanced
  /journals/advanced

* Keeps backwards compatibility with old paths.