### PR TITLE
[BL-359] Fix bound-with doc throws on fetch.

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -10,7 +10,8 @@ class AlmawsController < CatalogController
 
   def item
     @mms_id = params[:mms_id]
-    _, @document = fetch(@mms_id)
+    _, @document = begin fetch(params[:doc_id]) rescue [ nil, SolrDocument.new({}) ] end
+
     start = Time.now
     # TODO: refactor to repository/response/search_behavior ala primo/solr.
     page = (params[:page] || 1).to_i
@@ -19,6 +20,7 @@ class AlmawsController < CatalogController
 
     bib_items = Alma::BibItem.find(@mms_id, limit: limit, offset: offset)
     @response = Blacklight::Alma::Response.new(bib_items, params)
+
 
     json_request_logger(type: "bib_items_availability", uri: bib_items.request.uri.to_s, start: start)
     @items = bib_items.filter_missing_and_lost.grouped_by_library

--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -114,6 +114,8 @@ module AlmaDataHelper
   def unsuppressed_holdings(items_list, document)
     solr_holdings = document.fetch("holdings_display", "")
 
+    return if solr_holdings.blank?
+
     items_list.each_pair { |library, items|
       items_list[library] = items.select { |item|
        solr_holdings.include?(item["holding_data"]["holding_id"])

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -5,7 +5,7 @@
 
   <% if document.fetch("availability_facet", []).include? "At the Library" %>
     <div class="row button-break"></div>
-    <div data-controller="availability" data-availability-url="<%= item_url(document.alma_availability_mms_ids.first, redirect_to: request.url) %>">
+    <div data-controller="availability" data-availability-url="<%= item_url(document.alma_availability_mms_ids.first, doc_id: document.id, redirect_to: request.url) %>">
       <div class="controls">
         <button data-action="availability#item" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" class="btn btn-sm btn-default availability-toggle-details" data-toggle="collapse" data-target="#physical-document-<%=  document.id %>, availability.button" id="available_button-<%=  document.id %>">
           <span role="spin" aria-expanded="false">Loading...</span>

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -18,7 +18,7 @@
   <%= render_online_availability(doc_presenter) %>
 
   <% if document.fetch("availability_facet", []).include?("At the Library") %>
-    <div class="physical-holding-panel panel-body" data-controller="show" data-show-url="<%= item_url(document.alma_availability_mms_ids.first, redirect_to: request.url) %>">
+    <div class="physical-holding-panel panel-body" data-controller="show" data-show-url="<%= item_url(document.alma_availability_mms_ids.first, doc_id: document.id, redirect_to: request.url) %>">
       <div class="panel-content" >
         <div id="avail-spinner" data-target="show.spinner" class="spinner">
           <span class="glyphicon glyphicon-refresh spinning" role="spinbutton"></span>


### PR DESCRIPTION
The mms_id and the doc_id are not interchangeable for bound-with items.
Thus, when fetching a bound-with item using mms_id, solr will return nil
causing havoc.  This commit fixes the issue by passing doc_id along to
the controller as well as rescuing from error with a dummy Solr document
if all else fails.