### PR TITLE
[BL-723, BL-340] Fix purchase order email not working.

### DIFF
--- a/app/models/purchase_order_mailer.rb
+++ b/app/models/purchase_order_mailer.rb
@@ -9,10 +9,10 @@ class PurchaseOrderMailer < RecordMailer
             end
     subject = "Purchase Order: " + title.first
 
-    @documents      = [document]
+    @document       = document
     @message        = details[:message]
     @url_gen_params = url_gen_params
-    @from_email = details[:from]
+    @from_email     = details[:from]
 
     mail(to: "orders@temple.edu",  subject: subject)
   end

--- a/app/models/solr_book_document.rb
+++ b/app/models/solr_book_document.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
 class SolrBookDocument < SolrDocument
+  use_extension(Blacklight::Document::Email)
+  use_extension(Blacklight::Document::Sms)
 end

--- a/app/models/solr_journal_document.rb
+++ b/app/models/solr_journal_document.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
 class SolrJournalDocument < SolrDocument
+  use_extension(Blacklight::Document::Email)
+  use_extension(Blacklight::Document::Sms)
 end

--- a/app/views/purchase_order_mailer/purchase_order.text.erb
+++ b/app/views/purchase_order_mailer/purchase_order.text.erb
@@ -1,8 +1,7 @@
 Temple University Libraries Purchase Order Request:
 
-Requested by: <%= "#{@from}" %>
-
+Requested by: <%= "#{@from_email}" %>
 <%= @document.to_email_text %>
-<%= t('blacklight.email.text.url', :url =>polymorphic_url(document, @url_gen_params)) %>
-
+<%= t('blacklight.email.text.url', :url =>polymorphic_url(@document, @url_gen_params)) %>
 <%= t('blacklight.email.text.message', :message => @message) %>
+

--- a/app/views/record_mailer/purchase_order.text.erb
+++ b/app/views/record_mailer/purchase_order.text.erb
@@ -1,9 +1,0 @@
-Temple University Libraries record(s):
-
-<% @documents.each do |document| %>
-<%= document.to_email_text %>
-<%= t('blacklight.email.text.url', :url =>polymorphic_url(document, @url_gen_params)) %>
-
-<% end %>
-
-<%= t('blacklight.email.text.message', :message => @message) %>


### PR DESCRIPTION
REF BL-723, BL-340

 ## Description:

The new solr doc types cannot be emailed or texted because they are missing an include.  This is reproducible by doing a search in books or journals and clicking on a found item and then trying to email or text it.

There is also an issue with the purchase_order email template that this
fixes.