### PR TITLE
[BL-685/BL-712] Remove format facet for books and journals.

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -7,5 +7,7 @@ class BooksController < CatalogController
   configure_blacklight do |config|
     config.search_builder_class = BooksSearchBuilder
     config.document_model = ::SolrBookDocument
+    # Do not allow any further filtering on type.
+    config.facet_fields.delete("format")
   end
 end

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -9,5 +9,7 @@ class JournalsController < CatalogController
   configure_blacklight do |config|
     config.search_builder_class = JournalsSearchBuilder
     config.document_model = SolrJournalDocument
+    # Do not allow any further filtering on type.
+    config.facet_fields.delete("format")
   end
 end


### PR DESCRIPTION
REF BL-685, REF BL-712

By removing the facet filter from books and journals we are able to
share the other facet field URL search configurations across all the
catalog type.  Thus we would be able to filter in the More search by
facet format and not affect the books or journal search view.