### PR TITLE
Update availability pagination styling.

### DIFF
--- a/app/assets/stylesheets/partials/_pagination.scss
+++ b/app/assets/stylesheets/partials/_pagination.scss
@@ -1,4 +1,11 @@
 @import "_vars.scss";
+.modal-only .page_links {
+  display: none;
+}
+
+.modal-dialog .modal-only .page_links {
+  display: block;
+}
 
 .pagination  {
 	li {

--- a/app/assets/stylesheets/tucob.scss.erb
+++ b/app/assets/stylesheets/tucob.scss.erb
@@ -852,8 +852,9 @@ form#sms_form div.text-this-location label {
   padding-top: 0;
 }
 
-
-
+.modal-content .availability-modal {
+  padding: 20px;
+}
 
 .loading-message{
   font-size: 18px;

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -2,40 +2,46 @@
 
 <div id="request-url-data-<%= @mms_id %>" class="hidden" data-requests-url="<%= request_options_path(@mms_id, @pickup_locations, @request_level) %>"></div>
 
-<%= render :partial => "paginate_compact", :object => @response %>
 
 <% unless @items.empty? %>
   <% sort_order_for_holdings(@items).each do |key,items| %>
-  <table id="availability-container" class="table table-responsive border-bottom">
-    <thead>
-      <tr class="sr-only">
-          <th scope="col" id="location">Item Location</td>
-          <th scope="col" id="callnum">Call Number</th>
-          <th scope="col" id="desc">Description</th>
-          <th scope="col" id="type">Material Type</th>
-          <th scope="col" id="note">Public Note</th>
-          <th scope="col" id="status">Availability Status</th>
-      </tr>
-    </thead>
-    <tbody >
-      <tr class="table-heading">
-        <th id="<%= key %>" scope="colgroup" colspan="7">
-          <%= library_name_from_short_code(key) %>
-          <%= aeon_request_button(items) %>
-        </th>
-      </tr>
-      <% items.each do |item| %>
-        <tr>
-          <th id="<%= location_status(item) %>" headers="<%= key %> location" scope="row"><%= location_status(item) %></th>
-          <td headers="<%= key %> callnum" scope="row"><%= item.call_number %> <%= alternative_call_number(item) %></td>
-          <td headers="<%= key %> desc" scope="row"><%= description(item) %></td>
-          <td headers="<%= key %> type" scope="row"><%= physical_material_type(item) %></td>
-          <td headers="<%= key %> note" scope="row"><%= public_note(item) %></td>
-          <td headers="<%= key %> status" scope="row"><%= availability_status(item) %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+    <div class="availability-modal">
+      <div class="modal-only">
+        <%= render :partial => "paginate_compact", :object => @response %>
+      </div>
+      <table id="availability-container" class="table table-responsive border-bottom">
+        <thead>
+          <tr class="sr-only">
+              <th scope="col" id="location">Item Location</td>
+              <th scope="col" id="callnum">Call Number</th>
+              <th scope="col" id="desc">Description</th>
+              <th scope="col" id="type">Material Type</th>
+              <th scope="col" id="note">Public Note</th>
+              <th scope="col" id="status">Availability Status</th>
+          </tr>
+        </thead>
+        <tbody >
+          <tr class="table-heading">
+            <th id="<%= key %>" scope="colgroup" colspan="7">
+              <%= library_name_from_short_code(key) %>
+              <%= aeon_request_button(items) %>
+            </th>
+          </tr>
+          <% items.each do |item| %>
+            <tr>
+              <th id="<%= location_status(item) %>" headers="<%= key %> location" scope="row"><%= location_status(item) %></th>
+              <td headers="<%= key %> callnum" scope="row"><%= item.call_number %> <%= alternative_call_number(item) %></td>
+              <td headers="<%= key %> desc" scope="row"><%= description(item) %></td>
+              <td headers="<%= key %> type" scope="row"><%= physical_material_type(item) %></td>
+              <td headers="<%= key %> note" scope="row"><%= public_note(item) %></td>
+              <td headers="<%= key %> status" scope="row"><%= availability_status(item) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%= render :partial => "paginate_compact", :object => @response %>
+    </div>
+
   <% end %>
   <% else %>
   <table class="table table-responsive border-bottom">
@@ -46,3 +52,4 @@
     </tr>
   </table>
 <% end %>
+

--- a/app/views/kaminari/modal_compact/_paginator.html.erb
+++ b/app/views/kaminari/modal_compact/_paginator.html.erb
@@ -26,10 +26,4 @@
       <%= next_page_tag %>
     </div>
   <% end -%>
-<% else -%>
-    <div class="page_links">
-      <span class="page_entries">
-        <%= page_entries_info %>
-      </span>
-    </div>
 <% end -%>


### PR DESCRIPTION
REF BL-634 (follow up)

* Remove pagination view when there are less than 100 items (i.e. keep
display as it currently is production)

* When there are more than 100 items: Move pagination view to the bottom
of the scroll view on record page (however, if possible, leave
pagination at top of page for the pop-up display)

* Add more padding to outer border of the pop-up display