### PR TITLE
BL-688 UX header changes

### DIFF
--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -163,6 +163,12 @@ a.advanced_search {
 	display: inline-block;
 	font-weight: bold;
 	letter-spacing: 1px;
+	margin-left: 0;
+}
+
+.basic-search-form {
+	height: 25px;
+	margin-right: 0;
 }
 
 .navbar {
@@ -244,7 +250,6 @@ nav ul.navbar li.nav-btn.active a {
 .navbar-form {
 	display: inline-block;
 	height: 25px;
-	margin-left: -40px;
 	vertical-align: middle;
 }
 

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,6 +1,6 @@
-<%= form_tag search_url_picker, method: :get, class: 'search-query-form clearfix navbar-form', role: 'search', id: "catalog-search" do %>
+<%= form_tag search_url_picker, method: :get, class: 'search-query-form clearfix', role: 'search', id: "catalog-search" do %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
-  <div class="input-group">
+  <div class="input-group basic-search-form">
     <% if search_fields.length > 1 %>
       <span class="input-group-addon for-search-field">
         <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>


### PR DESCRIPTION
- Advanced link was going behind the search input group when screen size was smaller.  This updates the css styles to get rid of that issue.