### PR TITLE
BL-545 EZ-borrow integration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tulibraries/alma_rb.git
-  revision: 1940dde3834de49723c7a0449b6c3b779c36cfe7
+  revision: 48db945998a3e41db95c82cf64e89d391b2b430b
   branch: master
   specs:
     alma (0.2.8)
@@ -270,7 +270,7 @@ GEM
     mysql2 (0.4.10)
     nenv (0.3.0)
     nio4r (2.3.1)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)

--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -30,6 +30,7 @@ class AlmawsController < ApplicationController
   def request_options
     @mms_id = params[:mms_id]
     @items = Alma::BibItem.find(@mms_id, limit: 100)
+    @books = @items.items.map { |item| item.item_data.dig("physical_material_type", "value") }.first
     @holding_id = CobAlma::Requests.item_holding_id(@items)
     @item_pid = CobAlma::Requests.item_pid(@items)
     @author = @items.map { |item| item["bib_data"]["author"].to_s }.first

--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module AlmawsHelper
+  include Blacklight::CatalogHelperBehavior
+
+  def hold_allowed_partial(request_options)
+    if request_options.hold_allowed?
+      render partial: "hold_allowed", locals: { request_options: request_options }
+    end
+  end
+
+  def digitization_allowed_partial(request_options)
+    if request_options.digitization_allowed?
+      render partial: "digitization_allowed", locals: { request_options: request_options }
+    end
+  end
+
+  def booking_allowed_partial(request_options)
+    if request_options.booking_allowed?
+      render partial: "booking_allowed", locals: { request_options: request_options }
+    end
+  end
+
+  def resource_sharing_broker_allowed_partial(request_options, books)
+    if request_options.resource_sharing_broker_allowed? && books.present?
+      render partial: "resource_sharing_broker_allowed", locals: { request_options: request_options, books: books }
+    end
+  end
+
+  def no_temple_request_options_available(request_options, books)
+    if !@request_options.hold_allowed? && !@request_options.digitization_allowed? && !@request_options.booking_allowed?
+      resource_sharing_broker_allowed_partial(request_options, books)
+    end
+  end
+end

--- a/app/views/almaws/_booking_allowed.html.erb
+++ b/app/views/almaws/_booking_allowed.html.erb
@@ -1,0 +1,14 @@
+<div class="panel panel-default request-heading">
+  <div class="panel-heading">
+    <h4 class="panel-title">
+        <a class="booking-request accordian-toggle"  data-toggle="collapse" data-parent="#request-accordian-<%=  @mms_id %>" href="#collapseThree-<%= @mms_id %>">Request booking</a>
+    </h4>
+  </div>
+
+  <div id="collapseThree-<%= @mms_id %>" class="panel-collapse collapse">
+    <div class="panel-body">
+      <h5 class="request-header">Details of title you requested:</h5>
+      <%= render "booking_request_form" %>
+    </div>
+  </div>
+</div>

--- a/app/views/almaws/_digitization_allowed.html.erb
+++ b/app/views/almaws/_digitization_allowed.html.erb
@@ -1,0 +1,14 @@
+<div class="panel panel-default request-heading">
+  <div class="panel-heading">
+    <h4 class="panel-title">
+        <a class="digital-request accordian-toggle"  data-toggle="collapse" data-parent="#request-accordian-<%=  @mms_id %>" href="#collapseTwo-<%= @mms_id %>">Scan an article/book chapter</a>
+    </h4>
+  </div>
+
+  <div id="collapseTwo-<%= @mms_id %>" class="panel-collapse collapse">
+    <div class="panel-body">
+      <h5 class="request-header">Details of title you requested:</h5>
+      <%= render "digitization_request_form" %>
+    </div>
+  </div>
+</div>

--- a/app/views/almaws/_hold_allowed.html.erb
+++ b/app/views/almaws/_hold_allowed.html.erb
@@ -1,0 +1,14 @@
+<div class="panel panel-default request-heading">
+  <div class="panel-heading">
+    <h4 class="panel-title">
+        <a class="hold-request accordian-toggle" data-toggle="collapse" data-parent="#request-accordian-<%=  @mms_id %>" href="#collapseOne-<%= @mms_id %>">Request item</a>
+    </h4>
+  </div>
+
+  <div id="collapseOne-<%= @mms_id %>" class="panel-collapse collapse">
+    <div class="panel-body">
+        <h5 class="request-header">Details of title you requested:</h5>
+        <%= render "hold_request_form" %>
+    </div>
+  </div>
+</div>

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -7,7 +7,7 @@
     <%= form.hidden_field :user_id, value: @user_id %>
     <%= form.hidden_field :request_level, value: @request_level %>
 
-    <% if @equipment.empty? && @request_level == "bib" %>
+    <% if @equipment.empty?  && @request_level == "bib" %>
       <div class="row">
         <div class="col-sm-4 hold-form">
           <%= label("", :pickup_location, "Pickup Location: *") %>

