### PR TITLE
Add new purchase order feature for catalog items.

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -13,7 +13,17 @@ class SearchController < CatalogController
     @per_page = 3
     if params[:q]
       engines = %i( books articles journals more )
-      searcher = BentoSearch::ConcurrentSearcher.new(*engines)
+
+      # bento_search does not offer an easy way to pass in current_user
+      # via the concurrent_searcher initializer.
+      searcher = BentoSearch::ConcurrentSearcher.new
+      auto_rescued_exceptions = [StandardError]
+      engines.each do |id|
+        engine = BentoSearch.get_engine(id).tap { |e| e.auto_rescued_exceptions = auto_rescued_exceptions + e.auto_rescued_exceptions }
+        engine.current_user = current_user
+        searcher.add_engine(engine)
+      end
+
       searcher.search(params[:q], per_page: @per_page, semantic_search_field: params[:field])
       @results = split_more(searcher.results)
       @response = @results["resource_types"]&.first&.custom_data

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -106,11 +106,11 @@ module CatalogHelper
     end
   end
 
-  def render_online_availability_button(doc, count)
+  def render_online_availability_button(doc)
     links = check_for_full_http_link(document: doc, field: "electronic_resource_display")
 
     if !links.empty?
-      render "online_availability_button", document: doc, document_counter: count, links: links
+      render "online_availability_button", document: doc, links: links
     end
   end
 
@@ -127,9 +127,17 @@ module CatalogHelper
     blacklight_advanced_search_engine.advanced_search_path(params)
   end
 
-  def render_availability(doc, count)
-    if index_fields(doc).fetch("availability", nil)
-      render "index_availability_section", document: doc, document_counter: count
+  def render_availability(doc, doc_presenter)
+    if doc.purchase_order?
+      doc_presenter.purchase_order_button
+    elsif index_fields(doc).fetch("availability", nil)
+      render "index_availability_section", document: doc
+    end
+  end
+
+  def render_email_form_field
+    if !current_user&.email
+      render partial: "email_form_field"
     end
   end
 

--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -79,6 +79,11 @@ module Blacklight::PrimoCentral::Document
     # There are no physical items assoc. to Primo articles.
   end
 
+  def purchase_order?
+    # For now, disable all purchase orders for Primo documents.
+    false
+  end
+
 
   private
 

--- a/app/models/purchase_order_mailer.rb
+++ b/app/models/purchase_order_mailer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class PurchaseOrderMailer < RecordMailer
+  def purchase_order(document, details, url_gen_params)
+    title = begin
+              document.to_semantic_values[:title]
+            rescue
+              I18n.t("blacklight.email.text.default_title")
+            end
+    subject = "Purchase Order: " + title.first
+
+    @documents      = [document]
+    @message        = details[:message]
+    @url_gen_params = url_gen_params
+    @from_email = details[:from]
+
+    mail(to: "orders@temple.edu",  subject: subject)
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -113,6 +113,10 @@ class SolrDocument
     barcodes.include? barcode
   end
 
+  def purchase_order?
+    !!self["purchase_order"]
+  end
+
   private
     def barcode(item)
       item["item_data"]["pid"]

--- a/app/presenters/catalog_index_presenter.rb
+++ b/app/presenters/catalog_index_presenter.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CatalogIndexPresenter < Blacklight::IndexPresenter
+  def purchase_order_button
+    path = view_context.purchase_order_path(id: @document.id)
+
+    link = view_context.link_to "Request Purchase", path, class: "btn btn-sm btn-info", title: "Open a modal form to request a purchase for this item.", target: "_blank", id: "purchase_order_button-#{@document.id}", data: { "ajax-modal": "trigger" }
+    view_context.content_tag :div, link, class: "availability"
+  end
+end

--- a/app/presenters/primo_central_presenter.rb
+++ b/app/presenters/primo_central_presenter.rb
@@ -9,4 +9,8 @@ class PrimoCentralPresenter < Blacklight::IndexPresenter
     title << ": #{document[:subtitle]}" if (document.key?(:subtitle) && document[:subtitle])
     title
   end
