### PR TITLE
[devops] Fix rake docker:up fails

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,6 @@ else
 
   Rake::Task[:default].clear
   task default: :ci
-end
 
-require "solr_wrapper/rake_task" unless Rails.env.production?
+  require "solr_wrapper/rake_task" unless Rails.env.production?
+end


### PR DESCRIPTION
docker:up rake task does not have access to Rails because rails is not
running at the point it's invoked.