--- a/app/views/almaws/_resource_sharing_broker_allowed.html.erb
+++ b/app/views/almaws/_resource_sharing_broker_allowed.html.erb
@@ -1,0 +1,9 @@
+<p>This item cannot be requested from other Temple campuses.</p>
+
+<div class="panel panel-default request-heading">
+  <div class="panel-heading">
+    <h4 class="panel-title">
+        <a class="booking-request" href="<%= request_options.ez_borrow_link %>"  target="_blank">Request item from another library</a>
+    </h4>
+  </div>
+</div>

--- a/app/views/almaws/request_options.html.erb
+++ b/app/views/almaws/request_options.html.erb
@@ -6,69 +6,10 @@
 <div class="modal-body">
   <div class="panel-group request-group" id="request-accordian-<%= @mms_id %>">
 
-  <% if @request_options.hold_allowed? %>
-    <div class="panel panel-default request-heading">
-      <div class="panel-heading">
-        <h4 class="panel-title">
-            <a class="hold-request accordian-toggle" data-toggle="collapse" data-parent="#request-accordian-<%=  @mms_id %>" href="#collapseOne-<%= @mms_id %>">Request item</a>
-        </h4>
-      </div>
-
-      <div id="collapseOne-<%= @mms_id %>" class="panel-collapse collapse">
-        <div class="panel-body">
-            <h5 class="request-header">Details of title you requested:</h5>
-            <%= render "hold_request_form" %>
-        </div>
-      </div>
-    </div>
-  <% end %>
-
-  <% if @request_options.digitization_allowed? %>
-    <div class="panel panel-default request-heading">
-      <div class="panel-heading">
-        <h4 class="panel-title">
-            <a class="digital-request accordian-toggle"  data-toggle="collapse" data-parent="#request-accordian-<%=  @mms_id %>" href="#collapseTwo-<%= @mms_id %>">Scan an article/book chapter</a>
-        </h4>
-      </div>
-
-      <div id="collapseTwo-<%= @mms_id %>" class="panel-collapse collapse">
-        <div class="panel-body">
-          <h5 class="request-header">Details of title you requested:</h5>
-          <%= render "digitization_request_form" %>
-        </div>
-      </div>
-    </div>
-  <% end %>
-
-  <% if @request_options.booking_allowed? %>
-    <div class="panel panel-default request-heading">
-      <div class="panel-heading">
-        <h4 class="panel-title">
-            <a class="booking-request accordian-toggle"  data-toggle="collapse" data-parent="#request-accordian-<%=  @mms_id %>" href="#collapseThree-<%= @mms_id %>">Request booking</a>
-        </h4>
-      </div>
-
-      <div id="collapseThree-<%= @mms_id %>" class="panel-collapse collapse">
-        <div class="panel-body">
-          <h5 class="request-header">Details of title you requested:</h5>
-          <%= render "booking_request_form" %>
-        </div>
-      </div>
-    </div>
-  <% end %>
-
-   <% if !@request_options.hold_allowed? && !@request_options.digitization_allowed? && !@request_options.booking_allowed? %>
-      <p>This item cannot be requested from other Temple campuses.</p>
-      <% if @request_options.resource_sharing_broker_allowed? && @books.present? %>
-        <div class="panel panel-default request-heading">
-          <div class="panel-heading">
-            <h4 class="panel-title">
-                <a class="booking-request" href="<%= @request_options.ez_borrow_link %>"  target="_blank">Request item from another library</a>
-            </h4>
-          </div>
-        </div>
-      <% end %>
-   <% end %>
+  <%= hold_allowed_partial(@request_options) %>
+  <%= digitization_allowed_partial(@request_options) %>
+  <%= booking_allowed_partial(@request_options) %>
+  <%= no_temple_request_options_available(@request_options, @books) %>
 
   </div>
 </div>

--- a/app/views/almaws/request_options.html.erb
+++ b/app/views/almaws/request_options.html.erb
@@ -59,6 +59,15 @@
 
    <% if !@request_options.hold_allowed? && !@request_options.digitization_allowed? && !@request_options.booking_allowed? %>
       <p>This item cannot be requested from other Temple campuses.</p>
+      <% if @request_options.resource_sharing_broker_allowed? && @books.present? %>
+        <div class="panel panel-default request-heading">
+          <div class="panel-heading">
+            <h4 class="panel-title">
+                <a class="booking-request" href="<%= @request_options.ez_borrow_link %>"  target="_blank">Request item from another library</a>
+            </h4>
+          </div>
+        </div>
+      <% end %>
    <% end %>
 
   </div>