+
+  def purchase_order_button
+    # There is no purchase of Primo docs for now.
+  end
 end

--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -5,7 +5,12 @@ module BentoSearch
     include BentoSearch::SearchEngine
     include Blacklight::SearchHelper
 
+    attr_accessor :current_user
     delegate :blacklight_config, to: CatalogController
+
+    def current_user
+      @current_user
+    end
 
     def search_implementation(args)
       query = args.fetch(:query, "")

--- a/app/views/catalog/_email_form_field.html.erb
+++ b/app/views/catalog/_email_form_field.html.erb
@@ -1,0 +1,8 @@
+    <div class="form-group">
+      <label class="control-label col-sm-2" for="to">
+        <%= t('blacklight.email.form.to') %>
+      </label>
+      <div class="col-sm-10">
+        <%= email_field_tag :to, params[:to], class: 'form-control' %>
+      </div>
+    </div>

--- a/app/views/catalog/_fields.html.erb
+++ b/app/views/catalog/_fields.html.erb
@@ -17,5 +17,5 @@
   <% end -%>
 <% end -%>
 
-<%= render_availability(document, document_counter) %>
+<%= render_availability(document, doc_presenter) %>
 </dl>

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -1,13 +1,13 @@
 <div class="blacklight-availability availability-ajax-load" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" >
 </div>
 
-  <%= render_online_availability_button(document, document_counter) %>
+  <%= render_online_availability_button(document) %>
 
   <% if document.fetch("availability_facet", []).include? "At the Library" %>
     <div class="row button-break"></div>
     <div data-controller="availability" data-availability-url="<%= item_url(document.alma_availability_mms_ids.first, redirect_to: request.url) %>">
       <div class="controls">
-        <button data-action="availability#item" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" class="btn btn-sm btn-default availability-toggle-details" data-toggle="collapse" data-target="#physical-document-<%=  document_counter %>, availability.button" id="available_button-<%=  document_counter %>">
+        <button data-action="availability#item" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" class="btn btn-sm btn-default availability-toggle-details" data-toggle="collapse" data-target="#physical-document-<%=  document.id %>, availability.button" id="available_button-<%=  document.id %>">
           <span role="spin" aria-expanded="false">Loading...</span>
         </button>
         <div data-target="availability.spinner" class="spinner">
@@ -17,19 +17,19 @@
 
         <div id="requests-container-<%= document.id %>" class="hidden requests-container" data-controller="requests" data-target="show.request, availability.request">
           <% if user_signed_in? %>
-            <%= request_modal(document.id, document_counter, @pickup_locations, @request_level) %>
+            <%= request_modal(document.id, document.id, @pickup_locations, @request_level) %>
           <% else %>
             <%= link_to(t("blacklight.requests.log_in"), new_user_session_with_redirect_path(request.url),  data: {"ajax-modal": "trigger"}, class: "log-in-link") %>
           <% end %>
         </div>
       </div>
 
-      <div  data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" id="physical-document-<%= document_counter %>" class="collapse panel-content avail-container index-avail-container">
+      <div  data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" id="physical-document-<%= document.id %>" class="collapse panel-content avail-container index-avail-container">
         <div><%= render_holdings_summary_table(document) %></div>
 
         <div class="table-wrapper hidden">
           <div data-target="availability.panel"></div>
-          <div><%= render "check_holdings", document: document, document_counter: document_counter %></div>
+          <div><%= render "check_holdings", document: document, document_counter: document.id %></div>
         </div>
       </div>
     </div>

--- a/app/views/catalog/_online_availability_button.html.erb
+++ b/app/views/catalog/_online_availability_button.html.erb
@@ -2,10 +2,10 @@
   <%= link_to "Online", single_link_builder(document["electronic_resource_display"].first), class:"collapse-button btn btn-sm btn-info", title:"This link opens the resource in a new tab.", target:"_blank", id: "single_link_online" %>
 <% elsif has_many_electronic_resources?(document) %>
   <div class="row button-break"></div>
