### PR TITLE
BL-359 Refactor availability display

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -22,7 +22,8 @@ class AlmawsController < CatalogController
 
     json_request_logger(type: "bib_items_availability", uri: bib_items.request.uri.to_s, start: start)
     @items = bib_items.filter_missing_and_lost.grouped_by_library
-    @unsuppressed_items = helpers.unsuppressed_holdings(@items, @document)
+    #@items is mutated by unsuppressed_holdings helper method
+    helpers.unsuppressed_holdings(@items, @document)
     @pickup_locations = CobAlma::Requests.valid_pickup_locations(@items).join(",")
     @request_level = has_desc?(bib_items) ? "item" : "bib"
     @redirect_to = params[:redirect_to]

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -1,12 +1,12 @@
 <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-hidden="true">×</button>
 
 <div id="request-url-data-<%= @mms_id %>" class="hidden" data-requests-url="<%= request_options_path(@mms_id, @pickup_locations, @request_level) %>"></div>
-<% unless @items.empty? || @unsuppressed_items.values.include?([]) %>
+<% unless @items.values.all?(&:empty?) %>
   <div class="availability-modal">
     <div class="modal-only">
       <%= render :partial => "paginate_compact", :object => @response %>
     </div>
-  <% sort_order_for_holdings(@unsuppressed_items).each do |key,items| %>
+  <% sort_order_for_holdings(@items).each do |key,items| %>
     <table id="availability-container" class="table table-responsive border-bottom">
       <thead>
         <tr class="sr-only">

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -1,8 +1,7 @@
 <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-hidden="true">×</button>
 
 <div id="request-url-data-<%= @mms_id %>" class="hidden" data-requests-url="<%= request_options_path(@mms_id, @pickup_locations, @request_level) %>"></div>
-
-<% unless @items.empty? %>
+<% unless @items.empty? || @unsuppressed_items.values.include?([]) %>
   <div class="availability-modal">
     <div class="modal-only">
       <%= render :partial => "paginate_compact", :object => @response %>


### PR DESCRIPTION
Currently, if an item is suppressed it is still displaying the library name with an empty table.  This filters it to show the default text when all items are suppressed.