### PR TITLE
Fix error do to unknown field.

### DIFF
--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -38,15 +38,15 @@ class PrimoCentralController < CatalogController
     config.facet_paginator_class = Blacklight::PrimoCentral::FacetPaginator
 
     # Search fields
-    config.add_search_field :any, label: "All Fields"
+    config.add_search_field :any, label: "All Fields", catalog_map: :all_fields
     config.add_search_field :title
-    config.add_search_field :creator, label: "Author/Creator"
-    config.add_search_field :sub, label: "Subject"
-    config.add_search_field(:description, label: "Description") do |field|
+    config.add_search_field :creator, label: "Author/Creator", catalog_map: :creator_t
+    config.add_search_field :sub, label: "Subject", catalog_map: :subject
+    config.add_search_field(:description, label: "Description", catalog: :note_t) do |field|
       field.include_in_simple_select = false
     end
-    config.add_search_field :isbn, label: "ISBN"
-    config.add_search_field :issn, label: "ISSN"
+    config.add_search_field :isbn, label: "ISBN", catalog_map: :isbn_t
+    config.add_search_field :issn, label: "ISSN", catalog_map: :issn_t
 
     # Index fields
     config.add_index_field :isPartOf, label: "Is Part Of"

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -112,6 +112,7 @@ end
 module BlacklightAdvancedSearch
   class QueryParser
     include AdvancedHelper
+    include Blacklight::PrimoCentral::SolrAdaptor
 
     def keyword_op
       # NOTs get added to the query. Only AND/OR are operations
@@ -169,6 +170,7 @@ module BlacklightAdvancedSearch
       queries = []
       ops = keyword_op
       keyword_queries.each do |field, query|
+        field = primo_to_solr_search(field)
         queries << ParsingNesting::Tree.parse(query, config.advanced_search[:query_parser]).to_query(local_param_hash(field, config))
         queries << ops.shift
       end

--- a/app/models/blacklight/primo_central/solr_adaptor.rb
+++ b/app/models/blacklight/primo_central/solr_adaptor.rb
@@ -34,6 +34,10 @@ module Blacklight::PrimoCentral
       solr_to_primo_keys.invert
     end
 
+    def primo_to_solr_search(field)
+      (PrimoCentralController.blacklight_config.search_fields.dig(field, "catalog_map") || field).to_s
+    end
+
     private
 
       SOLR_TO_PRIMO_FACETS = {


### PR DESCRIPTION
REF BL-689

Fixes error when switching between Primo advanced and catalog search do
to an unknown field.