### PR TITLE
[DevOps] Refactors the include_items rspec matcher.

### DIFF
--- a/spec/relevance/include_items_spec.rb
+++ b/spec/relevance/include_items_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "include_items().within_the_first().before()" do
+  context "with include_items only" do
+    it "checks for included items" do
+      expect(["a", "b", "c", "d", "e"]).to include_items(["c", "b"])
+    end
+
+    it "fails for excluded items" do
+      expect(["a", "b", "c", "d", "e"]).not_to include_items(["f", "b"])
+    end
+  end
+
+  context "with include_items and within_the_first" do
+    it "checks included items are within index" do
+      expect(["a", "b", "c", "d", "e"]).to include_items(["c", "b"])
+        .within_the_first(3)
+    end
+
+    it "fails when not within index" do
+      expect(["a", "b", "c", "d", "e"]).not_to include_items(["c", "b"])
+        .within_the_first(2)
+    end
+  end
+
+  context "with include_items and before" do
+    it "works with positive assertions" do
+      expect(["a", "b", "c", "d", "e"]).to include_items(["c", "b"])
+        .before(["e", "d"])
+    end
+
+    it "works with negative assertions" do
+      expect(["c", "b", "a", "d", "e"]).not_to include_items(["f", "d"])
+        .before(["c", "b"])
+    end
+  end
+
+  context "with include_items, within_the_first and before" do
+    it "passes when all are true" do
+      expect(["a", "b", "c", "d", "e"]).to include_items(["c", "b"])
+        .within_the_first(3)
+        .before(["e", "d"])
+    end
+
+    it "fails when any is false" do
+      expect(["a", "b", "c", "d", "e"]).not_to include_items(["f", "b"])
+        .within_the_first(3)
+        .before(["e", "d"])
+
+      expect(["a", "b", "c", "d", "e"]).not_to include_items(["f", "b"])
+        .within_the_first(2)
+        .before(["e", "d"])
+
+      expect(["a", "b", "c", "d", "e"]).not_to include_items(["f", "b"])
+        .within_the_first(2)
+        .before(["f", "d"])
+    end
+  end
+end

--- a/spec/relevance/keyword_spec.rb
+++ b/spec/relevance/keyword_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
 
   let(:response) { JSON.parse(get(:index, params: { q: search_term, per_page: 100 }, format: "json").body) }
 
+  let(:ids) { (response.dig("response", "docs") || {}).map { |doc| doc.fetch("id") }.compact }
   describe "a search for" do
-
 
 
     context "epistemic injustice" do
       let(:search_term) { "epistemic injustice" }
 
       it "has expected results before a less relevant result" do
-        expect(response)
-          .to include_docs(%w[991024847639703811 991024847639703811 991033452769703811])
+        expect(ids)
+          .to include_items(%w[991024847639703811 991024847639703811 991033452769703811])
           .before(["991036813237303811"])
       end
     end
@@ -25,8 +25,8 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
       let(:search_term) { "Cabinet of Caligari" }
       xit "has expected results before a less relevant result" do
         pending("results with just term Caligari not in title do not boost enough")
-        expect(response)
-          .to include_docs(%w[991020778949703811 991001777289703811 991027229969703811 991001812089703811 991036804904003811])
+        expect(ids)
+          .to include_items(%w[991020778949703811 991001777289703811 991027229969703811 991001812089703811 991036804904003811])
           .before(["991029142769703811"])
       end
     end
@@ -35,8 +35,8 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
       let(:search_term) { "Clarice Lispector" }
 
       it "returns items about the author before books by the author" do
-        expect(response)
-          .to include_docs(%w[991036730479303811 991033955589703811 991036853181403811])
+        expect(ids)
+          .to include_items(%w[991036730479303811 991033955589703811 991036853181403811])
           .within_the_first(11)
       end
     end
@@ -45,8 +45,8 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
       let(:search_term) { "Basquiat" }
 
       it "returns relevant documents about Basquiat" do
