### PR TITLE
Fix docker max depth exceeded.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: .
       dockerfile: .docker/solr/Dockerfile
-    image: solr:6.6.1
+    image: tulibraries/solr:6.6.1
     ports:
       - "8983"
     networks:


### PR DESCRIPTION
REF https://stackoverflow.com/a/47274773/256854

Not name spasing my solr container is causing it to hit max depth
exceeded error every couple of months totally hosing my dev environment.