### PR TITLE
Boost catalog title search fields.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -100,8 +100,8 @@ class CatalogController < ApplicationController
         subtitle_t^10000
         title_statement_unstem_search^15000
         title_statement_t^5000
-        title_uniform_unstem_search^5000
-        title_uniform_t^2500
+        title_uniform_unstem_search^15000
+        title_uniform_t^5000
         title_addl_unstem_search^5000
         title_addl_t^2500
         title_added_entry_unstem_search^1500
@@ -127,7 +127,7 @@ class CatalogController < ApplicationController
         subtitle_t^100000
         title_statement_unstem_search^150000
         title_statement_t^50000
-        title_uniform_unstem_search^75000
+        title_uniform_unstem_search^150000
         title_uniform_t^50000
         title_addl_unstem_search^50000
         title_addl_t^25000


### PR DESCRIPTION
REF BL-661

Boost `title_uniform_unstem_search^15000` and `title_uniform_t^5000` for
qf.

For pf, try `title_uniform_unstem_search^150000` and
`title_uniform_t^50000`.