### PR TITLE
[BL-685/BL-712] Do not share facets across searches.

### DIFF
--- a/app/helpers/render_constraints_helper.rb
+++ b/app/helpers/render_constraints_helper.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module RenderConstraintsHelper
+  include Blacklight::RenderConstraintsHelperBehavior
+  include RenderConstraintsHelperBehaviorOverride
+end

--- a/app/helpers/render_constraints_helper_behavior_override.rb
+++ b/app/helpers/render_constraints_helper_behavior_override.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RenderConstraintsHelperBehaviorOverride
+  ##
+  # Overridden from module RenderConstraintsHelperBehavior.
+  #
+  # Overridden in order to disable rendering unknown facet fields.
+  ##
+  def render_filter_element(facet, values, path)
+    facet_config = facet_configuration_for_field(facet)
+
+    safe_join(Array(values).map do |val|
+      next if val.blank? # skip empty string
+      # skip if facet field not configured
+      next if blacklight_config.facet_fields[facet.to_s].blank?
+      render_constraint_element(facet_field_label(facet_config.key),
+                                facet_display_value(facet, val),
+                                remove: search_action_path(path.remove_facet_params(facet, val)),
+                                classes: ["filter", "filter-" + facet.parameterize])
+    end, "\n")
+  end
+end

--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -102,6 +102,8 @@ module Blacklight::PrimoCentral
       blacklight_params.fetch(:f, {})
         .merge(blacklight_params.fetch(:f_inclusive, {}))
         .each do |field, values|
+        # Only facet known fields
+        next unless blacklight_config.facet_fields[field.to_s].present?
         values.each do |value|
           primo_central_parameters[:query][:q].facet(
             field: solr_to_primo_facet(field),

--- a/app/models/blacklight/primo_central/solr_adaptor.rb
+++ b/app/models/blacklight/primo_central/solr_adaptor.rb
@@ -37,12 +37,6 @@ module Blacklight::PrimoCentral
     private
 
       SOLR_TO_PRIMO_FACETS = {
-        "creator_facet" => "creator",
-        "availability_facet" => "tlevel",
-        "format" => "rtype",
-        "pub_date_sort" => "creationdate",
-        "subject_topic_facet" => "topic",
-        "language_facet" => "lang",
       }
 
       SOLR_TO_PRIMO_KEYS = {

--- a/spec/helpers/render_constraints_helper_spec.rb
+++ b/spec/helpers/render_constraints_helper_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RenderConstraintsHelper, type: :helper do
+
+  describe "#render_filter_element" do
+    let(:config) do
+      Blacklight::Configuration.new do |config|
+        config.add_facet_field "type"
+      end
+    end
+    let(:params) { ActionController::Parameters.new q: "biz" }
+    let(:path) { Blacklight::SearchState.new(params, config, controller) }
+
+    before do
+      without_partial_double_verification do
+        allow(helper).to receive(:blacklight_config).and_return(config)
+      end
+    end
+
+    context "with unknown facet field in param" do
+      subject { helper.render_filter_element("unknown_field", "journal", path) }
+
+      it "does not render for an unknown field" do
+        expect(subject).to be_empty
+      end
+    end
+  end
+end

--- a/spec/models/primo_search_builder_spec.rb
+++ b/spec/models/primo_search_builder_spec.rb
@@ -153,6 +153,21 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
   end
 
   describe ".add_query_facets" do
+    let (:facets) { primo_central_parameters[:query][:q].include_facets }
+
+    before(:example) do
+      subject.add_query_to_primo_central(primo_central_parameters)
+      subject.set_query_field(primo_central_parameters)
+      subject.add_query_facets(primo_central_parameters)
+      subject.process_date_range_query(primo_central_parameters)
+    end
+
+    context "with unknown fields in params" do
+      let(:params) { ActionController::Parameters.new(f: { unknown_field: "foo" }) }
+      it "should not add query facet" do
+        expect(facets).to be_nil
+      end
+    end
   end
 
   describe ".process_date_range_query" do

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -250,4 +250,26 @@ RSpec.describe SearchBuilder , type: :model do
     end
 
   end
+
+  describe "#add_facet_fq_to_solr" do
+    it "converts a String fq into an Array" do
+      solr_parameters = { fq: "a string" }
+
+      subject.add_facet_fq_to_solr(solr_parameters)
+
+      expect(solr_parameters[:fq]).to be_a_kind_of Array
+    end
+
+    context "facet not defined in config" do
+      let(:single_facet) { { unknown_facet_field: "foo" } }
+      let(:user_params) { { f: single_facet } }
+
+      it "does not add facet to solr_parameters" do
+        solr_parameters = Blacklight::Solr::Request.new
+        subject.add_facet_fq_to_solr(solr_parameters)
+        expect(solr_parameters[:fq]).to be_empty
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
REF BL-712
REF projectblacklight/blacklight#1989

 ## Issue Description
After some QA testing, Jackie and I were talking further about the persistence of filters between Articles and the Solr menu options, and realized that there were some issues with this. For instance, even when there is a field match (author, topic, resource type), each index uses different vocabularies such that the values frequently don't match, leading to no results. We also felt that it might be confusing if some filters persisted (ex. date) while others didn't. So as a result, we'd like to scale this back and have just the basic query persist between Articles and the other options. Even in cases where the user has switched the basic query for "All Fields" to something else (ex. Title), it will revert back to All Fields. The relationship between Books, Journals, and More will remain as is, however.

 ## Implementation Description
This issue is a result of the upstream code being
promiscuous with respect to allowing any facet like user parameter to
be turned into a facet filter for the query.  Thus, it is not possible
to have multiple facet url parameters that should not be shared with
all searches.

By adding a check at the search build level that skips adding a facet
if the facet field in the parameter is not known (via configuration),
 then multiple searches can co-exist in the same URL and not clash.

An upstream PR has been submitted to fix this issue at the root,
hopefully it will be accepted.