### PR TITLE
[BL-685:713] Fix nav menu not active.

### DIFF
--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -47,8 +47,12 @@ module BentoSearch
       BentoSearch::ResultItem.new(title: item.fetch("title_truncated_display", []).first,
         authors: item.fetch("creator_display", []).map { |author| BentoSearch::Author.new(display: author.tr("|", " ")) },
         publisher: item.fetch("imprint_display", []).join(" "),
-        link: Rails.application.routes.url_helpers.solr_document_url(item["id"], only_path: true),
+        link: doc_link(item["id"]),
         custom_data: SolrDocument.new(item))
+    end
+
+    def doc_link(id)
+      Rails.application.routes.url_helpers.solr_document_path(id)
     end
 
     def url(helper)

--- a/app/search_engines/bento_search/books_engine.rb
+++ b/app/search_engines/bento_search/books_engine.rb
@@ -4,6 +4,10 @@ module BentoSearch
   class BooksEngine < BlacklightEngine
     delegate :blacklight_config, to: BooksController
 
+    def doc_link(id)
+      Rails.application.routes.url_helpers.solr_book_document_path(id)
+    end
+
     def url(helper)
       params = helper.params
       helper.search_books_path(q: params[:q])

--- a/app/search_engines/bento_search/journals_engine.rb
+++ b/app/search_engines/bento_search/journals_engine.rb
@@ -4,6 +4,10 @@ module BentoSearch
   class JournalsEngine < BlacklightEngine
     delegate :blacklight_config, to: JournalsController
 
+    def doc_link(id)
+      Rails.application.routes.url_helpers.solr_journal_document_path(id)
+    end
+
     def url(helper)
       params = helper.params
       helper.search_journals_path(q: params[:q])

--- a/app/search_engines/bento_search/primo_engine.rb
+++ b/app/search_engines/bento_search/primo_engine.rb
@@ -23,8 +23,12 @@ module BentoSearch
         title: item["title"],
         authors: item.fetch("creator", []).map { |author| BentoSearch::Author.new(display: author.tr(";", " ")) },
         publisher: item.fetch("isPartOf", "None found"),
-        link: Rails.application.routes.url_helpers.primo_central_document_url(item["pnxId"], only_path: true),
+        link: doc_link(item["pnxId"]),
         custom_data: item)
+    end
+
+    def doc_link(id)
+      Rails.application.routes.url_helpers.primo_central_document_path(id)
     end
 
     def url(helper)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,11 +39,11 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
-  resources :solr_book_documents, only: [:show], path: "/book", controller: "books" do
+  resources :solr_book_documents, only: [:show], path: "/books", controller: "books" do
     concerns :exportable
   end
 
-  resources :solr_journal_documents, only: [:show], path: "/journal", controller: "journals" do
+  resources :solr_journal_documents, only: [:show], path: "/journals", controller: "journals" do
     concerns :exportable
   end
 
@@ -60,9 +60,9 @@ Rails.application.routes.draw do
   end
 
   post "catalog/:id/track" => "catalog#track"
-  post "article/:id/track" => "primo_central#track", as: :track_primo_central
-  post "book/:id/track" => "book#track"
-  post "journal/:id/track" => "journal#track"
+  post "articles/:id/track" => "primo_central#track", as: :track_primo_central
+  post "books/:id/track" => "book#track"
+  post "journals/:id/track" => "journal#track"
 
   devise_for :users, controllers: { sessions: "sessions", omniauth_callbacks: "users/omniauth_callbacks" }
 
@@ -95,8 +95,8 @@ Rails.application.routes.draw do
   get "articles_advanced", to: "primo_advanced#index", as: "legacy_articles_advanced_search"
 
   get "catalog/:id/index_item", to: "catalog#index_item", as: "index_item"
-  get "book/:id/index_item", to: "books#index_item", as: "book_item"
-  get "journal/:id/index_item", to: "journals#index_item", as: "journal_item"
+  get "books/:id/index_item", to: "books#index_item", as: "book_item"
+  get "journals/:id/index_item", to: "journals#index_item", as: "journal_item"
   get "articles/:id/index_item", to: "primo_central#index_item", as: "articles_index_item"
 
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -139,12 +139,14 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#render_nav_link" do
-    let(:params) { {} }
-    let(:current_page?) { false }
+    let(:current_search_session) { OpenStruct.new(query_params: {}) }
+    let(:request) { OpenStruct.new(original_fullpath: "/") }
 
     before(:each) do
-      allow(helper).to receive(:params) { params }
-      allow(helper).to receive(:current_page?) { current_page? }
+      allow(helper).to receive(:request) { request }
+      without_partial_double_verification do
+        allow(helper).to receive(:current_search_session) { current_search_session }
+      end
     end
 
     context "path not current page" do
@@ -155,7 +157,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     context "path is current page" do
-      let(:current_page?) { true }
+      let(:request) { OpenStruct.new(original_fullpath: "/catalog") }
       it "renders a link with the active class" do
         link = "<li class=\"nav-btn active\"><a class=\"nav-link active\" href=\"/catalog\">More</a></li>"
         expect(helper.render_nav_link(:search_catalog_path, "More")).to eq(link)
@@ -163,13 +165,48 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     context "path contains a query" do
-      let(:params) { { q: "foo" } }
+      let(:current_search_session) { OpenStruct.new(query_params: { q: "foo" }) }
 
       it "gets the query added to the generated link" do
         link = "<li class=\"nav-btn\"><a class=\"nav-link\" href=\"/catalog?q=foo\">More</a></li>"
         expect(helper.render_nav_link(:search_catalog_path, "More")).to eq(link)
       end
     end
+  end
+
+  describe "#is_active?(path)" do
+    let(:current_page?) { true }
+    let(:request) { OpenStruct.new(original_fullpath: "/") }
+
+    before do
+      allow(helper).to receive(:request) { request }
+      allow(helper).to receive(:current_page?) { current_page? }
+    end
+
+    context "current page is :everything_path path and orig path is /" do
+      it "is active" do
+        expect(helper.is_active?(:everything_path)).to be_truthy
+      end
+    end
+
+    context "current page is :search_books_path and orig path is /books/foobar"  do
+      let(:current_page?) { false }
+      let(:request) { OpenStruct.new(original_fullpath: "/books/foobar") }
+
+      it "is active" do
+        expect(helper.is_active?(:search_books_path)).to be_truthy
+      end
+    end
+
+    context ":search_books_path does not match beginning of current page" do
+      let(:current_page?) { false }
+      let(:request) { OpenStruct.new(original_fullpath: "/articles/foobar") }
+
+      it "is not active" do
+        expect(helper.is_active?(:search_books_path)).to be_falsey
+      end
+    end
+
   end
 
   describe "#breadcrumb_links" do


### PR DESCRIPTION
REF BL-713

## Issue Description
“Everything” tab should be default highlighted in red on https://libqa.library.temple.edu/catalog/everything and https://libqa.library.temple.edu/catalog/ (where ever the user is starting a search in 'Everything')

“Everything” tab does not stay highlighted when you click on it, UNLESS you first click on another toggle then click back to “Everything”

Once you’re in Advanced Search, the section you’re in (Books, Articles, etc) still needs to be highlighted in the toggle.

## Changes Description
* Uses the current_search session to propagate search so that going to
    a record does not destroy nav menu.
* Updates the bento links to books and journals so that they match the new
    routes and following them activates the correct menu item.
* Updates the code that checks if a path is active so that it works on
    both the root path for the menu item and paths that build on that menu
    item path; that way when you go to /books/foobar (for example) the
    /books menu item is active etc.