-  <button class="btn-block btn btn-sm btn-info collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document_counter %>" id="many_links_online">
+  <button class="btn-block btn btn-sm btn-info collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document.id %>" id="many_links_online">
     <span class="avail-label" aria-expanded="false">Online</span>
   </button>
-  <div id="online-document-<%= document_counter %>" class="collapse online_resources">
+  <div id="online-document-<%= document.id %>" class="collapse online_resources">
     <table class="list_elec_links search_results_table">
       <%= links %>
       <span class="border-bottom"></span>

--- a/app/views/catalog/purchase_order.html.erb
+++ b/app/views/catalog/purchase_order.html.erb
@@ -1,0 +1,38 @@
+<% doc_presenter = show_presenter(@document) %>
+
+<div class="modal-header">
+<button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-hidden="true">×</button>
+<h1 class="modal-title">Request Rapid Access</h1>
+  </div>
+<%= form_tag url_for(:controller => controller_name, :action => "purchase_order_action"), :id => 'purchase_order_form', :class => "form-horizontal ajax_form", :method => :post do %>
+
+  <div class="modal-body">
+    <p>A purchase order request will be submitted for the item titled: <strong><%= doc_presenter.html_title %></strong>
+    </p>
+
+    <p>Please note that this request is not for an instant purchase. We will contact you when this request gets processed.</p>
+
+    <p>
+    Also, you may add extra instructions for this order in the messages field below if desired.
+    </p>
+
+    <%= render :partial=>'/flash_msg' %>
+
+    <%= render_email_form_field %>
+
+    <div class="form-group">
+      <label class="control-label col-sm-2" for="message">
+        <%= t('blacklight.email.form.message') %>
+      </label>
+      <div class="col-sm-10">
+        <%= text_area_tag :message, params[:message], class: 'form-control' %>
+      </div>
+    </div>
+
+    <%=hidden_field_tag "id", @document.id %>
+  </div>
+
+  <div class="modal-footer">
+  <button type="submit" class="btn btn-primary">Purchase Order</button>
+  </div>
+<% end %>

--- a/app/views/purchase_order_mailer/purchase_order.text.erb
+++ b/app/views/purchase_order_mailer/purchase_order.text.erb
@@ -1,0 +1,8 @@
+Temple University Libraries Purchase Order Request:
+
+Requested by: <%= "#{@from}" %>
+
+<%= @document.to_email_text %>
+<%= t('blacklight.email.text.url', :url =>polymorphic_url(document, @url_gen_params)) %>
+
+<%= t('blacklight.email.text.message', :message => @message) %>

--- a/app/views/record_mailer/purchase_order.text.erb
+++ b/app/views/record_mailer/purchase_order.text.erb
@@ -1,0 +1,9 @@
+Temple University Libraries record(s):
+
+<% @documents.each do |document| %>
+<%= document.to_email_text %>
+<%= t('blacklight.email.text.url', :url =>polymorphic_url(document, @url_gen_params)) %>
+
+<% end %>
+
+<%= t('blacklight.email.text.message', :message => @message) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   match "journals/advanced", to: "journals_advanced#index", as: "journals_advanced_search", via: [:get, :post]
   match "articles/advanced", to: "primo_advanced#index", as: "articles_advanced_search", via: [:get, :post]
   match "catalog/advanced", to: "advanced#index", as: "advanced_search", via: [:get, :post]
+  match "catalog/:id/purchase_order", to: "catalog#purchase_order_action", via: [:post], as: "purchase_order_action"
 
   # concerns
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
@@ -98,6 +99,7 @@ Rails.application.routes.draw do
   get "books/:id/index_item", to: "books#index_item", as: "book_item"
   get "journals/:id/index_item", to: "journals#index_item", as: "journal_item"
   get "articles/:id/index_item", to: "primo_central#index_item", as: "articles_index_item"
