### PR TITLE
[BL-695] removes maj = major solr synonym.

### DIFF
--- a/solr/conf/synonyms.txt
+++ b/solr/conf/synonyms.txt
@@ -51,8 +51,6 @@ c++ => cplusplus
 .NET => dotnet
 
 min => minor
-maj => major
-maj. => major
 
 # Added for BL-447
 employment,labor => work


### PR DESCRIPTION
REF BL-695

Removing the synonym because of stemming we cannot make a distinction
between maj. and maj and since Maj is a word we would lose those
results.