### PR TITLE
[BL-524] Increase the default library based boosting to 1000.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -203,7 +203,7 @@ class CatalogController < ApplicationController
       sow: "false",
       bq: [
           "pub_date_tdt:[NOW/DAY-10YEAR TO NOW/DAY]^3500",
-          "(library_based_boost_t:* -no_boost)^500"],
+          "(library_based_boost_t:* -no_boost)^1000"],
       fq: %w[
         -suppress_items_b:*
       ]


### PR DESCRIPTION
REF BL-524

Further de-emphasizes PRESSER results by boosting other libraries score.