+  get "catalog/:id/purchase_order", to: "catalog#purchase_order", as: "purchase_order"
 
 
   #

--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -241,3 +241,4 @@ to_field "changed_back_to_display", extract_marc("785|08|iabdghkmnopqrstuxyz3", 
 to_field "library_based_boost_t", library_based_boost
 
 to_field "bound_with_ids", extract_marc("ADFa")
+to_field "purchase_order", extract_purchase_order

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -534,6 +534,12 @@ module Traject
           acc << Traject::MarcExtractor.cached(spec).extract(rec).join(" . ")
         end
       end
+
+      def extract_purchase_order
+        lambda do |rec, acc|
+          acc << Traject::MarcExtractor.cached("902a").extract(rec).any? { |s| s.match?(/EBC-POD/) } || false
+        end
+      end
     end
   end
 end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -70,7 +70,7 @@
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
 
     <!-- boolean type: "true" or "false" -->
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="false"/>
     <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
     <fieldtype name="binary" class="solr.BinaryField"/>
 
@@ -496,6 +496,8 @@
    <field name="bound_with_ids" type="string" indexed="true" stored="true" multiValued="true"/>
 
    <field name="work_access_point" type="string" indexed="true" stored="true" multiValued="true"/>
+   <field name="purchase_order" type="boolean" indexed="true" stored="true" multiValued="false" default="false" />
+
 
    <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
         will be used if the name matches any of the patterns.

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe CatalogController, type: :controller do
     end
   end
 
+
   describe "GET index as json" do
     render_views
     before do
@@ -113,6 +114,34 @@ RSpec.describe CatalogController, type: :controller do
 
         expect(request.flash[:error]).to be_nil
         expect(doc[:sms]).to eq("CHOSEN BOOK")
+      end
+    end
+  end
+
+  describe "#purchase_order/#purchase_order_action" do
+    before do
+      allow(controller).to receive(:purchase_order_action) {}
+    end
+
+    context "user is not logged in" do
+      it "does not allow access to purchase order action" do
+        get :purchase_order, params: { id: doc_id }
+        expect(response).not_to be_success
+
+        post :purchase_order_action, params: { id: doc_id }
+        expect(response).not_to be_success
+      end
+    end
+
+    context "user is logged in" do
+      it "allows access to purchase order actioins" do
+        sign_in FactoryBot.create(:user)
+
+        get :purchase_order, params: { id: doc_id }
+        expect(response).to be_success
+
+        post :purchase_order_action, params: { id: doc_id }
+        expect(response).to be_success
       end
     end
   end

--- a/spec/fixtures/purchase_online_bibs.xml
+++ b/spec/fixtures/purchase_online_bibs.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
+  <record>
+    <leader>03887nam a22003973i 4500</leader>
+    <controlfield tag="005">20181016121354.0</controlfield>
+    <controlfield tag="006">m     o  d |      </controlfield>
+    <controlfield tag="007">cr cnu||||||||</controlfield>
+    <controlfield tag="008">181016s2018    xx      o     ||||0 eng d</controlfield>
+    <controlfield tag="001">991036931835603811</controlfield>
+    <datafield tag="020" ind1=" " ind2=" ">
+      <subfield code="a">9783030003265</subfield>
+      <subfield code="q">(electronic bk.)</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+      <subfield code="z">9783030003258</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(MiAaPQ)EBC5521379</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(Au-PeEL)EBL5521379</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(OCoLC)1054128988</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">MiAaPQ</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="e">rda</subfield>
+      <subfield code="e">pn</subfield>
+      <subfield code="c">MiAaPQ</subfield>
+      <subfield code="d">MiAaPQ</subfield>
+    </datafield>
+    <datafield tag="050" ind1=" " ind2="4">
+      <subfield code="a">HN25JF20-2112HD72-HD</subfield>
+    </datafield>
+    <datafield tag="100" ind1="1" ind2=" ">
+      <subfield code="a">el-Aswad, El-Sayed.</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="4">
+      <subfield code="a">The Quality of Life and Policy Issues among the Middle East and North African Countries.</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="1">
+      <subfield code="a">Cham :</subfield>
+      <subfield code="b">Springer,</subfield>
+      <subfield code="c">2018.</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="4">
+      <subfield code="c">©2018.</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+      <subfield code="a">1 online resource (162 pages)</subfield>
+    </datafield>
+    <datafield tag="336" ind1=" " ind2=" ">
+      <subfield code="a">text</subfield>
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+      <subfield code="a">computer</subfield>
+      <subfield code="b">c</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+      <subfield code="a">online resource</subfield>
+      <subfield code="b">cr</subfield>
+      <subfield code="2">rdacarrier</subfield>
+    </datafield>
+    <datafield tag="490" ind1="1" ind2=" ">
+      <subfield code="a">Human Well-Being Research and Policy Making Ser.</subfield>
+    </datafield>
+    <datafield tag="505" ind1="0" ind2=" ">
+      <subfield code="a">Intro -- Preface -- About the Book -- References -- Acknowledgements -- Contents -- About the Author -- Abbreviations and Acronyms -- List of Figures -- List of Tables -- 1 Introduction -- References -- 2 Methodology -- 2.1 Introduction -- 2.2 Framework -- References -- 3 Historical Background -- 3.1 Introduction -- 3.2 The Middle East and North Africa Region -- 3.3 Population -- 3.4 Overall Human Development -- 3.5 Brief History -- 3.5.1 The Quality of Life in the Ancient MENA Region -- 3.5.2 The Quality of Life in the Medieval Era -- 3.5.3 The Quality of Life in Modern History -- 3.6 Well-Being and Challenges Since 1950 -- 3.6.1 External Factors -- 3.6.2 Internal Factors -- 3.6.3 Militarization -- 3.7 Quality of Life: Religion and Ideology -- 3.8 Conclusion -- References -- 4 Indicators of Quality of Life and Well-Being in the Middle East and North African Region: A Comparative Analysis -- 4.1 Introduction -- 4.2 Quality of Life in the Middle East and North Africa -- 4.2.1 Quality of Life in Egypt -- 4.2.2 Quality of Life in the Islamic Republic of Iran -- 4.2.3 Quality of Life in Israel -- 4.2.4 Quality of Life in Tunisia -- 4.2.5 Quality of Life in Turkey -- 4.2.6 Quality of Life in the United Arab Emirates -- 4.3 Comparative Analysis -- 4.3.1 Happiness and Human Development -- 4.3.2 Inequality Issues -- 4.4 Conclusion -- References -- 5 Key Drivers of Well-Being and Policy Issues in the Middle East and North Africa Region -- 5.1 Introduction -- 5.2 Brief History -- 5.3 Key Drivers -- 5.3.1 Key Drivers in Egypt -- 5.3.2 Key Drivers in Iran -- 5.3.3 Key Drivers in Israel -- 5.3.4 Key Drivers in Tunisia -- 5.3.5 Key Drivers in Turkey -- 5.3.6 Key Drivers in the United Arab Emirates (UAE) -- 5.4 Human Rights and Religious Tolerance: A Comparative Analysis.</subfield>
+    </datafield>
+    <datafield tag="505" ind1="8" ind2=" ">
+      <subfield code="a">5.5 Information Communication Technology in the Middle East and North Africa Region: A Comparative Analysis -- 5.6 Social Policies -- 5.7 Conclusion -- References -- 6 Conclusion -- 6.1 Introduction -- 6.1.1 Cross-Cultural and Historical Perspectives -- 6.1.2 Quality of Life and Well-Being -- 6.1.3 Social Policy: Governmental and Non-governmental Agencies -- References -- Index.</subfield>
+    </datafield>
+    <datafield tag="588" ind1=" " ind2=" ">
+      <subfield code="a">Description based on publisher supplied metadata and other sources.</subfield>
+    </datafield>
+    <datafield tag="590" ind1=" " ind2=" ">
+      <subfield code="a">Electronic reproduction. Ann Arbor, Michigan : ProQuest Ebook Central, 2018. Available via World Wide Web. Access may be limited to ProQuest Ebook Central affiliated libraries. </subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="4">
+      <subfield code="a">Electronic books.</subfield>
+    </datafield>
+    <datafield tag="776" ind1="0" ind2="8">
+      <subfield code="i">Print version:</subfield>
+      <subfield code="a">el-Aswad, El-Sayed</subfield>
+      <subfield code="t">The Quality of Life and Policy Issues among the Middle East and North African Countries</subfield>
+      <subfield code="d">Cham : Springer,c2018</subfield>
+      <subfield code="z">9783030003258</subfield>
+    </datafield>
+    <datafield tag="797" ind1="2" ind2=" ">
+      <subfield code="a">ProQuest (Firm)</subfield>
+    </datafield>
+    <datafield tag="830" ind1=" " ind2="0">
+      <subfield code="a">Human Well-Being Research and Policy Making Ser.</subfield>
+    </datafield>
+    <datafield tag="902" ind1=" " ind2=" ">
+      <subfield code="a">EBC-POD 2018_10 Load</subfield>
+    </datafield>
+    <datafield tag="979" ind1=" " ind2=" ">
+      <subfield code="a">EBC5521379</subfield>
+    </datafield>
+    <datafield tag="ADM" ind1=" " ind2=" ">
+      <subfield code="e">EBC5521379</subfield>
+      <subfield code="b">2018-10-16 19:25:33</subfield>
+      <subfield code="d">OTHER</subfield>
+      <subfield code="f">20181016121354.0</subfield>
+      <subfield code="a">2018-10-16 19:25:37</subfield>
+      <subfield code="c">false</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -72,4 +72,55 @@ RSpec.describe CatalogHelper, type: :helper do
       end
     end
   end
+
+  describe "#render_availability" do
+    let(:doc) { SolrDocument.new(purchase_order: true) }
+    let(:presenter) { CatalogIndexPresenter.new(doc, self) }
+    let(:blacklight_config) { CatalogController.blacklight_config }
+
+    before do
+      allow(presenter).to receive(:purchase_order_button) { "purchase_order_button" }
+      allow(helper).to receive(:render) { "availability_section" }
+      without_partial_double_verification do
+        allow(helper).to receive(:blacklight_config) { blacklight_config }
+      end
+    end
+
+    context "document has purchase order" do
+      it "should render the purchase order button" do
+        expect(helper.render_availability(doc, presenter)).to eq("purchase_order_button")
+      end
+    end
+
+    context "document does not have purchase order button" do
+      let(:doc) { SolrDocument.new(purchase_order: false) }
+      it "should not render the purchase_order_button" do
+        expect(helper.render_availability(doc, presenter)).to eq("availability_section")
+      end
+    end
+  end
+
+  describe "#render_email_form_field" do
+    let(:current_user) { OpenStruct.new(email: nil) }
+
+    before do
+      allow(helper).to receive(:current_user) { current_user }
+      allow(helper).to receive(:render) { "render_email_form_field" }
+    end
+
+    context "user does not have email" do
+      it "renders the email field" do
+        expect(helper.render_email_form_field).to eq("render_email_form_field")
+      end
+    end
+
+    context "user has email" do
+      let(:current_user) { OpenStruct.new(email: "foo") }
+
+      it "does not render the email form field" do
+        expect(helper.render_email_form_field).to be_nil
+      end
+    end
+
+  end
 end

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -1018,6 +1018,67 @@ RSpec.describe Traject::Macros::Custom do
         expect(subject.map_record(record)).to eq({})
       end
     end
+  end
 
+  describe "#extract_purchase_order" do
+    let (:record) { MARC::XMLReader.new(StringIO.new(record_text)).first }
+
+    before do
+      subject.instance_eval do
+        to_field "purchase_order", extract_purchase_order
+        settings do
+          provide "marc_source.type", "xml"
+        end
+      end
+    end
+
+    context "with mathing 902a field" do
+      let(:record_text) { "
+<record>
+  <datafield ind1='1' ind2=' ' tag='902'>
+    <subfield code='a'>EBC-POD</subfield>
+    <subfield code='d'>d</subfield>
+  </datafield>
+  <datafield ind1='1' ind2=' ' tag='100'>
+    <subfield code='a'>Foo</subfield>
+    <subfield code='q'>q</subfield>
+  </datafield>
+</record>
+                     " }
+
+      it "maps to true" do
+        expect(subject.map_record(record)).to eq("purchase_order" => [true])
+      end
+    end
+
+    context "without a matching 902a field" do
+      let(:record_text) { "
+<record>
+  <datafield ind1='1' ind2=' ' tag='902'>
+    <subfield code='a'>Buzz</subfield>
+    <subfield code='d'>d</subfield>
+  </datafield>
+  <datafield ind1='1' ind2=' ' tag='100'>
+    <subfield code='a'>Foo</subfield>
+    <subfield code='q'>q</subfield>
+  </datafield>
+</record>
+                     " }
+
+      it "maps to false" do
+        expect(subject.map_record(record)).to eq("purchase_order" => [false])
+      end
+    end
+
+    context "without a 902a field" do
+      let(:record_text) { "
+<record>
+</record>
+                     " }
+
+      it "maps to false" do
+        expect(subject.map_record(record)).to eq("purchase_order" => [false])
+      end
+    end
   end
 end

--- a/spec/models/books_search_builder_spec.rb
+++ b/spec/models/books_search_builder_spec.rb
@@ -7,8 +7,13 @@ RSpec.describe BooksSearchBuilder , type: :model do
   let(:params) { ActionController::Parameters.new }
   let(:search_builder) { BooksSearchBuilder.new(context) }
   let(:solr_parameters) { Blacklight::Solr::Request.new(fq: []) }
+  let(:user) { FactoryBot.create(:user) }
 
   subject { search_builder }
+
+  before(:each) do
+    allow(context).to receive(:current_user) { user }
+  end
 
   it "Should include a books_facet search preprocessor" do
     expect(subject.default_processor_chain).to include(:books_facet)

--- a/spec/models/journals_search_builder_spec.rb
+++ b/spec/models/journals_search_builder_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe JournalsSearchBuilder , type: :model do
   let(:params) { ActionController::Parameters.new }
   let(:search_builder) { JournalsSearchBuilder.new(context) }
   let(:solr_parameters) { Blacklight::Solr::Request.new(fq: []) }
+  let(:user) { FactoryBot.create(:user) }
+
+  before(:each) do
+    allow(context).to receive(:current_user) { user }
+  end
 
   subject { search_builder }
 

--- a/spec/models/primo_central_document_spec.rb
+++ b/spec/models/primo_central_document_spec.rb
@@ -158,4 +158,30 @@ RSpec.describe PrimoCentralDocument, type: :model do
       expect(subject["isbn"]).to eq(["a"])
     end
   end
+
+  describe "#purchase_order?" do
+    context "with purchase_order false" do
+      let(:document) { PrimoCentralDocument.new(purchase_order: false) }
+
+      it "should be false" do
+        expect(document.purchase_order?).to be false
+      end
+    end
+
+    context "with purchase_order true" do
+      let(:document) { PrimoCentralDocument.new(purchase_order: true) }
+
+      it "should be false" do
+        expect(document.purchase_order?).to be false
+      end
+    end
+
+    context "with no purchase_order" do
+      let(:document) { PrimoCentralDocument.new({}) }
+
+      it "should be false" do
+        expect(document.purchase_order?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -173,4 +173,31 @@ RSpec.describe SolrDocument, type: :model do
       end
     end
   end
+
+  describe "#purchase_order?" do
+    context "with purchase_order false" do
+      let(:document) { SolrDocument.new(purchase_order: false) }
+
+      it "should be false" do
+        expect(document.purchase_order?).to be false
+      end
+    end
+
+    context "with purchase_order true" do
+      let(:document) { SolrDocument.new(purchase_order: true) }
+
+      it "should be true" do
+        expect(document.purchase_order?).to be true
+      end
+    end
+
+    context "with no purchase_order" do
+      let(:document) { SolrDocument.new({}) }
+
+      it "should be false" do
+        expect(document.purchase_order?).to be false
+      end
+
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,3 +67,15 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :truncation
   end
 end
+
+FactoryBot.define do
+  sequence :email do |n|
+    "person#{n}@example.com"
+  end
+end
+
+FactoryBot.modify do
+  factory :user do
+    email { generate(:email) }
+  end
+end


### PR DESCRIPTION
REF BL-340

  ## Feature description

Original message from Brian S.:

  I would like to explore the feasibility of adding an option for authenticated patrons to request purchase of materials via records in Primo/Blacklight. The idea is that we would load some marc records for unpurchased materials into Alma which would then be presented to patrons
  with a link of some sort (e.g. "Request Rapid Access"), instead of the current "Available at" or "Online" options. Upon clicking the link, the authenticated patron is presented with a prefilled form containing item metadata and patron info, which s/he then submits. The form info goes to an Acq email address and the ebook is quickly ordered.

  See attached for a screenshot of how another ExL school has done something similar (though they have the form info going directly to their vendor ordering software \- which we are not looking to implement, for now at least).

  If we could get this operating, I estimate it could save us $125K/yr by allowing us to break out of a "big-deal" ebook package. Realistically, it would probably be December 2018 before this could affect our arrangement for the particular ebook package I have in mind, but I would like to move ahead quickly on scoping out the technical feasibility and timelines for
  this."

  This is a time sensitive issue, as Brian needs to determine the feasibility of this plan by early Nov. in order to make budgetary decision. While this does not need to be completely finished by the end of the sprint, please prioritize initial work and review of this issue.

 ### Requirements+

Currently a test set of records has been loaded into the Alma sandbox for these records. Emily had export that set to the linode Alma FTP server, which will need to be manually loaded into libqa. The file is alma_bibs_purchase_order_2018102317_8599345330003811_new.xml.tar.gz. Only once we are ready for production will these records be added to the production site.

* Flag the record type by MARC field 902, when subfield a includes EBC-POD (note that this local field is used for other purposes as well, so including logic about specific string is important)
* For flagged records, add a new value for the Availability facet, “Purchase Order”, in addition to Online and At the Library (Sandi – let me know if you have a better phrasing for this)
* These records should be indexed, searched, and displayed the same way as normal ones, _except_ for the Availability section.
* For Availability section, omit regular display, except for the header and instead include the following text: TBD (Sandi will provide this copy).
* Use the general request button/modal for the purchase order, with separate form option for just these record types (this should not show up for normal records).
* Users must be authenticated via My Library Account to access this option.
* For purchase order form, use header "Request Rapid Access" with short description (Sandi will provide this copy) and optional note field. Otherwise, pass through the following fields to the email [orders@temple.edu|mailto:orders@temple.edu]: MMS ID, title statement, creator, contributor, imprint, optional note, some form of user identification (not sure what security limitations are for this via email, but maybe TUID or Alma username? Discuss with Chad), user email. Indicate that this is a Blacklight-generated purchase order.

 ## Implementation Description

 A new index has been added called purchase_order that is indexed to
 false by default but true when appropriate field are present in the
 marc record.

 The new field is of type float and update has been made to the solr
 schema.xml to allow for faceting of fields of type Boolean.

 Two new actions have been added to the controller that are accessible
 only to the logged in user.

 Further, when a user is not logged in a filter is automatically added
 to a query to filter out any results that can be purchase ordered.

 ### Local Testing
* After restarting sorl and reindexing, search for "991036931835603811".
It's a new local record that that can be purchase ordered. You will need
to be logged in order to get a result.