### PR TITLE
[BL-685/BL-717] Relax facets rendering.

### DIFF
--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,6 +1,6 @@
 <% # main container for facets/limits menu -%>
 
-<% if has_facet_values?  %>
+<% if has_facet_values? || has_search_parameters? %>
 <div id="facets" class="facets sidenav">
 
 <div class="top-panel-heading panel-heading">


### PR DESCRIPTION
REF BL-717

 ## Issue Description
  Now that the constraint fields are getting added inside of the facets side bar, whenever there is an empty search the constraints do not get rendered because the facets only get rendered when there are results.  We need to start rendering not just when facets are available but also when search params are present, that way on empty searches the user still has the ability to unselect a facet or search term that caused the search to return an empty results set.

 ## Implementation Description
 * Add or predicate to check if search parameters are present before
 rendering.