### PR TITLE
Have make_date helper respect timezones

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -8,7 +8,7 @@ module UsersHelper
   end
 
   def make_date(date)
-    DateTime.parse(date).strftime("%m/%d/%Y")
+    DateTime.iso8601(date).in_time_zone.strftime("%m/%d/%Y")
   end
 
   def loan_options(loan)

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,9 @@ module Tulcob
     config.traject_indexer = File.join(Rails.root, "lib/traject/indexer_config.rb")
     ENV["ALLOW_IMPERSONATOR"] ||= "no"
 
+    config.time_zone = "Eastern Time (US & Canada)"
+    config.active_record.default_timezone = :local
+
     begin
       config.relative_url_root = config_for(:deploy_to)["path"]
     rescue StandardError => error

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UsersHelper, type: :helper do
+  describe "#make_date" do
+    it "returns a date in the correct timezone" do
+      iso8601_dt = "2018-10-16T02:00:00Z"
+      expect(make_date(iso8601_dt)).to eql "10/15/2018"
+    end
+  end
+end


### PR DESCRIPTION
Dates coming back from Alma's api are in UTC. We need to explicitly tell
rails to use a timezone or strftime will output UTC times.

This fixes human readnable dates on the account page for due dates and
Renewal due dates when a user renews an item.

Sets the Application timezone to "Eastern Time (US & Canada)".