### PR TITLE
[BL-489] Fix links for title_addl and contributor display mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Catalog on Blacklight
+# Catalog on Blacklights
 
 A minimal Blacklight Application for exploring Temple University MARC data in preparation for migration to Alma.
 


### PR DESCRIPTION
description: |
  The added subfields in https://tulibdev.atlassian.net/browse/BL-475 should not be included as part of the active link back to the search results. We did something similar for creator/contributor fields before.