-        expect(response)
-          .to include_docs(%w[991032082719703811 991013618249703811 991004084189703811 991002158879703811 991009887669703811])
+        expect(ids)
+          .to include_items(%w[991032082719703811 991013618249703811 991004084189703811 991002158879703811 991009887669703811])
           .within_the_first(10)
       end
     end
@@ -55,16 +55,16 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
     context "crypto-jews" do
       let(:search_term) { "crypto-jews" }
       it "with hyphen has results about crypto-Jews and crypto-judaism above results about cryptography" do
-        expect(response)
-          .to include_docs(
+        expect(ids)
+          .to include_items(
             %w[991036813411403811 991036730245703811 991036421349703811 991032963459703811
               991025064439703811 991033710779703811 991036732155603811])
       end
 
       let(:search_term) { "crypto jews" }
       it "without hyphen has results about crypto-Jews and crypto-judaism above results about cryptography" do
-        expect(response)
-          .to include_docs(
+        expect(ids)
+          .to include_items(
             %w[991036813411403811 991036730245703811 991036421349703811 991032963459703811
               991025064439703811 991033710779703811 991036732155603811])
       end
@@ -75,8 +75,8 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
 
       xit "returns more recent results before older results" do
         pending("Journal Pub Dates are the start of the run, which penalizes many journals")
-        expect(response)
-          .to include_docs(
+        expect(ids)
+          .to include_items(
             %w[991036719384303811 991036792223603811 991036798582803811 991036700239703811])
           .within_the_first(20)
       end
@@ -85,8 +85,8 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
     context "Denmark Vesey" do
       let(:search_term) { "Denmark Vesey" }
       it "returns a mix of primary and secondary sources" do
-        expect(response)
-          .to include_docs(
+        expect(ids)
+          .to include_items(
             %w[991006931909703811 991029916219703811 991024765709703811 991003742459703811]
           )
           .within_the_first(15)
@@ -96,8 +96,8 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
     context "Contingent labor" do
       let(:search_term) { "Contingent labor" }
       it "returns recent results as more relevant" do
-        expect(response)
-          .to include_docs(
+        expect(ids)
+          .to include_items(
             %w[991002132979703811 991024521489703811 991026169729703811]
             # 991030027489703811 removed as metadata does not match
           )
@@ -108,8 +108,8 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
     context "Audio signal processing" do
       let(:search_term) { "Audio signal processing" }
       it "returns relevant results" do
-        expect(response)
-          .to include_docs(%w[991011656609703811 991036792442803811 991036798461503811])
+        expect(ids)
+          .to include_items(%w[991011656609703811 991036792442803811 991036798461503811])
           .within_the_first(15)
       end
     end
@@ -117,8 +117,8 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
     context "political polarization" do
       let(:search_term) { "political polarization" }
       it "returns relevant results" do
-        expect(response)
-          .to include_docs(
+        expect(ids)
+          .to include_items(
             %w[991009537899703811 991020291669703811 991010670569703811 991020302469703811]
             )
           .within_the_first(10)
@@ -128,16 +128,16 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
     context "musical searching" do
       let(:search_term) { "c# min" }
       it "returns results about c sharp minor" do
-        expect(response)
-            .to include_docs(
+        expect(ids)
+            .to include_items(
               %w[991001795629703811 991001879639703811 991022362639703811]
               )
             .within_the_first(10)
       end
       let(:search_term) { "c sharp min" }
       it "returns results about c sharp minor" do
-        expect(response)
-          .to include_docs(
+        expect(ids)
+          .to include_items(
             %w[991001795629703811 991001879639703811 991022362639703811]
             )
           .within_the_first(10)

--- a/spec/relevance/query_results_spec.rb
+++ b/spec/relevance/query_results_spec.rb
@@ -15,24 +15,26 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
 
   let(:results) { JSON.parse(response.body) }
 
+  let(:ids) { (results.dig("response", "docs") || {}).map { |doc| doc.fetch("id") }.compact }
+
   describe "Query results as JSON" do
     context "search for title 'peer interaction and second language learning'" do
       let(:search_terms)  { { title: "peer interaction and second language learning" } }
-      let(:primary_results) { [
+      let(:primary_ids) { [
         "991001254809703811",
         "991022272009703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search for title 'hillbilly elegy'" do
       let(:search_terms) { { title: "hillbilly elegy" } }
-      let(:primary_results) { [ "991024587289703811" ] }
+      let(:primary_ids) { [ "991024587289703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
@@ -41,14 +43,14 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
         { title: "Temple university",
           subtitle: "125 years of service to philadelphia" } }
 
-      let(:primary_results) {
+      let(:primary_ids) {
         [ "991036742233003811",
           "991017814679703811",
           "991001513649703811",
           "991002431869703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
@@ -57,177 +59,177 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
         { title: "our children's future",
           subtitle: "child care policy in canada" } }
 
-      let(:primary_results) {
+      let(:primary_ids) {
         [ "991036816752403811",
           "991024784309703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search 'new england journal of medicine'" do
       let(:search_terms) { { title: "new england journal of medicine" } }
-      let(:primary_results) {
+      let(:primary_ids) {
         [ "991036753565903811",
           "991026206569703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search 'foot and ankle international'" do
       let(:search_terms) { { title: "foot and ankle international" } }
-      let(:primary_results) {
+      let(:primary_ids) {
         [ "991036791313203811",
           "991011580459703811"] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search 'chronicle of higher education'" do
       let(:search_terms) { { title: "chronicle of higher education" } }
-      let(:primary_results) {
+      let(:primary_ids) {
         [ "991036721510203811",
           "991012152319703811",
           "991017377949703811",
           "991006975379703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search 'housing association of delaware valley records'" do
       let(:search_terms) { { title: "housing association of delaware valley records" } }
-      let(:primary_results) { [ "991003108369703811" ] }
+      let(:primary_ids) { [ "991003108369703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search 'lawrence gitman'" do
       let(:search_terms) { { author: "lawrence gitman" } }
-      let(:primary_results) { [ "991008448689703811" ] }
+      let(:primary_ids) { [ "991008448689703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search 'miles livy'" do
       let(:search_terms) { { keywords: "miles livy" } }
-      let(:primary_results) { [ "991034319589703811" ] }
+      let(:primary_ids) { [ "991034319589703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search 'moter learning magill'" do
       let(:search_terms) { { keywords: "motor learning magill" } }
-      let(:primary_results) {
+      let(:primary_ids) {
         [ "991009723459703811",
           "991022257719703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search 'Mahlon Howard Hellerich dissertation'" do
       let(:search_terms) { { keywords: "Mahlon Howard Hellerich dissertation" } }
-      let(:primary_results) { [ "991034105309703811" ] }
+      let(:primary_ids) { [ "991034105309703811" ] }
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search '00095982'" do
       let(:search_terms) { { ISSN: "00095982" } }
-      let(:primary_results) {
+      let(:primary_ids) {
         [ "991036721510203811",
           "991012152319703811",
           "991017377949703811",
           "991006975379703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search '9780140449198'" do
       let(:search_terms) { { ISBN: "9780140449198" } }
-      let(:primary_results) { [ "991006700799703811" ] }
+      let(:primary_ids) { [ "991006700799703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search '0140449191'" do
       let(:search_terms) { { ISBN: "0140449191" } }
-      let(:primary_results) { [ "991006700799703811" ] }
+      let(:primary_ids) { [ "991006700799703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search '991036743832103811'" do
       let(:search_terms) { { doc_id: "991036743832103811" } }
-      let(:primary_results) { [ "991036743832103811" ] }
+      let(:primary_ids) { [ "991036743832103811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search '991035120939703811'" do
       let(:search_terms) { {  callnum: '"PN1997.2 .S462x 2003"' } }
-      let(:primary_results) { [ "991035120939703811" ] }
+      let(:primary_ids) { [ "991035120939703811" ] }
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search 'bicycle thieves'" do
       let(:search_terms) { { title: "bicycle thieves" } }
-      let(:primary_results) {
+      let(:primary_ids) {
         [ "991024736809703811",
           "991035018259703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search 'journal of materials chemistry'" do
       let(:search_terms) { { title: "journal of materials chemistry" } }
-      let(:primary_results) { [ "991036749632703811" ] }
-      let(:secondary_reults) {
+      let(:primary_ids) { [ "991036749632703811" ] }
+      let(:secondary_ids) {
         [ "991036749633503811",
           "991036749630403811",
           "991036749630103811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
-          .before(secondary_reults)
+        expect(ids).to include_items(primary_ids)
+          .before(secondary_ids)
       end
     end
 
     context "search 'new york times'" do
       let(:search_terms) { { title: "new york times" } }
-      let(:primary_results) {
+      let(:primary_ids) {
         [ "991036797063703811",
           "991026245969703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
@@ -235,46 +237,58 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
       let(:search_terms) {
         { title: "gray's anatomy",
           subtitle: "the anatomical basis of clinical practice" } }
-      let(:primary_results) {
+      let(:primary_ids) {
         [ "991007333849703811",
           "991003194609703811",
           "991028264669703811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
+        expect(ids).to include_items(primary_ids)
       end
     end
 
     context "search 'Handbook on injectable drugs'" do
       let(:search_terms) { { title: "Handbook on injectable drugs" } }
-      let(:primary_results) { [ "991000868839703811" ] }
-      let(:secondary_reults) {
+      let(:primary_ids) { [ "991000868839703811" ] }
+      let(:secondary_ids) {
         [ "991033401389703811",
           "991011446329703811",
           "991036802592903811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
-          .before(secondary_reults)
+        expect(ids).to include_items(primary_ids)
+          .before(secondary_ids)
       end
     end
 
     context "search 'the epic of gilgamesh'" do
       let(:search_terms) { { title: "the epic of gilgamesh" } }
-      let(:primary_results) {
+      let(:primary_ids) {
         [ "991006700799703811",
           "991017636819703811",
           "991006996069703811",
           "991013242359703811",
           "991029586949703811" ] }
-      let(:secondary_reults) {
+      let(:secondary_ids) {
         [ "991036749005103811",
           "991036742769003811" ] }
 
       it "returns expected values" do
-        expect(results).to include_docs(primary_results)
-          .before(secondary_reults)
+        expect(ids).to include_items(primary_ids)
+          .before(secondary_ids)
       end
     end
+  end
+end
+
+RSpec.describe "include_items().within_index().before()" do
+  it "works with positive assertions" do
+    expect(["a", "b", "c", "d", "e"]).to include_items(["c", "b"])
+      .before(["e", "d"])
+  end
+
+  it "works with negative assertions" do
+    expect(["c", "b", "a", "d", "e"]).not_to include_items(["f", "d"])
+      .before(["c", "b"])
   end
 end

--- a/spec/relevance/tul_specific_spec.rb
+++ b/spec/relevance/tul_specific_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe CatalogController, type: :controller, relevance: true do
   describe "a faceted search for Presser Listening Library " do
     let(:response) { JSON.parse(get(:index, params: { "f" => { "library_facet" => ["Presser Listening Library"] }, per_page: 100 }, format: "json").body) }
 
+    let(:ids) { (response.dig("response", "docs") || {}).map { |doc| doc.fetch("id") }.compact }
 
     it "has results with another library before before results only at presser" do
-      expect(response)
-        .to include_docs(%w[991025170559703811 991012972279703811 991036165169703811])
+      expect(ids)
+        .to include_items(%w[991025170559703811 991012972279703811 991036165169703811])
         .before(["991034751269703811"])
     end
   end


### PR DESCRIPTION
Refactoring include_items because

* Tests are passing even when a secondary item is not present
(i.e. .before(secondary_items)).

* Benchmarking shows that the declarative approach is not inefficient
even in the most drastic possibility of 100,000 calculations.

```
items = (1..100).to_a

Benchmark.bm do |x|
  x.report("benchmark 100 x 100 index checks") {
    items.all? { |front_item|
      items.all? { |back_item|
        items.index(front_item) + items.index(back_item)
      }
    }
  }
end

```

 ## results:

```
user     system      total        real
benchmark 100 x 100 index checks  0.010000   0.000000   0.010000
(  0.005298)

```