### PR TITLE
BL-749 Accessibility issues

### DIFF
--- a/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
+++ b/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
@@ -126,11 +126,11 @@ var BlacklightAlma = function (options) {
    check = checkHoldings(holdings);
 
    if (available) {
-     html = "<dt >Available at: </dt><dd>" + available + "</dd>";
+     html = "<dt class='index-label' >Available at: </dt><dd>" + available + "</dd>";
    }
 
    if (check) {
-   html += "<dt >Other Libraries: </dt><dd>" + check + "</dd>";
+   html += "<dt class='index-label' >Other Libraries: </dt><dd>" + check + "</dd>";
    }
    return html;
  };

--- a/app/assets/stylesheets/partials/_bento.scss
+++ b/app/assets/stylesheets/partials/_bento.scss
@@ -57,9 +57,8 @@
 }
 
 .bento_item_title {
-	font-size: 14px;
+	font-size: 14px !important;
 	font-weight: bold;
-	margin-left: 15px;
 	margin-bottom: 3px;
 }
 

--- a/app/assets/stylesheets/tucob.scss.erb
+++ b/app/assets/stylesheets/tucob.scss.erb
@@ -95,6 +95,10 @@ h1.advanced.page-header a {
   margin-top: 14px;
 }
 
+.index-label {
+  color: #595959 !important;
+}
+
 /* === HOME PAGES === */
 #page-wrapper {
   background-color: #F4F6F5;

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -6,8 +6,8 @@
 
     <div class="row">
       <div class="col-sm-4 hold-form">
-        <%= label("", :pickup_location, t("requests.form.pickup_locations")) %>
-        <%= select("", :pickup_location, @booking_location.collect { |lib| [ lib.last, lib.first ] }, {class: "request-form form-control"}, {include_blank: true, required: true, "aria-required": true }) %>
+        <%= label("", :booking_pickups, t("requests.form.pickup_locations")) %>
+        <%= select("", :pickup_location, @booking_location.collect { |lib| [ lib.last, lib.first ] }, {id: "booking_pickups", class: "request-form form-control"}, {include_blank: true, required: true, "aria-required": true }) %>
       </div>
     </div>
     <div class="row">
@@ -43,8 +43,8 @@
 
     <div class="row hold-form">
       <div class="col-sm-4">
-        <%= form.label(:comment, t("requests.form.notes_label")) %>
-        <%= form.text_area :comment, class: "request-form form-control" %>
+        <%= form.label(:booking_comments, t("requests.form.notes_label")) %>
+        <%= form.text_area :comment, id: "booking_comments", class: "request-form form-control" %>
       </div>
     </div>
 

--- a/app/views/almaws/_digitization_request_form.html.erb
+++ b/app/views/almaws/_digitization_request_form.html.erb
@@ -45,7 +45,7 @@
 
     <div class="form-group row">
       <div class="col-sm-5">
-        <%= form.label(:last_interest_date, t("requests.form.not_needed_after")) %>
+        <%= form.label(:digitization_date_field, t("requests.form.not_needed_after")) %>
         <%= date_field_tag :last_interest_date, "", pattern:"[0-9]{4}-[0-9]{2}-[0-9]{2}", id: "digitization_date_field" %>
         <%= render "format_date_message" %>
       </div>
@@ -53,8 +53,8 @@
 
     <div class="form-group row">
       <div class="col-sm-4">
-        <%= form.label(:comment, t("requests.form.notes_label")) %>
-        <%= form.text_area :comment, class: "request-form form-control" %>
+        <%= form.label(:digitization_comment, t("requests.form.notes_label")) %>
+        <%= form.text_area :comment, id: "digitization_comment", class: "request-form form-control" %>
       </div>
     </div>
 

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -29,8 +29,8 @@
     <% if @request_level == "item" %>
       <div class="form-group row">
         <div class="col-sm-4">
-          <%= form.label(:description, t("requests.form.description_label")) %>
-          <%= select_tag(:description, options_for_select(@description), { data: { "action": "form#select" }, class: "request-form form-control", include_blank: true, required: true, "aria-required": true } ) %>
+          <%= form.label(:item_description, t("requests.form.description_label")) %>
+          <%= select_tag(:description, options_for_select(@description), { data: { "action": "form#select" }, id: "item_description", class: "request-form form-control", include_blank: true, required: true, "aria-required": true } ) %>
         </div>
       </div>
 
@@ -45,7 +45,7 @@
 
     <div class="row hold-form">
       <div class="col-sm-5">