--- a/spec/helpers/almaws_helper_spec.rb
+++ b/spec/helpers/almaws_helper_spec.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AlmawsHelper, type: :helper do
+  describe "#hold_allowed_partial" do
+    let(:json) {
+      { request_option:
+        [{
+        "type" => { "value" => "HOLD", "desc" => "Hold" },
+        "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+        }]
+      }.to_json
+    }
+    let(:response) { OpenStruct.new(body: json) }
+    let(:request_options) { Alma::RequestOptions.new(response) }
+
+    before do
+      helper.instance_variable_set(:@equipment, [])
+    end
+
+    context "hold can be placed on an item" do
+      it "renders the hold partial" do
+        expect(helper.hold_allowed_partial(request_options)).not_to be_nil
+      end
+    end
+
+    context "hold cannot be placed on an item" do
+      let(:json) {
+        { request_option:
+          [{
+          "type" => { "value" => "BOOKING", "desc" => "Booking" },
+          "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+          }]
+        }.to_json
+      }
+
+      it "does not render the hold partial" do
+        expect(helper.hold_allowed_partial(request_options)).to be_nil
+      end
+    end
+  end
+
+  describe "#digitization_allowed_partial" do
+    let(:json) {
+      { request_option:
+        [{
+        "type" => { "value" => "DIGITIZATION", "desc" => "Digitization" },
+        "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+        }]
+      }.to_json
+    }
+    let(:response) { OpenStruct.new(body: json) }
+    let(:request_options) { Alma::RequestOptions.new(response) }
+
+    context "An item can be requested to be scanned" do
+      it "renders the digitization_allowed partial" do
+        expect(helper.digitization_allowed_partial(request_options)).not_to be_nil
+      end
+    end
+
+    context "An item cannot be requested to be scanned" do
+      let(:json) {
+        { request_option:
+          [{
+          "type" => { "value" => "BOOKING", "desc" => "Booking" },
+          "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+          }]
+        }.to_json
+      }
+
+      it "does not render the digitization_allowed partial" do
+        expect(helper.digitization_allowed_partial(request_options)).to be_nil
+      end
+    end
+  end
+
+  describe "#booking_allowed_partial" do
+    let(:json) {
+      { request_option:
+        [{
+        "type" => { "value" => "BOOKING", "desc" => "Booking" },
+        "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+        }]
+      }.to_json
+    }
+    let(:response) { OpenStruct.new(body: json) }
+    let(:request_options) { Alma::RequestOptions.new(response) }
+
+    context "booking can be placed on an item" do
+      it "renders the booking_allowed partial" do
+        expect(helper.booking_allowed_partial(request_options)).not_to be_nil
+      end
+    end
+
+    before do
+      helper.instance_variable_set(:@booking_location, [])
+      helper.instance_variable_set(:@material_types, [])
+    end
+
+    context "booking cannot be placed on an item" do
+      let(:json) {
+        { request_option:
+          [{
+          "type" => { "value" => "HOLD", "desc" => "Hold" },
+          "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+          }]
+        }.to_json
+      }
+
+      it "does not render the booking_allowed partial" do
+        expect(helper.booking_allowed_partial(request_options)).to be_nil
+      end
+    end
+  end
+
+  describe "#resource_sharing_broker_allowed_partial" do
+    let(:json) {
+      { request_option:
+        [{
+        "type" => { "value" => "RS_BROKER", "desc" => "Resource Sharing Broker" },
+        "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+        }]
+      }.to_json
+    }
+    let(:response) { OpenStruct.new(body: json) }
+    let(:request_options) { Alma::RequestOptions.new(response) }
+    let(:books) { "BOOK" }
+
+    context "item can be requested through ez-borrow" do
+      it "renders the resource_sharing_broker partial" do
+        expect(helper.resource_sharing_broker_allowed_partial(request_options, books)).not_to be_nil
+      end
+    end
+
+    context "item cannot be requested through ez-borrow" do
+      let(:json) {
+        { request_option:
+          [{
+          "type" => { "value" => "BOOKING", "desc" => "Booking" },
+          "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+          }]
+        }.to_json
+      }
+
+      it "does not render the hold partial" do
+        expect(helper.resource_sharing_broker_allowed_partial(request_options, books)).to be_nil
+      end
+    end
+  end
+
+  describe "#no_temple_request_options_available" do
+    let(:json) {
+      { request_option:
+        [{
+        "type" => { "value" => "RS_BROKER", "desc" => "Resource Sharing Broker" },
+        "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+        }]
+      }.to_json
+    }
+    let(:response) { OpenStruct.new(body: json) }
+    let(:request_options) { Alma::RequestOptions.new(response) }
+    let(:books) { "BOOK" }
+
+    context "there are no Temple request options available" do
+      it "renders the resource_sharing_broker partial" do
+        expect(helper.resource_sharing_broker_allowed_partial(request_options, books)).not_to be_nil
+      end
+    end
+
+    context "Temple request options are available" do
+      let(:json) {
+        { request_option:
+          [{
+          "type" => { "value" => "BOOKING", "desc" => "Booking" },
+          "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+          }]
+        }.to_json
+      }
+
+      it "does not render the hold partial" do
+        expect(helper.resource_sharing_broker_allowed_partial(request_options, books)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Uses the alma request options api to retreive the link to EZ-borrow.  
- The link should only appear on items that are books currently unavailable at Temple Libraries.