### PR TITLE
BL-737 Update Google analytics actions for navigational updates

### DIFF
--- a/app/assets/javascripts/listeners.js
+++ b/app/assets/javascripts/listeners.js
@@ -4,7 +4,7 @@ $(document).ready(function(){
 		{id: "header-logo", category: "navigation"},
 		{id: "login", category: "navigation"},
 		{id: "logout", category: "navigation"},
-		{id: "bookmarks", category: "navigation"},
+		{id: "bookmarks_nav", category: "navigation"},
 		{id: "articles-header", category: "navigation"},
 		{id: "articles-button", category: "navigation"},
 		{id: "catalog-header", category: "navigation"},
@@ -19,7 +19,7 @@ $(document).ready(function(){
 		{id: "advanced_search", category: "search-results"},
 		{id: "basic_search", category: "search-results"},
 		{id: "online_button", category: "search-results"},
-		{id: "bookmarks", category: "search-results"},
+		{id: "bookmark_button", category: "search-results"},
 		{id: "direct_link_online", category: "search-results"},
 		{id: "single_link_online", category: "search-results"},
 		{id: "many_links_online", category: "search-results"},
@@ -35,6 +35,17 @@ $(document).ready(function(){
 		{id: "signin_for_request_options", category: "search-results"},
 		{id: "request", category: "search-results"},
 		{id: "available_button", category: "search-results"}
+		{id: "navbar_everything", category: "navigation"}
+		{id: "navbar_books", category: "navigation"}
+		{id: "navbar_articles", category: "navigation"}
+		{id: "navbar_journals", category: "navigation"}
+		{id: "navbar_more", category: "navigation"}
+		{id: "breadcrumbs_book", category: "navigation"}
+		{id: "breadcrumbs_record", category: "navigation"}
+		{id: "breadcrumbs_article", category: "navigation"}
+		{id: "breadcrumbs_journal", category: "navigation"}
+		{id: "request_options", category: "search-results"}
+		{id: "request-btn-0", category: "search-results"}
 	];
 
   function handleEventClicks(event) {

--- a/app/controllers/books_advanced_controller.rb
+++ b/app/controllers/books_advanced_controller.rb
@@ -3,7 +3,7 @@
 class BooksAdvancedController < AdvancedController
   copy_blacklight_config_from(BooksController)
 
-  add_breadcrumb "Books", :back_to_books_path, options: { id: "breadcrumbs_book" } 
+  add_breadcrumb "Books", :back_to_books_path, options: { id: "breadcrumbs_book" }
   add_breadcrumb I18n.t(:books_advanced_search), :books_advanced_search_path,
     only: [ :index ]
 

--- a/app/controllers/books_advanced_controller.rb
+++ b/app/controllers/books_advanced_controller.rb
@@ -3,7 +3,7 @@
 class BooksAdvancedController < AdvancedController
   copy_blacklight_config_from(BooksController)
 
-  add_breadcrumb "Books", :back_to_books_path, { options: { id: "breadcrumbs_book" } }
+  add_breadcrumb "Books", :back_to_books_path, options: { id: "breadcrumbs_book" } 
   add_breadcrumb I18n.t(:books_advanced_search), :books_advanced_search_path,
     only: [ :index ]
 

--- a/app/controllers/books_advanced_controller.rb
+++ b/app/controllers/books_advanced_controller.rb
@@ -3,7 +3,7 @@
 class BooksAdvancedController < AdvancedController
   copy_blacklight_config_from(BooksController)
 
-  add_breadcrumb "Books", :back_to_books_path
+  add_breadcrumb "Books", :back_to_books_path, { options: { id: "breadcrumbs_book" } }
   add_breadcrumb I18n.t(:books_advanced_search), :books_advanced_search_path,
     only: [ :index ]
 

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BooksController < CatalogController
-  add_breadcrumb "Books", :back_to_books_path, options: { id: "breadcrumbs_book" }, only: [ :show ] }
+  add_breadcrumb "Books", :back_to_books_path, options: { id: "breadcrumbs_book" }, only: [ :show ] 
   add_breadcrumb "Record", :solr_book_document_path, only: [ :show ]
 
   configure_blacklight do |config|

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BooksController < CatalogController
-  add_breadcrumb "Books", :back_to_books_path, options: { id: "breadcrumbs_book" }, only: [ :show ] 
+  add_breadcrumb "Books", :back_to_books_path, options: { id: "breadcrumbs_book" }, only: [ :show ] }
   add_breadcrumb "Record", :solr_book_document_path, only: [ :show ]
 
   configure_blacklight do |config|

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BooksController < CatalogController
-  add_breadcrumb "Books", :back_to_books_path, options: { id: "breadcrumbs_book" }, only: [ :show ] 
+  add_breadcrumb "Books", :back_to_books_path, options: { id: "breadcrumbs_book" }, only: [ :show ]
   add_breadcrumb "Record", :solr_book_document_path, only: [ :show ]
 
   configure_blacklight do |config|

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BooksController < CatalogController
-  add_breadcrumb "Books", :back_to_books_path, only: [ :show ]
+  add_breadcrumb "Books", :back_to_books_path, { options: { id: "breadcrumbs_book" }, only: [ :show ] }
   add_breadcrumb "Record", :solr_book_document_path, only: [ :show ]
 
   configure_blacklight do |config|

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BooksController < CatalogController
-  add_breadcrumb "Books", :back_to_books_path, { options: { id: "breadcrumbs_book" }, only: [ :show ] }
+  add_breadcrumb "Books", :back_to_books_path, options: { id: "breadcrumbs_book" }, only: [ :show ] 
   add_breadcrumb "Record", :solr_book_document_path, only: [ :show ]
 
   configure_blacklight do |config|

--- a/app/controllers/journals_advanced_controller.rb
+++ b/app/controllers/journals_advanced_controller.rb
@@ -3,7 +3,7 @@
 class JournalsAdvancedController < AdvancedController
   copy_blacklight_config_from(JournalsController)
 
-  add_breadcrumb "Journals", :back_to_journals_path
+  add_breadcrumb "Journals", :back_to_journals_path, { options: { id: "breadcrumbs_journal" }, only: [ :show ] }
   add_breadcrumb I18n.t(:journals_advanced_search), :journals_advanced_search_path,
     only: [ :index ]
 

--- a/app/controllers/journals_advanced_controller.rb
+++ b/app/controllers/journals_advanced_controller.rb
@@ -3,7 +3,7 @@
 class JournalsAdvancedController < AdvancedController
   copy_blacklight_config_from(JournalsController)
 
-  add_breadcrumb "Journals", :back_to_journals_path, { options: { id: "breadcrumbs_journal" }, only: [ :show ] }
+  add_breadcrumb "Journals", :back_to_journals_path, options: { id: "breadcrumbs_journal" }
   add_breadcrumb I18n.t(:journals_advanced_search), :journals_advanced_search_path,
     only: [ :index ]
 

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -3,7 +3,7 @@
 require "twilio-ruby"
 
 class JournalsController < CatalogController
-  add_breadcrumb "Journals", :back_to_journals_path, only: [ :show ]
+  add_breadcrumb "Journals", :back_to_journals_path, { options: { id: "breadcrumbs_journal" }, only: [ :show ] }
   add_breadcrumb "Record", :solr_journal_document_path, only: [ :show ]
 
   configure_blacklight do |config|

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -3,7 +3,7 @@
 require "twilio-ruby"
 
 class JournalsController < CatalogController
-  add_breadcrumb "Journals", :back_to_journals_path, options: { id: "breadcrumbs_journal" }, only: [ :show ] 
+  add_breadcrumb "Journals", :back_to_journals_path, options: { id: "breadcrumbs_journal" }, only: [ :show ]
   add_breadcrumb "Record", :solr_journal_document_path, only: [ :show ]
 
   configure_blacklight do |config|

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -3,7 +3,7 @@
 require "twilio-ruby"
 
 class JournalsController < CatalogController
-  add_breadcrumb "Journals", :back_to_journals_path, { options: { id: "breadcrumbs_journal" }, only: [ :show ] }
+  add_breadcrumb "Journals", :back_to_journals_path, options: { id: "breadcrumbs_journal" }, only: [ :show ] 
   add_breadcrumb "Record", :solr_journal_document_path, only: [ :show ]
 
   configure_blacklight do |config|

--- a/app/controllers/primo_advanced_controller.rb
+++ b/app/controllers/primo_advanced_controller.rb
@@ -3,7 +3,7 @@
 class PrimoAdvancedController < PrimoCentralController
   copy_blacklight_config_from(PrimoCentralController)
 
-  add_breadcrumb "Articles", :back_to_articles_path
+  add_breadcrumb "Articles", :back_to_articles_path, { options: { id: "breadcrumbs_article" }, only: [ :show ] }
   add_breadcrumb I18n.t(:articles_advanced_search), :articles_advanced_search_path,
     only: [ :index ]
 end

--- a/app/controllers/primo_advanced_controller.rb
+++ b/app/controllers/primo_advanced_controller.rb
@@ -3,7 +3,7 @@
 class PrimoAdvancedController < PrimoCentralController
   copy_blacklight_config_from(PrimoCentralController)
 
-  add_breadcrumb "Articles", :back_to_articles_path, { options: { id: "breadcrumbs_article" }, only: [ :show ] }
+  add_breadcrumb "Articles", :back_to_articles_path, options: { id: "breadcrumbs_article" }
   add_breadcrumb I18n.t(:articles_advanced_search), :articles_advanced_search_path,
     only: [ :index ]
 end

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -5,7 +5,7 @@ class PrimoCentralController < CatalogController
   include CatalogConfigReinit
   include Blacklight::Document::Export
 
-  add_breadcrumb "Articles", :back_to_articles_path, only: [ :show ]
+  add_breadcrumb "Articles", :back_to_articles_path, { options: { id: "breadcrumbs_article" }, only: [ :show ] }
   add_breadcrumb "Record", :primo_central_document_path, only: [ :show ]
 
   helper_method :browse_creator

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -5,7 +5,7 @@ class PrimoCentralController < CatalogController
   include CatalogConfigReinit
   include Blacklight::Document::Export
 
-  add_breadcrumb "Articles", :back_to_articles_path, options: { id: "breadcrumbs_article" }, only: [ :show ] 
+  add_breadcrumb "Articles", :back_to_articles_path, options: { id: "breadcrumbs_article" }, only: [ :show ]
   add_breadcrumb "Record", :primo_central_document_path, only: [ :show ]
 
   helper_method :browse_creator

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -5,7 +5,7 @@ class PrimoCentralController < CatalogController
   include CatalogConfigReinit
   include Blacklight::Document::Export
 
-  add_breadcrumb "Articles", :back_to_articles_path, { options: { id: "breadcrumbs_article" }, only: [ :show ] }
+  add_breadcrumb "Articles", :back_to_articles_path, options: { id: "breadcrumbs_article" }, only: [ :show ] 
   add_breadcrumb "Record", :primo_central_document_path, only: [ :show ]
 
   helper_method :browse_creator

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -206,7 +206,7 @@ module ApplicationHelper
     end
   end
 
-  def render_nav_link(path, name, analytics_id = "")
+  def render_nav_link(path, name, analytics_id = nil)
     active = is_active?(path) ? [ "active" ] : []
     button_class = ([ "nav-btn header-links" ] + active).join(" ")
     link_class = ([ "nav-link" ] + active).join(" ")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -206,13 +206,13 @@ module ApplicationHelper
     end
   end
 
-  def render_nav_link(path, name)
+  def render_nav_link(path, name, analytics_id)
     active = is_active?(path) ? [ "active" ] : []
     button_class = ([ "nav-btn header-links" ] + active).join(" ")
     link_class = ([ "nav-link" ] + active).join(" ")
 
     content_tag :li, class: button_class do
-      link_to(name, send(path, search_params), class: link_class)
+      link_to(name, send(path, search_params), class: link_class, id: analytics_id)
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -206,7 +206,7 @@ module ApplicationHelper
     end
   end
 
-  def render_nav_link(path, name, analytics_id=nil)
+  def render_nav_link(path, name, analytics_id = "")
     active = is_active?(path) ? [ "active" ] : []
     button_class = ([ "nav-btn header-links" ] + active).join(" ")
     link_class = ([ "nav-link" ] + active).join(" ")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -206,7 +206,7 @@ module ApplicationHelper
     end
   end
 
-  def render_nav_link(path, name, analytics_id)
+  def render_nav_link(path, name, analytics_id=nil)
     active = is_active?(path) ? [ "active" ] : []
     button_class = ([ "nav-btn header-links" ] + active).join(" ")
     link_class = ([ "nav-link" ] + active).join(" ")

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -3,11 +3,11 @@
     <div class="col-sm-12">
       <nav clas="navbar-nav">
         <ul class="navbar nav-header-links">
-          <%= render_nav_link(:everything_path, "Everything") %>
-          <%= render_nav_link(:search_books_path, "Books") %>
-          <%= render_nav_link(:search_path, "Articles") %>
-          <%= render_nav_link(:search_journals_path, "Journals") %>
-          <%= render_nav_link(:search_catalog_path, "More") %>
+          <%= render_nav_link(:everything_path, "Everything", "navbar_everything") %>
+          <%= render_nav_link(:search_books_path, "Books", "navbar_books") %>
+          <%= render_nav_link(:search_path, "Articles", "navbar_articles") %>
+          <%= render_nav_link(:search_journals_path, "Journals", "navbar_journals") %>
+          <%= render_nav_link(:search_catalog_path, "More", "navbar_more") %>
         </ul>
       </nav>
     </div>

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -9,7 +9,7 @@
         <% if user_signed_in? %>
           <%= request_modal(document.id, document_counter="0", @pickup_locations, @request_level) %>
         <% else %>
-          <%= link_to(t("requests.log_in"), new_user_session_with_redirect_path(request.url),  data: {"ajax-modal": "trigger"}) %>
+          <%= link_to(t("requests.log_in"), new_user_session_with_redirect_path(request.url),  data: {"ajax-modal": "trigger"}, id: "request_options") %>
         <% end %>
       </div>
     </div>

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -12,7 +12,7 @@
       <ul id="tools-navbar">
         <%= render_show_doc_actions @document do |config, inner| %>
         <% if config.key == :bookmark %>
-          <li class="<%= config.key %>">
+          <li class="<%= config.key %>" id="bookmark_button">
             <%= inner %>
           </li>
           <% if @document.citable? %>


### PR DESCRIPTION
Update GA actions (created in https://tulibdev.atlassian.net/browse/BL-551) for navigational updates from Fall 2018.

Add tracking for the following actions:

Action on menu items

Books/Articles/Journals/More headers
Books/Articles/Journals/More menu items
Actions on search results pages (ex. Clicking on links, buttons, etc.)

Make sure that Catalog Search actions still work for Books/Journals/More searches: Advanced Search links, Availability/Online buttons (don’t know if this is possible, since it can be a dropdown), Bookmark checkbox
Actions on record pages (ex. Clicking on links, buttons, etc.)

Breadcrumb links
Make sure that Catalog Search actions still work for Books/Journals/More searches: Back to Search button, Start Over button, Bookmark button, “Send To” dropdown/links, “Log in to see request options” link, Request button (only visible when logged in)

****

- Menu items replaced by Library Search link at top of pages

- Availability buttons and Bookmark checkboxes cannot be added due to their IDs being used for other purposes which require unique identifiers on each instance per page

- Added IDs to Books/Articles/Journals/More headers (modified render_nav_link method to accept id)
- Updated listeners.js for new navbar ids
- Updated breadcrumbs ids
- Added bookmarks button (trying the li wrapper as the link id is used for another purpose and too unique to be meaningful to analytics)
- Added Request Options link
- Added request button on record page to listeners.js
- Rubocop fixes