-        <%= form.label(:not_needed, t("requests.form.not_needed_after")) %>
+        <%= form.label(:hold_date_field, t("requests.form.not_needed_after")) %>
         <%= date_field_tag :last_interest_date, "", pattern:"[0-9]{4}-[0-9]{2}-[0-9]{2}", id: "hold_date_field" %>
         <%= render "format_date_message" %>
       </div>

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -9,7 +9,7 @@
     <table id="availability-container" class="table table-responsive border-bottom">
       <thead>
         <tr class="sr-only">
-            <th scope="col" id="location">Item Location</td>
+            <th scope="col" id="location">Item Location</th>
             <th scope="col" id="callnum">Call Number</th>
             <th scope="col" id="desc">Description</th>
             <th scope="col" id="type">Material Type</th>
@@ -21,9 +21,9 @@
         <tr class="table-heading">
           <th id="<%= key %>" class="library-name" scope="colgroup" colspan="2"><%= library_name_from_short_code(key) %></th>
           <% if @document["holdings_summary_display"] %>
-            <th class="holdings-summary" colspan="7"><%= @holdings_summary[key] %></th>
+            <td class="holdings-summary" colspan="7"><%= @holdings_summary[key] %></td>
           <% end %>
-          <th class="aeon-request" colspan="7"><%= aeon_request_button(items) %></th>
+          <td class="aeon-request" colspan="7"><%= aeon_request_button(items) %></td>
 
         </tr>
         <% items.each do |item| %>

--- a/app/views/bento_search/_item_title.html.erb
+++ b/app/views/bento_search/_item_title.html.erb
@@ -1,0 +1,42 @@
+<%#
+  # Prepare a title in an H4, with formats in parens in a <small> (for
+  # bootstrap), linked, etc.
+  #
+  # Pass in local `item` with BentoSearch::ResultItem (can use :as arg to
+  # Rails render).
+  #
+  # Optionally pass in a local "index" with result set index to display
+  # in front of title. 1. 2. etc.
+  #
+  # If index is passed in, we'll make an 'id' attribute that can be used
+  # for an attribute based on anchor. Using either a passed in 'id_prefix'
+  # or, the engine_id if present. If neither present no go (need a prefix for
+  # uniqueness when more than one bento_results on a page).
+  #
+  # If "indicate_fulltext" is set in display configuration, an "Online"
+  # marker will be output after title, in class .bento_available_online
+  #
+  # %>
+  <h3 class="bento_item_title">
+    <% if local_assigns[:index] %>
+      <% id_attr = item.html_id(local_assigns[:id_prefix], index) %>
+      <%= content_tag("span", :class => "bento_index", :id => (id_attr if id_attr)) do %>
+        <%= index %>.
+      <% end %>
+    <% end %>
+
+    <%= link_to_unless(item.link.blank?, item.complete_title, item.link) %>
+
+    <% if item.display_format.present? || item.display_language.present? %>
+
+      <small class="bento_item_about">
+        <%# sorry, no whitespace so parens are flush %>
+        (<%- if item.display_format.present? -%><span class="bento_format"><%= item.display_format -%></span><%- end -%><%- if item.display_language.present? -%><span class="bento_language"> in <%= item.display_language -%></span><%- end -%>)
+      </small>
+
+    <% end %>
+
+    <% if item.display_configuration.try{|h| h[:indicate_fulltext]} && item.link_is_fulltext? %>
+      <small class="bento_available_online">Online</small>
+    <% end %>
+  </h3>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -3,7 +3,7 @@
   <div class="book-info-srch <%= thumbnail_classes(document) %>" <%= isbn_data_attribute(document) %> >
     <%= link_to document do %>
       <%= image_tag "", :alt => "Book cover for " + document["title_statement_display"].to_s, :class => "book_cover invisible"  %>
-      <%= image_tag default_cover_image(document), :class => "default" %>
+      <%= image_tag default_cover_image(document), :class => "default", :alt => "default cover image" %>
     <% end %>
   </div>
   <div class="book_info col-sm-9 col-lg-10">

--- a/spec/features/bento_search_spec.rb
+++ b/spec/features/bento_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Bento Searches" do
         fill_in "q", with: item["title"]
         click_button
       end
-      within first("h4") do
+      within first("h3") do
         expect(page).to have_text item["title"]
       end
     end


### PR DESCRIPTION
- Change bento headings structure
- add alt tag to default image icons
- change label color on search results page
- change 2nd and 3rd table headers to td
- update form labels on request forms to associate by id to avoid duplicate labels being present between forms

REF BL-749
REF: https://github.com/jrochkind/bento_search/pull/38