### PR TITLE
Remove pry dep from traject indexer.

### DIFF
--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -2,7 +2,6 @@
 
 require "library_stdnums"
 require "active_support/core_ext/object/blank"
-require "pry"
 # A set of custom traject macros (extractors and normalizers) used by the
 module Traject
   module Macros


### PR DESCRIPTION
When I tried to import some files directly into the libqa solr, having
this requirement made the import fail.  This dependency should only be
added locally if and when required.