### PR TITLE
Fix deploy fails on rake error.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,4 +16,4 @@ else
   task default: :ci
 end
 
-require "solr_wrapper/rake_task"
+require "solr_wrapper/rake_task" unless Rails.env.production?


### PR DESCRIPTION
Fixes `stderr": "rake aborted!\nLoadError: cannot load such file` error
on deployments.