### PR TITLE
BL-699 Request modal should default to being open  (#785)

### DIFF
--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module AlmawsHelper
+  include Blacklight::CatalogHelperBehavior
+
+  def booking_allowed_partial(request_options)
+    if request_options.booking_allowed?
+      render partial: "booking_allowed", locals: { request_options: request_options }
+    end
+  end
+
+  def only_one_option_allowed(request_options)
+    [ request_options.hold_allowed?,
+     request_options.digitization_allowed?,
+     request_options.booking_allowed? ]
+    .select(&:itself).count == 1
+  end
+end

--- a/app/views/almaws/_booking_allowed.html.erb
+++ b/app/views/almaws/_booking_allowed.html.erb
@@ -1,0 +1,14 @@
+<div class="panel panel-default request-heading">
+  <div class="panel-heading">
+    <h4 class="panel-title">
+        <a class="booking-request accordian-toggle"  data-toggle="collapse" data-parent="#request-accordian-<%=  @mms_id %>" href="#collapseThree-<%= @mms_id %>">Request booking</a>
+    </h4>
+  </div>
+
+  <div id="collapseThree-<%= @mms_id %>" class="panel-collapse collapse <%= 'in' if only_one_option_allowed(request_options)%>">
+    <div class="panel-body">
+      <h5 class="request-header">Details of title you requested:</h5>
+      <%= render "booking_request_form" %>
+    </div>
+  </div>
+</div>

--- a/app/views/almaws/_digitization_allowed.html.erb
+++ b/app/views/almaws/_digitization_allowed.html.erb
@@ -1,0 +1,14 @@
+<div class="panel panel-default request-heading">
+  <div class="panel-heading">
+    <h4 class="panel-title">
+        <a class="digital-request accordian-toggle"  data-toggle="collapse" data-parent="#request-accordian-<%=  @mms_id %>" href="#collapseTwo-<%= @mms_id %>">Scan an article/book chapter</a>
+    </h4>
+  </div>
+
+  <div id="collapseTwo-<%= @mms_id %>" class="panel-collapse collapse <%= 'in' if only_one_option_allowed(request_options)%>">
+    <div class="panel-body">
+      <h5 class="request-header">Details of title you requested:</h5>
+      <%= render "digitization_request_form" %>
+    </div>
+  </div>
+</div>

--- a/app/views/almaws/_hold_allowed.html.erb
+++ b/app/views/almaws/_hold_allowed.html.erb
@@ -1,0 +1,14 @@
+<div class="panel panel-default request-heading">
+  <div class="panel-heading">
+    <h4 class="panel-title">
+        <a class="hold-request accordian-toggle" data-toggle="collapse" data-parent="#request-accordian-<%=  @mms_id %>" href="#collapseOne-<%= @mms_id %>">Request item</a>
+    </h4>
+  </div>
+
+  <div id="collapseOne-<%= @mms_id %>" class="panel-collapse collapse <%= 'in' if only_one_option_allowed(request_options)%>">
+    <div class="panel-body">
+        <h5 class="request-header">Details of title you requested:</h5>
+        <%= render "hold_request_form" %>
+    </div>
+  </div>
+</div>

--- a/spec/helpers/almaws_helper_spec.rb
+++ b/spec/helpers/almaws_helper_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AlmawsHelper, type: :helper do
+
+  describe "#only_one_option_allowed(request_options)" do
+    context "only a hold is allowed" do
+      let(:json) {
+        { request_option:
+          [{
+          "type" => { "value" => "HOLD", "desc" => "Hold" },
+          "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+          }]
+        }.to_json
+      }
+      let(:response) { OpenStruct.new(body: json) }
+      let(:request_options) { Alma::RequestOptions.new(response) }
+
+      it "is true" do
+        expect(helper.only_one_option_allowed(request_options)).to be true
+      end
+    end
+
+    context "only a booking is allowed" do
+      let(:json) {
+        { request_option:
+          [{
+          "type" => { "value" => "BOOKING", "desc" => "Booking" },
+          "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+          }]
+        }.to_json
+      }
+      let(:response) { OpenStruct.new(body: json) }
+      let(:request_options) { Alma::RequestOptions.new(response) }
+
+      it "is true" do
+        expect(helper.only_one_option_allowed(request_options)).to be true
+      end
+    end
+
+    context "both a hold and a booking are allowed" do
+      let(:json) {
+        {
+          "request_option": [
+        {
+            "type": {
+                "value": "HOLD",
+                "desc": "Hold"
+            },
+            "request_url": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/users/915602377/requests/"
+        },
+        {
+            "type": {
+                "value": "BOOKING",
+                "desc": "Booking"
+            },
+            "request_url": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/users/915602377/requests/"
+        },
+        {
+            "type": {
+                "value": "PURCHASE",
+                "desc": "Purchase"
+            }
+        }
+          ]
+      }.to_json
+      }
+
+      let(:response) { OpenStruct.new(body: json) }
+      let(:request_options) { Alma::RequestOptions.new(response) }
+
+      it "is false" do
+        expect(helper.only_one_option_allowed(request_options)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
* BL-699 Request modal should default to being open when only hold requests are allowed

* Refactor method to default to open when there is only one request option available

* Refactored method and added another test