### PR TITLE
BL-596 Create new genre_display field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -285,6 +285,7 @@ class CatalogController < ApplicationController
     config.add_facet_field "subject_era_facet", label: "Era", limit: true, show: true
     config.add_facet_field "subject_region_facet", label: "Region", limit: true, show: true
     config.add_facet_field "genre_facet", label: "Genre", limit: true, show: true
+    config.add_facet_field "genre_full_facet", label: "Genre", limit: true, show: false
     config.add_facet_field "language_facet", label: "Language", limit: true, show: true
 
 
@@ -361,6 +362,7 @@ class CatalogController < ApplicationController
     config.add_show_field "note_accruals_display", label: "Additions to Collection"
     config.add_show_field "note_local_display", label: "Local Note"
     config.add_show_field "subject_display", label: "Subject", helper_method: :subject_links, multi: true
+    config.add_show_field "genre_display", label: "Genre", helper_method: :genre_links, multi: true
     config.add_show_field "collection_display", label: "Collection"
     config.add_show_field "collection_area_display", label: "SCRC Collecting Area"
 
@@ -457,6 +459,13 @@ class CatalogController < ApplicationController
       field.solr_local_parameters = {
         qf: "$subject_qf",
         pf: "$subject_pf"
+      }
+    end
+
+    config.add_search_field("genre") do |field|
+      field.include_in_simple_select = false
+      field.solr_local_parameters = {
+        qf: "genre_t",
       }
     end
 

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -224,6 +224,12 @@ module CatalogHelper
     end
   end
 
+  def genre_links(args)
+    args[:document][args[:field]].map do |genre|
+      link_to(genre, "#{search_catalog_path}?f[genre_full_facet][]=#{CGI.escape genre}")
+    end
+  end
+
   def has_one_electronic_resource?(document)
     document.fetch("electronic_resource_display", []).length == 1
   end

--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -169,6 +169,10 @@ to_field "subject_topic_facet", extract_subject_topic_facet
 to_field "subject_era_facet", extract_marc("648a:650y:651y:654y:655y:690y:647y", trim_punctuation: true)
 to_field "subject_region_facet", marc_geo_facet
 to_field "genre_facet", extract_genre
+to_field "genre_display", extract_genre_display
+to_field "genre_t", extract_genre_display
+# genre_full_facet is an invisible field that is used to generate the direct links on individual record pages
+to_field "genre_full_facet", extract_genre_display
 
 to_field "subject_t", extract_marc_with_flank(%W(
   600#{ATOU}
@@ -179,7 +183,7 @@ to_field "subject_t", extract_marc_with_flank(%W(
   650abcde
   653a:654abcde
                                    ).join(":"))
-to_field "subject_addl_t", extract_marc_with_flank("600vwxyz:610vwxyz:611vwxyz:630vwxyz:647vwxyz:648avwxyz:650vwxyz:651aegvwxyz:654vwxyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvwxyz")
+to_field "subject_addl_t", extract_marc_with_flank("600vwxyz:610vwxyz:611vwxyz:630vwxyz:647vwxyz:648avwxyz:650vwxyz:651aegvwxyz:654vwxyz:656akvxyz:657avxyz:690abcdegvwxyz")
 
 # Location fields
 to_field "call_number_display", extract_marc("HLDhi")

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -105,7 +105,7 @@ module Traject
       def extract_subject_display
         lambda do |rec, acc|
           subjects = []
-          Traject::MarcExtractor.cached("600abcdefghklmnopqrstuvxyz:610abcdefghklmnoprstuvxyz:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:655abcvxyz:656akvxyz:657avxyz:690abcdegvxyz").collect_matching_lines(rec) do |field, spec, extractor|
+          Traject::MarcExtractor.cached("600abcdefghklmnopqrstuvxyz:610abcdefghklmnoprstuvxyz:611acdefghjklnpqstuvxyz:630adefghklmnoprstvxyz:648axvyz:650abcdegvxyz:651aegvxyz:653a:654abcevyz:656akvxyz:657avxyz:690abcdegvxyz").collect_matching_lines(rec) do |field, spec, extractor|
             subject = extractor.collect_subfields(field, spec).first
             unless subject.nil?
               field.subfields.each do |s_field|
@@ -117,6 +117,24 @@ module Traject
             subjects
           end
           acc.replace(subjects)
+        end
+      end
+
+      def extract_genre_display
+        lambda do |rec, acc|
+          genres = []
+          Traject::MarcExtractor.cached("655abcvxyz").collect_matching_lines(rec) do |field, spec, extractor|
+            genre = extractor.collect_subfields(field, spec).first
+            unless genre.nil?
+              field.subfields.each do |s_field|
+                genre = genre.gsub(" #{s_field.value}", "#{SEPARATOR}#{s_field.value}") if (s_field.code == "v" || s_field.code == "x" || s_field.code == "y" || s_field.code == "z")
+              end
+              genre = genre.split(SEPARATOR)
+              genres << genre.map { |s| Traject::Macros::Marc21.trim_punctuation(s) }.join(SEPARATOR)
+            end
+            genres
+          end
+          acc.replace(genres)
         end
       end
 

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -862,14 +862,6 @@ RSpec.feature "RecordPageFields" do
       end
     end
 
-    let (:item_655) { fixtures.fetch("subject_655") }
-    scenario "User visits a document with subject" do
-      visit "catalog/#{item_655['doc_id']}"
-      within "dd.blacklight-subject_display" do
-        expect(page).to have_text(item_655["subject"])
-      end
-    end
-
     let (:item_656) { fixtures.fetch("subject_656") }
     scenario "User visits a document with subject" do
       visit "catalog/#{item_656['doc_id']}"
@@ -891,6 +883,16 @@ RSpec.feature "RecordPageFields" do
       visit "catalog/#{item_690['doc_id']}"
       within "dd.blacklight-subject_display" do
         expect(page).to have_text(item_690["subject"])
+      end
+    end
+  end
+
+  feature "Genre display fields" do
+    let (:item_655) { fixtures.fetch("genre_655") }
+    scenario "User visits a document with genre" do
+      visit "catalog/#{item_655['doc_id']}"
+      within "dd.blacklight-genre_display" do
+        expect(page).to have_text(item_655["genre"])
       end
     end
   end

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -305,9 +305,6 @@ subject_653:
 subject_654:
   doc_id: "991012132499760719"
   subject: "Dictionary of American history: 654. Subfield B. Subfield C. Subfield E. — Subfield V. — Subfield Y. — Subfield Z."
-subject_655:
-  doc_id: "991012132499760720"
-  subject: "Dictionary of American history: 655. Subfield B. Subfield C. — Subfield V. — Subfield X. — Subfield Y. — Subfield Z."
 subject_656:
   doc_id: "991012132499760721"
   subject: "Dictionary of American history: 656. Subfield K. — Subfield V. — Subfield X. — Subfield Y. — Subfield Z."
@@ -317,6 +314,9 @@ subject_657:
 subject_690:
   doc_id: "991012132499760678"
   subject: "Dictionary of American history: 690. Subfield B. Subfield C. Subfield D. Subfield E. Subfield G. — Subfield V. — Subfield X. — Subfield Y. — Subfield Z."
+genre_655:
+  doc_id: "991012132499760720"
+  genre: "Dictionary of American history: 655. Subfield B. Subfield C. — Subfield V. — Subfield X. — Subfield Y. — Subfield Z."
 isbn_020:
   doc_id: "991012132499760679"
   isbn: "Dictionary of American history: 020."

--- a/spec/fixtures/marc_files/genre_display.xml
+++ b/spec/fixtures/marc_files/genre_display.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
+  <record>
+    <!-- 0. No genre_display field present -->
+  </record>
+  <record>
+    <!-- 1. genre_display field is present -->
+    <datafield ind1=' ' ind2='0' tag='655'>
+      <subfield code='a'>Documentary films</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='0' tag='655'>
+      <subfield code='a'>Foreign language films</subfield>
+      <subfield code='x'>Chinese</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/spec/fixtures/requests/item_limits.xml
+++ b/spec/fixtures/requests/item_limits.xml
@@ -1,0 +1,6444 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
+  <record>
+    <leader>18259nas a2204273 4500</leader>
+    <controlfield tag="005">20180315122852.0</controlfield>
+    <controlfield tag="008">921116c19339999cauwr1p 0 a0eng</controlfield>
+    <controlfield tag="001">991026207509703811</controlfield>
+    <datafield ind1=" " ind2=" " tag="010">
+      <subfield code="a">35009615 //r43</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="022">
+      <subfield code="a">0028-9604</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="032">
+      <subfield code="a">390020</subfield>
+      <subfield code="b">USPS</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(PPT)b15412805-01tuli_inst</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">ocn471940703</subfield>
+      <subfield code="9">ExL</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">PATG92-S06527</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">ocm01760328</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCLC)ocm01760328</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">DLC</subfield>
+      <subfield code="c">MnMULS</subfield>
+      <subfield code="d">OCoLC</subfield>
+      <subfield code="d">CtY</subfield>
+      <subfield code="d">DLC</subfield>
+      <subfield code="d">NSDP</subfield>
+      <subfield code="d">m.c.</subfield>
+      <subfield code="d">DLC</subfield>
+      <subfield code="d">RCS</subfield>
+      <subfield code="d">NSDP</subfield>
+      <subfield code="d">AIP</subfield>
+      <subfield code="d">NSDP</subfield>
+      <subfield code="d">AIP</subfield>
+      <subfield code="d">MH</subfield>
+      <subfield code="d">AIP</subfield>
+      <subfield code="d">NSDP</subfield>
+      <subfield code="d">AIP</subfield>
+      <subfield code="d">MH</subfield>
+      <subfield code="d">NST</subfield>
+      <subfield code="d">NSDP</subfield>
+      <subfield code="d">OUCA</subfield>
+      <subfield code="d">InU</subfield>
+      <subfield code="d">CStRLIN</subfield>
+      <subfield code="d">PPT</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="042">
+      <subfield code="a">lc</subfield>
+      <subfield code="a">nsdp</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="079">
+      <subfield code="a">ocm01760328</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="090">
+      <subfield code="a">AP2</subfield>
+      <subfield code="b">.N6772</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="210">
+      <subfield code="a">Newsweek</subfield>
+      <subfield code="b">(U.S. ed.)</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="222">
+      <subfield code="a">Newsweek</subfield>
+      <subfield code="b">(U.S. ed.)</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="0" tag="245">
+      <subfield code="a">Newsweek.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">[Los Angeles, Calif., etc.,</subfield>
+      <subfield code="b">Newsweek, Inc., etc.]</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="270">
+      <subfield code="a">Newsweek, Newsweek Bldg., Livingston, NJ 07039</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">v.</subfield>
+      <subfield code="b">ill. (incl. ports)</subfield>
+      <subfield code="c">29 cm.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="310">
+      <subfield code="a">Weekly</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="321">
+      <subfield code="a">Weekly</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="321">
+      <subfield code="a">53 no. a year</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="362">
+      <subfield code="a">v. 1- Feb. 17, 1933-</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="510">
+      <subfield code="a">Book review digest</subfield>
+      <subfield code="x">0006-7326</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="510">
+      <subfield code="a">Canadian periodical index</subfield>
+      <subfield code="x">0008-4719</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="510">
+      <subfield code="a">Magazine index</subfield>
+      <subfield code="b">1977-</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="510">
+      <subfield code="a">NEXIS</subfield>
+      <subfield code="b">Jan. 6, 1975-</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="510">
+      <subfield code="a">Readers' guide abstracts (microform)</subfield>
+      <subfield code="x">0886-0092</subfield>
+    </datafield>
+    <datafield ind1="1" ind2=" " tag="510">
+      <subfield code="a">Readers' guide to periodical literature</subfield>
+      <subfield code="x">0034-0464</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="510">
+      <subfield code="a">ABI/INFORM</subfield>
+      <subfield code="b">1975-1977</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="510">
+      <subfield code="a">Abridged readers' guide to periodical literature</subfield>
+      <subfield code="x">0001-334X</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="510">
+      <subfield code="a">Book review index</subfield>
+      <subfield code="x">0524-0581</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="510">
+      <subfield code="a">Cumulative index to nursing and allied health literature</subfield>
+      <subfield code="x">0146-5554</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="510">
+      <subfield code="a">Energy information abstracts</subfield>
+      <subfield code="x">0147-6521</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="510">
+      <subfield code="a">Environment abstracts</subfield>
+      <subfield code="x">0093-3287</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="510">
+      <subfield code="a">Film literature index</subfield>
+      <subfield code="x">0093-6758</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="510">
+      <subfield code="a">Hospital literature index</subfield>
+      <subfield code="x">0018-5736</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="510">
+      <subfield code="a">Infobank</subfield>
+      <subfield code="b">Jan. 1969-</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="510">
+      <subfield code="a">Media review digest</subfield>
+      <subfield code="x">0363-7778</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="510">
+      <subfield code="a">Predicasts</subfield>
+    </datafield>
+    <datafield ind1="2" ind2=" " tag="510">
+      <subfield code="a">Recently published articles</subfield>
+      <subfield code="x">0145-5311</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="510">
+      <subfield code="a">Biography index</subfield>
+      <subfield code="x">0006-3053</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="510">
+      <subfield code="a">Music index</subfield>
+      <subfield code="x">0027-4348</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="530">
+      <subfield code="a">Available on microfilm from University Microfilms International.</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="590">
+      <subfield code="a">Also available on microfilm. (MICR) Per. 757</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="775">
+      <subfield code="t">Newsweek</subfield>
+      <subfield code="b">(International, Atlantic ed.)</subfield>
+      <subfield code="x">0163-7053</subfield>
+      <subfield code="w">(DLC) 90640165</subfield>
+      <subfield code="w">(OCoLC)4447924</subfield>
+    </datafield>
+    <datafield ind1="0" ind2="5" tag="780">
+      <subfield code="t">Today (1933)</subfield>
+      <subfield code="g">Feb. 27, 1937</subfield>
+      <subfield code="w">(OCoLC)1604628</subfield>
+      <subfield code="w">(DLC) 34039437</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="907">
+      <subfield code="a">.b15412805</subfield>
+      <subfield code="b">multi</subfield>
+      <subfield code="c">-</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="935">
+      <subfield code="a">00582633</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">astk</subfield>
+      <subfield code="u">v.v.53:1959</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">astk</subfield>
+      <subfield code="u">v.v.97 (Jan. - June 1981)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">astk</subfield>
+      <subfield code="u">v.v. 98 (Jul. - Dec. 1981)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kmicr</subfield>
+      <subfield code="a">Micro- film Per. 757</subfield>
+      <subfield code="u">v.v.1:1933</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.Index 67-70</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.Index 71-74</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.3 (Jan.-Jun. 1934)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.3:1934</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.4 (Jul.-Dec. 1934)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.5 (Jan.-Jun. 1935)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.6 (Jul.-Dec. 1935)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.7 (Apr.-Jun. 1936)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.7 (Jan.-Mar. 1936)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.8 (Jul.-Dec. 1936)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.9 (Jan.-Jun. 1937)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.10 (Jul.-Dec. 1937)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.11 (Jan.-Jun. 1938)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.12 (Jul.-Dec. 1938)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.13 (Apr.-Jun. 1939)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.13 (Jan.-Mar. 1939)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.15 (Jan.-Jun. 1940)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.16 (Jul.-Dec. 1940)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.17 (Apr.-Jun. 1941)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.17 (Jan.-Mar. 1941)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.18 (Jul.-Sep. 1941)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.18 (Oct.-Dec. 1941)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.19 (Apr.-Jun. 1942)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.19 (Jan.-Mar. 1942)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.20 (Jul.-Sep. 1942)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.20 (Oct.-Dec. 1942)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.21 (Apr.-Jun. 1943)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.21 (Jan.-Mar. 1943)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.22 (Jul.-Sep. 1943)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.22 (Oct.-Dec. 1943)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.23 (Apr.-Jun. 1944)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.23 (Jan.-Mar. 1944)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.24 (Jul.-Sep. 1944)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.24 (Oct.-Dec. 1944)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.25 (Apr.-Jun. 1945)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.25 (Jan.-Mar. 1945)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.26 (Jul.-Sep. 1945)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.26 (Oct.-Dec. 1945)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.27 (Apr.-Jun. 1946)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.27 (Jan.-Mar.1946)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.28 (Jul.-Sep. 1946)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.28 (Oct.-Dec. 1946)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.29 (Apr.-Jun. 1947)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.29 (Jan.-Mar. 1947)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.30 (Jul.-Sep. 1947)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.30 (Oct. Dec. 1947)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.31 (Apr.-Jun. 1948)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.31 (Jan.-Mar. 1948)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.32 (Jul.-Sep. 1948)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.32 (Oct.-Dec. 1948)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.33 (Apr.-Jun. 1949)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.33 (Jan.-Mar. 1949)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.34 (Jul.-Sep. 1949)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.34 (Oct.-Dec. 1949)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.35 (Apr.-Jun. 1950)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.35 (Jan.-Mar. 1950)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.36 (Jul.-Sep. 1950)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.36 (Oct.-Dec. 1950)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.37 (Apr.-Jun. 1951)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.37 (Jan.-Mar. 1951)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.38 (Jul.-Sep. 1951)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.38 (Oct.-Dec. 1951)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.39 (Apr.-Jun. 1952)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.39 (Jan.-Mar. 1952)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.40 (Jul.-Sep. 1952)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.41 (Apr.-Jun. 1953)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.41 (Jan.-Mar. 1953)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.42 (Jul.-Sep. 1953)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.42 (Oct.-Dec. 1953)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.43 (Apr.-Jun. 1954)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.43 (Jan.-Mar. 1954)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.44 (Jul.-Sep. 1954)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.44 (Oct.-Dec. 1954)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.45 (Apr.-Jun. 1955)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.45 (Jan.-Mar. 1955)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.46 (Jul.-Sep. 1955)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.47 (Apr.-Jun. 1956)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.47 (Jan.-Mar. 1956)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.48 (Jul.-Sep. 1956)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.48 (Oct.-Dec. 1956)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.49 (Apr.Jun. 1957)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.49 (Jan.-Mar. 1957)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.50 (Jul.-Sep. 1957)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.50 (Oct.-Dec. 1957)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.51 (Apr.-Jun. 1958)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.51 (Jan.-Mar. 1958)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.52 (Jul.-Sep. 1958)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.52 (Oct.-Dec. 1958)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.53 (Apr.-Jun. 1959)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.53 (Jan.-Mar. 1959)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.54 (Jul.-Sep. 1959)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.54 (Oct.-Dec. 1959)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.55 (Apr.-Jun. 1960)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.55 (Jan.-Mar. 1960)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.56 (Jul.-Sep. 1960)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.56 (Oct.-Dec. 1960)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.57 (Apr.-Jun. 1961)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.57 (Jan.-Mar. 1961)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.58 (Jul.-Sep. 1961)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.58 (Oct.-Dec. 1961)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.59 (Apr.-Jun. 1962)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.59 (Jan.-Mar. 1962)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.60 (Jul.-Sep. 1962)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.60 (Oct.-Dec. 1962)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.61 (Apr.-Jun. 1963)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.61 (Jan.-Mar. 1963)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.62 (Oct.-Dec. 1963)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.63 (Apr.-Jun. 1964)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.63 (Jan.-Mar. 1964)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.64 (Jul.-Sep. 1964)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.64 (Oct.-Dec. 1964)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.65 (Jan.-Mar. 1965)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.66 (Jul.-Sep. 1965)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.67 (Apr.-Jun. 1966)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.67 (Jan.-Mar. 1966)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.68 (Jul.-Sep. 1966)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.68 (Oct.-Dec. 1966)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.69 (Apr.-Jun. 1967)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.70 (Jul.-Sep. 1967)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.70 (Oct.-Dec. 1967)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.71 (Apr.-Jun. 1968)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.71 (Jan.-Mar. 1968)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.72 (Jul.-Sep. 1968)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.72 (Oct.-Dec. 1968)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.73 (Apr.-Jun. 1969)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.73 (Jan.-Mar. 1969)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.74 (Jul.-Sep. 1969)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.74 (Oct.-Dec. 1969)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.75 (Apr.-Jun. 1970)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.75 (Jan.-Mar. 1970)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.76 (Jul.-Sep. 1970)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.76 (Oct.-Dec. 1970)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.77 (Apr.-Jun. 1971)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.77 (Jan.-Mar. 1971)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.78 (Jul.-Sep. 1971)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.78 (Oct.-Dec. 1971)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.79 (Apr.-jun. 1972)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.79 (Jan.-Mar. 1972)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.80 (Jul.-Sep. 1972)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.80 (Jul.-Sep. 1972)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.80 (Oct.-Dec. 1972)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.81 (Apr.-Jun. 1973)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.81 (Jan.-Mar. 1973)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.82 (Jul.-Sep. 1973)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.82 (Oct.-Dec. 1973)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.83 (Apr.-Jun. 1974)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.83 (Jan.-Mar. 1974)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.84 (Jul.-Sep. 1974)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.84 (Oct.-Dec. 1974)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.85 (Apr.-Jun. 1975)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.85 (Jan.-Mar. 1975)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.86 (Jul.-Sep. 1975)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.86 (Oct.-Dec. 1975)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.87 (Apr.-Jun. 1976)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.87 (Jan.-Mar. 1976)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.88 (Jul.-Sep. 1976)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.88 (Jul.-Sep. 1976)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.88 (Oct.-Dec. 1976)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.89 (Apr.-Jun. 1977)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.89 (Jan.-Mar. 1977)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.90 (Jul.-Sep. 1977)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.90 (Oct.-Dec. 1977)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.91 (Apr.-Jun. 1978)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.91 (Jan.-Mar. 1978)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.92 (Jul.-Sep. 1978)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.92 (Nov.-Dec. 1978)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.92 (Oct.-Nov. 1978)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.93 (Apr.-Jun. 1979)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.93 (Jan.-Mar. 1979)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.94 (Jul.-Sep. 1979)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.95 (May-Jun. 1980)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.97 (Apr.-Jun. 1981)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.97 (Jan.-Mar. 1981)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.98 (Jul.-Sep. 1981)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.98 (Oct.-Dec. 1981)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.99 (Apr.-Jun. 1982)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.99 (Jan.-Mar. 1982)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.100 (Jul.-Sep. 1982)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.100 (Oct.-Dec. 1982)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.101 (Apr.-Jun. 1983)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.101 (Jan.-Mar. 1983)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.102 (Jul.-Sep. 1983)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.102 (Oct.-Dec. 1983)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.103 (Apr.-Jun. 1984)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.103 (Jan.-Mar. 1984)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.104 (Jul.-Sep. 1984)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.104 (Oct.-Dec. 1984)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.105 (Apr.-Jun. 1985)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.105 (Jan.-Mar. 1985)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.106 (Jul.-Sept. 1985)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.106 (Oct.-Dec. 1985)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.107 (Apr.-Jun. 1986)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.107 (Jan.-Mar. 1986)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.108 (Jul.-Sep. 1986)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.108 (Oct.-Dec. 1986)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.109 (Apr.-Jun. 1987)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.109 (Jan.-Mar. 1987)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.110 (Oct.-Dec. 1987)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.111 (Apr.-Jun. 1988)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.111 (Jan.-Mar. 1988)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.112 (Jul.-Sep. 1988)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.112 (Jul.-Sep. 1988)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.112 (Oct.-Dec. 1988)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.113 (Jan.-Mar. 1989)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.114 (Jul.-Sep. 1989)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.114 (Oct.-Dec. 1989)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.115 (Apr.-Jun. 1990)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.115 (Jan.-Mar. 1990)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.116 (Jul.-Sep. 1990)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.116 (Oct.-Dec. 1990)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.117 (Apr.-Jun. 1991)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.117 (Jan.-Mar. 1991)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.121 (Apr.-Jun. 1993)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.121 (Jan.-Mar. 1993)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.122 (Jul.-Sep. 1993)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.122 (Oct.-Dec. 1993)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.123 (Jan.-Mar. 1994)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.124 (Nov. 1994-Jan. 1995)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.124 (Oct.-Nov. 1993)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.125 (Jan.-Mar. 1995)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.126 (Jul.-Sep. 1995)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.126 (Oct. 1995-Jan. 1996)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.127 (Apr.-Jun. 1996)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.127 (Jan.-Mar. 1996)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.128 (Jul.-Sep. 1996); Missing no.3</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.128 (Oct. 1996-Jan. 1997)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.129 (Apr.-Jun. 1997); Special Issue</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.129 (Jan.-Mar. 1997)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.130 (Jul.-Sep. 1997)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.130 (Oct.-Dec. 1997)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.131 (Apr.-Jun. 1998)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.131 (Jan.-Mar. 1998)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.132 (Jul.-Sep. 1998)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.132 (Oct.-Dec. 1998)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.133 (Apr.-Jun.1999); Special Edition</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.133 (Jan.-Mar. 1999); Missing no.11, no.18</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.134 (Jul.-Sep. 1999)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.134 (Oct.-Dec. 1999); Missing no.26</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.135 (Apr.-Jun. 2000)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.135 (Jan.-Mar. 2000)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.136 (Jul.-Sep. 2000)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.136 (Oct.-Dec. 2000)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.137 (Apr.-Jun. 2001)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.137 (Jan.-Mar. 2001)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.138 (Jul.-Sep. 2001)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.138 (Oct.-Dec. 2001)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.139 (Apr.-Jun. 2002)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.139 (Dec. 2001-Mar. 2002)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.140 (Jul.-Sep. 2002)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.140 (Oct.-Dec. 2002)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.141 (Apr.-Jun. 2003)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.141 (Jan.-Mar. 2005)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.142 (Jul.-Sep. 2003)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.142 (Oct.-Dec. 2003); Special Issue</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.143 (Apr.-Jun. 2004)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.143 (Jan.-Mar. 2004)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.144 (Jul.-Sep. 2004)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.144 (Oct.-Dec. 2004)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.145 (Apr.-Jun. 2005)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.145 (Jan.-Mar. 2005)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.146 (Jul.-Sep. 2005)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.146-147 (Oct. 2005-Jan. 2006)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.147 (Apr.3-Jun.26 2006)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.147 (Jan.-Mar. 2006)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.148 (Oct.2, 2006-Jan.1, 2007)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.148(July 10-Sept.25, 2006)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.149 (Apr.2-Jun.25, 2007)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.149 (Jan.8-Mar.26, 2007)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.150 (Jul.9-Sep.24, 2007)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.150-151 (Oct. 2007-Jan. 7, 2008)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.151 (Apr.7-Jun.30, 2008)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.151 (Jan.14-Mar.31, 2008)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.152 (Jul.7-Sep.29, 2008)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.152-152/153 (Oct.6, 2008-Jan.5, 2009)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.153 (Apr.6-Jun.29, 2009)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.153 (Jan.12-Mar.30, 2009)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.154 (Jul.6-Sep.28, 2009)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.154-155 (Oct.5, 2009-Jan.4, 2010)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.155 (Apr.-Jul.5, 2010)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.155 (Jan.-Mar.2010)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.156 (Jul.12-Sep.2010)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.156 (Oct.2010-Jan.1, 2011)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.157 (Jan.-Apr.4, 2011)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.157-158 (May.-Aug.2011)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.157-158 (May.-Aug.2011)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.158 (Sep.-Nov.2011)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.159 (Jan.-Apr.2012)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.159-160 (May.-Aug.2012)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="945">
+      <subfield code="l">kstk</subfield>
+      <subfield code="u">v.v.160 (Sep.-Dec.2012)</subfield>
+      <subfield code="g">1</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="950">
+      <subfield code="l">P</subfield>
+      <subfield code="v">v.3- ;</subfield>
+      <subfield code="y">1934-</subfield>
+      <subfield code="f">PER</subfield>
+      <subfield code="i">11/16/92 N</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="950">
+      <subfield code="l">AMB</subfield>
+      <subfield code="v">v.53- ;</subfield>
+      <subfield code="y">1959-</subfield>
+      <subfield code="n">Available on microfilm v.81 (1973)- ; Lib. keeps current paper issues until microfilm arrives.</subfield>
+      <subfield code="f">PER.</subfield>
+      <subfield code="i">11/16/92 N</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="950">
+      <subfield code="l">MICRO</subfield>
+      <subfield code="b">Micro- film Per. 757</subfield>
+      <subfield code="v">v.1-94;</subfield>
+      <subfield code="y">1933-1979.</subfield>
+      <subfield code="f">PER.</subfield>
+      <subfield code="i">11/16/92 N 495:SL</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="955">
+      <subfield code="l">P</subfield>
+      <subfield code="c">0:(v.3:1934)</subfield>
+      <subfield code="a">REF-1</subfield>
+      <subfield code="i">11/16/92 C</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="955">
+      <subfield code="l">AMB</subfield>
+      <subfield code="c">0:(v.53:1959)</subfield>
+      <subfield code="a">REF-1</subfield>
+      <subfield code="i">11/16/92 C</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="955">
+      <subfield code="l">MICRO</subfield>
+      <subfield code="c">0:(v.1:1933)</subfield>
+      <subfield code="i">11/16/92 C</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocm01760328</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="b">303</subfield>
+      <subfield code="c">990101</subfield>
+      <subfield code="d">s</subfield>
+      <subfield code="e">a</subfield>
+      <subfield code="f">-</subfield>
+      <subfield code="g">0</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="998">
+      <subfield code="a">11/16/92</subfield>
+      <subfield code="t">c</subfield>
+      <subfield code="s">9110</subfield>
+      <subfield code="n">PPT</subfield>
+      <subfield code="w">DCLC359615S</subfield>
+      <subfield code="d">11/16/92</subfield>
+      <subfield code="c">CW</subfield>
+      <subfield code="b">VC</subfield>
+      <subfield code="i">921116</subfield>
+      <subfield code="l">PATG</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ADM">
+      <subfield code="b">2018-03-15 16:28:53</subfield>
+      <subfield code="e">b15412805-01tuli_inst</subfield>
+      <subfield code="d">ILS</subfield>
+      <subfield code="a">2017-06-20 11:31:38</subfield>
+      <subfield code="c">false</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="HLD">
+      <subfield code="b">AMBLER</subfield>
+      <subfield code="c">stacks</subfield>
+      <subfield code="h">AP2</subfield>
+      <subfield code="i">.N6772</subfield>
+      <subfield code="x">NOTE(CHECKIN): Ambler | FREQUENCY: w | SCODE3: - | VEN TITLE#: rb474100006636555005</subfield>
+      <subfield code="8">22311900640003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="HLD866">
+      <subfield code="a">Current issues only kept until microform arrives.</subfield>
+      <subfield code="8">22311900640003811</subfield>
+    </datafield>
+    <datafield ind1="0" ind2=" " tag="HLD">
+      <subfield code="b">KARDON</subfield>
+      <subfield code="c">p_remote</subfield>
+      <subfield code="h">AP2</subfield>
+      <subfield code="i">.N6772</subfield>
+      <subfield code="8">22311903550003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="HLD">
+      <subfield code="b">MAIN</subfield>
+      <subfield code="c">techserv</subfield>
+      <subfield code="x">NOTE(CHECKIN): Paley Binding Copy. Pull for binding in Apr, July, Oct, Jan | FREQUENCY: w | SCODE3: n | VEN TITLE#: rb474100001636555005</subfield>
+      <subfield code="8">22311903560003811</subfield>
+    </datafield>
+    <datafield ind1="8" ind2=" " tag="HLD">
+      <subfield code="b">MAIN</subfield>
+      <subfield code="c">zpaley</subfield>
+      <subfield code="x">NOTE(CHECKIN): Shelve in Paley News Center. **TATTLETAPE** dc 01/10 | NOTE(CHECKIN): Pull for binding in Apr,July,Oct,Jan. | FREQUENCY: w | SCODE3: - | VEN TITLE#: rb474100001636555005</subfield>
+      <subfield code="8">22311903570003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="HLD866">
+      <subfield code="a">v.3- 160 1934-2012</subfield>
+      <subfield code="8">22311903570003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="HLD">
+      <subfield code="b">MEDIA</subfield>
+      <subfield code="c">micro</subfield>
+      <subfield code="h">Micro- film Per. 757</subfield>
+      <subfield code="x">INT. NOTE: PER | NOTE(CHECKIN): AP 2.N6772 - 2 REELS PER YEAR, ONE VOLUME PER REEL. | RETENTION: -</subfield>
+      <subfield code="8">22311903580003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="HLD866">
+      <subfield code="a">v.1(1933)-v.94(1976)</subfield>
+      <subfield code="8">22311903580003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="HLD">
+      <subfield code="b">AMBLER</subfield>
+      <subfield code="c">micro</subfield>
+      <subfield code="x">NOTE(CHECKIN): Microfilm canceled. Last reel vols 149-150 Jan-Dec 2007. dc 03/10 | NOTE(CHECKIN): Ambler Microfilm - Discard paper issues when microfilm arrives. | FREQUENCY: f | SCODE3: -</subfield>
+      <subfield code="8">22311903590003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2="0" tag="HLD866">
+      <subfield code="a">v.53(1959)-v.150(2007)</subfield>
+      <subfield code="8">22311903590003811</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768826</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902960003811</subfield>
+      <subfield code="c">v.32 (Oct.-Dec. 1948)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726428</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901610003811</subfield>
+      <subfield code="c">v.103 (Apr.-Jun. 1984)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726436</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901630003811</subfield>
+      <subfield code="c">v.102 (Jul.-Sep. 1983)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">0</subfield>
+      <subfield code="u">TECHNICAL</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074027162775</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903110003811</subfield>
+      <subfield code="c">v.25 (Apr.-Jun. 1945)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769659</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901240003811</subfield>
+      <subfield code="c">v.127 (Apr.-Jun. 1996)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767521</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902590003811</subfield>
+      <subfield code="c">v.52 (Oct.-Dec. 1958)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769576</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901220003811</subfield>
+      <subfield code="c">v.128 (Oct. 1996-Jan. 1997)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769634</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901260003811</subfield>
+      <subfield code="c">v.126 (Oct. 1995-Jan. 1996)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074024531</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903500003811</subfield>
+      <subfield code="c">v.154 (Jul.6-Sep.28, 2009)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769600</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901280003811</subfield>
+      <subfield code="c">v.125 (Jan.-Mar. 1995)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769113</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903170003811</subfield>
+      <subfield code="c">v.22 (Oct.-Dec. 1943)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770467</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901690003811</subfield>
+      <subfield code="c">v.99 (Jan.-Mar. 1982)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768776</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902900003811</subfield>
+      <subfield code="c">v.35 (Apr.-Jun. 1950)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726477</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901670003811</subfield>
+      <subfield code="c">v.100 (Jul.-Sep. 1982)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768941</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903150003811</subfield>
+      <subfield code="c">v.23 (Apr.-Jun. 1944)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769097</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903190003811</subfield>
+      <subfield code="c">v.21 (Apr.-Jun. 1943)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726485</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901650003811</subfield>
+      <subfield code="c">v.101 (Jan.-Mar. 1983)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768966</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903130003811</subfield>
+      <subfield code="c">v.24 (Oct.-Dec. 1944)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768750</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902920003811</subfield>
+      <subfield code="c">v.34 (Jul.-Sep. 1949)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768800</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902940003811</subfield>
+      <subfield code="c">v.33 (Apr.-Jun. 1949)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768859</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902980003811</subfield>
+      <subfield code="c">v.31 (Apr.-Jun. 1948)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767422</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902510003811</subfield>
+      <subfield code="c">v.56 (Oct.-Dec. 1960)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767513</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902600003811</subfield>
+      <subfield code="c">v.52 (Jul.-Sep. 1958)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767497</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902620003811</subfield>
+      <subfield code="c">v.51 (Jan.-Mar. 1958)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767471</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902640003811</subfield>
+      <subfield code="c">v.50 (Oct.-Dec. 1957)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726402</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901200003811</subfield>
+      <subfield code="c">v.102 (Oct.-Dec. 1983)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767406</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902530003811</subfield>
+      <subfield code="c">v.55 (Apr.-Jun. 1960)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767380</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902550003811</subfield>
+      <subfield code="c">v.54 (Oct.-Dec. 1959)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767364</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902570003811</subfield>
+      <subfield code="c">v.53 (Jan.-Mar. 1959)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770186</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901190003811</subfield>
+      <subfield code="c">v.129 (Apr.-Jun. 1997) Special Issue</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769733</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901370003811</subfield>
+      <subfield code="c">v.117 (Jan.-Mar. 1991)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768875</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903020003811</subfield>
+      <subfield code="c">v.29 (Apr.-Jun. 1947)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770509</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901720003811</subfield>
+      <subfield code="c">v.97 (Apr.-Jun. 1981)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768784</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902890003811</subfield>
+      <subfield code="c">v.36 (Jul.-Sep. 1950)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770046</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901150003811</subfield>
+      <subfield code="c">v.131 (Apr.-Jun. 1998)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767554</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902680003811</subfield>
+      <subfield code="c">v.48 (Jul.-Sep. 1956)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769378</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901910003811</subfield>
+      <subfield code="c">v.87 (Apr.-Jun. 1976)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768909</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903060003811</subfield>
+      <subfield code="c">v.28 (Jul.-Sep. 1946)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769675</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901330003811</subfield>
+      <subfield code="c">v.122 (Jul.-Sep. 1993)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769279</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901760003811</subfield>
+      <subfield code="c">v.93 (Apr.-Jun. 1979)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768016</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903430003811</subfield>
+      <subfield code="c">v.3 (Jan.-Jun. 1934)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769089</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903200003811</subfield>
+      <subfield code="c">v.21 (Jan.-Mar. 1943)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769816</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901500003811</subfield>
+      <subfield code="c">v.110 (Oct.-Dec. 1987)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769808</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901540003811</subfield>
+      <subfield code="c">v.108 (Jul.-Sep. 1986)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769212</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903280003811</subfield>
+      <subfield code="c">v.17 (Jan.-Mar. 1941)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726386</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901580003811</subfield>
+      <subfield code="c">v.105 (Apr.-Jun. 1985)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769048</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903240003811</subfield>
+      <subfield code="c">v.19 (Jan.-Mar. 1942)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726709</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902230003811</subfield>
+      <subfield code="c">v.72 (Jul.-Sep. 1968)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074017552530</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900750003811</subfield>
+      <subfield code="c">v.148 (Oct.2, 2006-Jan.1, 2007)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769477</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902050003811</subfield>
+      <subfield code="c">v.80 (Jul.-Sep. 1972)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726667</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902300003811</subfield>
+      <subfield code="c">v.68 (Jul.-Sep. 1966)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769535</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901990003811</subfield>
+      <subfield code="c">v.83 (Jan.-Mar. 1974)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074017530965</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900820003811</subfield>
+      <subfield code="c">v.147 (Apr.3-Jun.26 2006)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074017491895</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900860003811</subfield>
+      <subfield code="c">v.146 (Jul.-Sep. 2005)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726444</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902090003811</subfield>
+      <subfield code="c">v.78 (Oct.-Dec. 1971)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074025209917</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903470003811</subfield>
+      <subfield code="c">v.106 (Jul.-Sept. 1985)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769519</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902010003811</subfield>
+      <subfield code="c">v.82 (Jul.-Sep. 1973)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726519</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902120003811</subfield>
+      <subfield code="c">v.77 (Jan.-Mar. 1971)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726659</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902160003811</subfield>
+      <subfield code="c">v.75 (Jan.-Mar. 1970)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769402</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901880003811</subfield>
+      <subfield code="c">v.88 (Jul.-Sep. 1976)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074024498321</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903540003811</subfield>
+      <subfield code="c">v.152 (Jul.7-Sep.29, 2008)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767323</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902380003811</subfield>
+      <subfield code="c">v.63 (Apr.-Jun. 1964)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769436</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901950003811</subfield>
+      <subfield code="c">v.85 (Jan.-Mar. 1975)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727418</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901030003811</subfield>
+      <subfield code="c">v.137 (Apr.-Jun. 2001)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726683</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902270003811</subfield>
+      <subfield code="c">v.70 (Jul.-Sep. 1967)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074023025406</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900710003811</subfield>
+      <subfield code="c">v.149 (Jan.8-Mar.26, 2007)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770020</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901070003811</subfield>
+      <subfield code="c">v.135 (Apr.-Jun. 2000)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074017542036</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900790003811</subfield>
+      <subfield code="c">v.148(July 10-Sept.25, 2006)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726766</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902340003811</subfield>
+      <subfield code="c">v.66 (Jul.-Sep. 1965)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074027806827</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900680003811</subfield>
+      <subfield code="c">v.160 (Sep.-Dec.2012)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769865</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901450003811</subfield>
+      <subfield code="c">v.112 (Oct.-Dec. 1988)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768677</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902790003811</subfield>
+      <subfield code="c">v.41 (Apr.-Jun. 1953)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770103</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901090003811</subfield>
+      <subfield code="c">v.134 (Oct.-Dec. 1999) Missing no.26</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074019921469</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901420003811</subfield>
+      <subfield code="c">v.114 (Jul.-Sep. 1989)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769840</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901470003811</subfield>
+      <subfield code="c">v.112 (Jul.-Sep. 1988)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768578</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902760003811</subfield>
+      <subfield code="c">v.43 (Jan.-Mar. 1954)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768628</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902780003811</subfield>
+      <subfield code="c">v.42 (Oct.-Dec. 1953)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769311</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901810003811</subfield>
+      <subfield code="c">v.91 (Apr.-Jun. 1978)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769303</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901830003811</subfield>
+      <subfield code="c">v.90 (Oct.-Dec. 1977)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769337</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901840003811</subfield>
+      <subfield code="c">v.90 (Jul.-Sep. 1977)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768594</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902730003811</subfield>
+      <subfield code="c">v.45 (Jan.-Mar. 1955)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769121</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903330003811</subfield>
+      <subfield code="c">v.12 (Jul.-Dec. 1938)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769188</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903350003811</subfield>
+      <subfield code="c">v.10 (Jul.-Dec. 1937)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769196</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903360003811</subfield>
+      <subfield code="c">v.9 (Jan.-Jun. 1937)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769758</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901400003811</subfield>
+      <subfield code="c">v.115 (Apr.-Jun. 1990)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769832</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901480003811</subfield>
+      <subfield code="c">v.111 (Apr.-Jun. 1988)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769014</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903300003811</subfield>
+      <subfield code="c">v.15 (Jan.-Jun. 1940)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769170</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903380003811</subfield>
+      <subfield code="c">v.7 (Apr.-Jun. 1936)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074027158781</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900830003811</subfield>
+      <subfield code="c">v.157 (Jan.-Apr.4, 2011)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767307</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902400003811</subfield>
+      <subfield code="c">v.62 (Oct.-Dec. 1963)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074017504523</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900850003811</subfield>
+      <subfield code="c">v.146-147 (Oct. 2005-Jan. 2006)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727632</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900940003811</subfield>
+      <subfield code="c">v.142 (Jul.-Sep. 2003)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727624</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900960003811</subfield>
+      <subfield code="c">v.141 (Jan.-Mar. 2005)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769501</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902020003811</subfield>
+      <subfield code="c">v.81 (Apr.-Jun. 1973)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769485</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902040003811</subfield>
+      <subfield code="c">v.80 (Oct.-Dec. 1972)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769394</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901890003811</subfield>
+      <subfield code="c">v.88 (Oct.-Dec. 1976)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767257</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902460003811</subfield>
+      <subfield code="c">v.59 (Jan.-Mar. 1962)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767455</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902480003811</subfield>
+      <subfield code="c">v.58 (Jul.-Sep. 1961)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727400</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901040003811</subfield>
+      <subfield code="c">v.137 (Jan.-Mar. 2001)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726758</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902350003811</subfield>
+      <subfield code="c">v.65 (Jan.-Mar. 1965)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727558</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901060003811</subfield>
+      <subfield code="c">v.136 (Jul.-Sep. 2000)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767331</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902370003811</subfield>
+      <subfield code="c">v.64 (Jul.-Sep. 1964)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769790</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901530003811</subfield>
+      <subfield code="c">v.108 (Oct.-Dec. 1986)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770525</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901700003811</subfield>
+      <subfield code="c">v.98 (Oct.-Dec. 1981)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768891</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903000003811</subfield>
+      <subfield code="c">v.30 (Oct. Dec. 1947)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770194</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901170003811</subfield>
+      <subfield code="c">v.130 (Oct.-Dec. 1997)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768735</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902870003811</subfield>
+      <subfield code="c">v.37 (Jan.-Mar. 1951)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768917</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903050003811</subfield>
+      <subfield code="c">v.28 (Oct.-Dec. 1946)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769766</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901390003811</subfield>
+      <subfield code="c">v.116 (Jul.-Sep. 1990)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769691</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901310003811</subfield>
+      <subfield code="c">v.123 (Jan.-Mar. 1994)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769709</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901340003811</subfield>
+      <subfield code="c">v.121 (Apr.-Jun. 1993)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768685</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903080003811</subfield>
+      <subfield code="c">v.27 (Jan.-Mar.1946)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769253</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901780003811</subfield>
+      <subfield code="c">v.92 (Oct.-Nov. 1978)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074027149913</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903440003811</subfield>
+      <subfield code="c">v.156 (Jul.12-Sep.2010)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769287</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901750003811</subfield>
+      <subfield code="c">v.94 (Jul.-Sep. 1979)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767968</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903410003811</subfield>
+      <subfield code="c">v.5 (Jan.-Jun. 1935)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768719</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902840003811</subfield>
+      <subfield code="c">v.38 (Oct.-Dec. 1951)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726345</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901560003811</subfield>
+      <subfield code="c">v.107 (Jan.-Mar. 1986)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769071</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903220003811</subfield>
+      <subfield code="c">v.20 (Oct.-Dec. 1942)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769220</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903270003811</subfield>
+      <subfield code="c">v.17 (Apr.-Jun. 1941)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074023058266</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900660003811</subfield>
+      <subfield code="c">v.151 (Jan.14-Mar.31, 2008)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769469</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902070003811</subfield>
+      <subfield code="c">v.79 (Apr.-jun. 1972)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726733</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902320003811</subfield>
+      <subfield code="c">v.67 (Apr.-Jun. 1966)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727442</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900910003811</subfield>
+      <subfield code="c">v.143 (Apr.-Jun. 2004)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074024532061</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903490003811</subfield>
+      <subfield code="c">v.154-155 (Oct.5, 2009-Jan.4, 2010)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726626</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902210003811</subfield>
+      <subfield code="c">v.73 (Jan.-Mar. 1969)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726634</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902180003811</subfield>
+      <subfield code="c">Index 71-74</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769550</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901970003811</subfield>
+      <subfield code="c">v.84 (Jul.-Sep. 1974)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726535</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902100003811</subfield>
+      <subfield code="c">v.78 (Jul.-Sep. 1971)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769329</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901860003811</subfield>
+      <subfield code="c">v.89 (Apr.-Jun. 1977)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074024523342</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903520003811</subfield>
+      <subfield code="c">v.153 (Apr.6-Jun.29, 2009)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727566</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900990003811</subfield>
+      <subfield code="c">v.139 (Dec. 2001-Mar. 2002)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770079</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901120003811</subfield>
+      <subfield code="c">v.133 (Jan.-Mar. 1999) Missing no.11, no.18</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767570</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902650003811</subfield>
+      <subfield code="c">v.49 (Apr.Jun. 1957)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727467</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900880003811</subfield>
+      <subfield code="c">v.145 (Jan.-Mar. 2005)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726717</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902290003811</subfield>
+      <subfield code="c">v.68 (Oct.-Dec. 1966)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767398</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902540003811</subfield>
+      <subfield code="c">v.55 (Jan.-Mar. 1960)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="k">Micro- film Per. 757</subfield>
+      <subfield code="8">23311900800003811</subfield>
+      <subfield code="c">v.1:1933</subfield>
+      <subfield code="a">4</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767356</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902430003811</subfield>
+      <subfield code="c">v.60 (Oct.-Dec. 1962)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727582</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901010003811</subfield>
+      <subfield code="c">v.138 (Oct.-Dec. 2001)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074027172014</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900770003811</subfield>
+      <subfield code="c">v.157-158 (May.-Aug.2011)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768834</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902970003811</subfield>
+      <subfield code="c">v.32 (Jul.-Sep. 1948)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768990</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903100003811</subfield>
+      <subfield code="c">v.26 (Jul.-Sep. 1945)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726360</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901600003811</subfield>
+      <subfield code="c">v.104 (Jul.-Sep. 1984)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726410</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901620003811</subfield>
+      <subfield code="c">v.103 (Jan.-Mar. 1984)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768974</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903120003811</subfield>
+      <subfield code="c">v.25 (Jan.-Mar. 1945)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769667</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901230003811</subfield>
+      <subfield code="c">v.128 (Jul.-Sep. 1996) Missing no.3</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769642</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901250003811</subfield>
+      <subfield code="c">v.127 (Jan.-Mar. 1996)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769618</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901270003811</subfield>
+      <subfield code="c">v.126 (Jul.-Sep. 1995)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769626</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901290003811</subfield>
+      <subfield code="c">v.124 (Nov. 1994-Jan. 1995)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726493</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901680003811</subfield>
+      <subfield code="c">v.99 (Apr.-Jun. 1982)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768933</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903160003811</subfield>
+      <subfield code="c">v.23 (Jan.-Mar. 1944)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769105</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903180003811</subfield>
+      <subfield code="c">v.22 (Jul.-Sep. 1943)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768818</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902930003811</subfield>
+      <subfield code="c">v.34 (Oct.-Dec. 1949)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768958</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903140003811</subfield>
+      <subfield code="c">v.24 (Jul.-Sep. 1944)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726469</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901640003811</subfield>
+      <subfield code="c">v.101 (Apr.-Jun. 1983)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726543</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901660003811</subfield>
+      <subfield code="c">v.100 (Oct.-Dec. 1982)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768768</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902910003811</subfield>
+      <subfield code="c">v.35 (Jan.-Mar. 1950)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768792</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902950003811</subfield>
+      <subfield code="c">v.33 (Jan.-Mar. 1949)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768842</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902990003811</subfield>
+      <subfield code="c">v.31 (Jan.-Mar. 1948)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074027188903</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900740003811</subfield>
+      <subfield code="c">v.157-158 (May.-Aug.2011)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726550</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902150003811</subfield>
+      <subfield code="c">v.75 (Apr.-Jun. 1970)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074023042757</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900670003811</subfield>
+      <subfield code="c">v.150-151 (Oct. 2007-Jan. 7, 2008)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074023066830</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900650003811</subfield>
+      <subfield code="c">v.151 (Apr.7-Jun.30, 2008)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074025209925</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903480003811</subfield>
+      <subfield code="c">v.104 (Oct.-Dec. 1984)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726618</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902200003811</subfield>
+      <subfield code="c">v.73 (Apr.-Jun. 1969)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726592</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902220003811</subfield>
+      <subfield code="c">v.72 (Oct.-Dec. 1968)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726584</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902240003811</subfield>
+      <subfield code="c">v.71 (Apr.-Jun. 1968)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726691</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902260003811</subfield>
+      <subfield code="c">v.70 (Oct.-Dec. 1967)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726527</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902110003811</subfield>
+      <subfield code="c">v.77 (Apr.-Jun. 1971)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074024547440</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903460003811</subfield>
+      <subfield code="c">v.155 (Jan.-Mar.2010)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769543</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901980003811</subfield>
+      <subfield code="c">v.83 (Apr.-Jun. 1974)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726642</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902170003811</subfield>
+      <subfield code="c">v.74 (Oct.-Dec. 1969)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726600</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902190003811</subfield>
+      <subfield code="c">v.74 (Jul.-Sep. 1969)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726501</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902130003811</subfield>
+      <subfield code="c">v.76 (Oct.-Dec. 1970)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074024523748</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903510003811</subfield>
+      <subfield code="c">v.153 (Jan.12-Mar.30, 2009)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074024508319</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903530003811</subfield>
+      <subfield code="c">v.152-152/153 (Oct.6, 2008-Jan.5, 2009)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769428</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901940003811</subfield>
+      <subfield code="c">v.85 (Apr.-Jun. 1975)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769352</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901920003811</subfield>
+      <subfield code="c">v.86 (Oct.-Dec. 1975)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769444</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901960003811</subfield>
+      <subfield code="c">v.84 (Oct.-Dec. 1974)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726675</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902280003811</subfield>
+      <subfield code="c">v.69 (Apr.-Jun. 1967)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074027167840</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900780003811</subfield>
+      <subfield code="c">v.156 (Oct.2010-Jan.1, 2011)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074023033236</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900690003811</subfield>
+      <subfield code="c">v.150 (Jul.9-Sep.24, 2007)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311900640003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">stacks</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074011355757</subfield>
+      <subfield code="e">stacks</subfield>
+      <subfield code="8">23311900610003811</subfield>
+      <subfield code="c">v. 98 (Jul. - Dec. 1981)</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">AMBLER</subfield>
+      <subfield code="f">AMBLER</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311900640003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">stacks</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="e">stacks</subfield>
+      <subfield code="8">23311900630003811</subfield>
+      <subfield code="c">v.53:1959</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">AMBLER</subfield>
+      <subfield code="f">AMBLER</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074027180124</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900760003811</subfield>
+      <subfield code="c">v.158 (Sep.-Nov.2011)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074027195734</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900700003811</subfield>
+      <subfield code="c">v.159-160 (May.-Aug.2012)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074023025299</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900720003811</subfield>
+      <subfield code="c">v.149 (Apr.2-Jun.25, 2007)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769725</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901360003811</subfield>
+      <subfield code="c">v.117 (Apr.-Jun. 1991)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768867</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903030003811</subfield>
+      <subfield code="c">v.42 (Jul.-Sep. 1953)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770178</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901180003811</subfield>
+      <subfield code="c">v.130 (Jul.-Sep. 1997)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768743</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902860003811</subfield>
+      <subfield code="c">v.37 (Apr.-Jun. 1951)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770459</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901730003811</subfield>
+      <subfield code="c">v.97 (Jan.-Mar. 1981)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767562</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902670003811</subfield>
+      <subfield code="c">v.48 (Oct.-Dec. 1956)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769683</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901320003811</subfield>
+      <subfield code="c">v.122 (Oct.-Dec. 1993)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769386</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901900003811</subfield>
+      <subfield code="c">v.88 (Jul.-Sep. 1976)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769261</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901770003811</subfield>
+      <subfield code="c">v.93 (Jan.-Mar. 1979)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768008</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903420003811</subfield>
+      <subfield code="c">v.4 (Jul.-Dec. 1934)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768693</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903070003811</subfield>
+      <subfield code="c">v.27 (Apr.-Jun. 1946)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768644</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902820003811</subfield>
+      <subfield code="c">v.39 (Apr.-Jun. 1952)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769147</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903290003811</subfield>
+      <subfield code="c">v.16 (Jul.-Dec. 1940)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769782</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901510003811</subfield>
+      <subfield code="c">v.109 (Apr.-Jun. 1987)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726352</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901550003811</subfield>
+      <subfield code="c">v.107 (Apr.-Jun. 1986)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769063</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903210003811</subfield>
+      <subfield code="c">v.20 (Jul.-Sep. 1942)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726378</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901590003811</subfield>
+      <subfield code="c">v.105 (Jan.-Mar. 1985)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769030</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903250003811</subfield>
+      <subfield code="c">v.18 (Jul.-Sep. 1941)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727640</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900930003811</subfield>
+      <subfield code="c">v.142 (Oct.-Dec. 2003) Special Issue</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727608</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900970003811</subfield>
+      <subfield code="c">v.140 (Oct.-Dec. 2002)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767687</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902700003811</subfield>
+      <subfield code="c">v.47 (Jan.-Mar. 1956)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769584</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901210003811</subfield>
+      <subfield code="c">v.129 (Jan.-Mar. 1997)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767489</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902630003811</subfield>
+      <subfield code="c">v.50 (Jul.-Sep. 1957)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770095</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901100003811</subfield>
+      <subfield code="c">v.134 (Jul.-Sep. 1999)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770053</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901140003811</subfield>
+      <subfield code="c">v.132 (Jul.-Sep. 1998)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767372</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902560003811</subfield>
+      <subfield code="c">v.54 (Jul.-Sep. 1959)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767414</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902520003811</subfield>
+      <subfield code="c">v.56 (Jul.-Sep. 1960)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767448</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902490003811</subfield>
+      <subfield code="c">v.57 (Apr.-Jun. 1961)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767299</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902410003811</subfield>
+      <subfield code="c">v.61 (Apr.-Jun. 1963)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767273</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902450003811</subfield>
+      <subfield code="c">v.59 (Apr.-Jun. 1962)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769873</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901440003811</subfield>
+      <subfield code="c">v.113 (Jan.-Mar. 1989)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769881</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901430003811</subfield>
+      <subfield code="c">v.114 (Oct.-Dec. 1989)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769857</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901460003811</subfield>
+      <subfield code="c">v.112 (Jul.-Sep. 1988)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769295</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901820003811</subfield>
+      <subfield code="c">v.91 (Jan.-Mar. 1978)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768586</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902750003811</subfield>
+      <subfield code="c">v.44 (Jul.-Sep. 1954)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768610</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902770003811</subfield>
+      <subfield code="c">v.43 (Apr.-Jun. 1954)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769238</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901800003811</subfield>
+      <subfield code="c">v.92 (Jul.-Sep. 1978)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768602</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902740003811</subfield>
+      <subfield code="c">v.44 (Oct.-Dec. 1954)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769360</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901850003811</subfield>
+      <subfield code="c">v.87 (Jan.-Mar. 1976)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769162</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903340003811</subfield>
+      <subfield code="c">v.11 (Jan.-Jun. 1938)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767661</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902720003811</subfield>
+      <subfield code="c">v.45 (Apr.-Jun. 1955)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769527</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902000003811</subfield>
+      <subfield code="c">v.82 (Oct.-Dec. 1973)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769139</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903320003811</subfield>
+      <subfield code="c">v.13 (Jan.-Mar. 1939)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769741</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901410003811</subfield>
+      <subfield code="c">v.115 (Jan.-Mar. 1990)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769204</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903370003811</subfield>
+      <subfield code="c">v.8 (Jul.-Dec. 1936)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769824</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901490003811</subfield>
+      <subfield code="c">v.111 (Jan.-Mar. 1988)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769154</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903310003811</subfield>
+      <subfield code="c">v.13 (Apr.-Jun. 1939)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769568</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902060003811</subfield>
+      <subfield code="c">v.80 (Jul.-Sep. 1972)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074017488610</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900900003811</subfield>
+      <subfield code="c">v.144 (Jul.-Sep. 2004)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727434</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900920003811</subfield>
+      <subfield code="c">v.143 (Jan.-Mar. 2004)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726725</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902310003811</subfield>
+      <subfield code="c">Index 67-70</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900810003811</subfield>
+      <subfield code="c">v.3:1934</subfield>
+      <subfield code="a">12</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767984</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903390003811</subfield>
+      <subfield code="c">v.7 (Jan.-Mar. 1936)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769451</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902080003811</subfield>
+      <subfield code="c">v.79 (Jan.-Mar. 1972)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769410</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901870003811</subfield>
+      <subfield code="c">v.89 (Jan.-Mar. 1977)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767315</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902390003811</subfield>
+      <subfield code="c">v.63 (Jan.-Mar. 1964)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727590</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900980003811</subfield>
+      <subfield code="c">v.140 (Jul.-Sep. 2002)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727426</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901020003811</subfield>
+      <subfield code="c">v.138 (Jul.-Sep. 2001)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770087</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901110003811</subfield>
+      <subfield code="c">v.133 (Apr.-Jun.1999) Special Edition</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770061</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901130003811</subfield>
+      <subfield code="c">v.132 (Oct.-Dec. 1998)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074017493164</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900870003811</subfield>
+      <subfield code="c">v.145 (Apr.-Jun. 2005)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727459</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900890003811</subfield>
+      <subfield code="c">v.144 (Oct.-Dec. 2004)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727574</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901000003811</subfield>
+      <subfield code="c">v.139 (Apr.-Jun. 2002)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767265</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902440003811</subfield>
+      <subfield code="c">v.60 (Jul.-Sep. 1962)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770012</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901080003811</subfield>
+      <subfield code="c">v.135 (Jan.-Mar. 2000)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726741</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902330003811</subfield>
+      <subfield code="c">v.67 (Jan.-Mar. 1966)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767281</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902420003811</subfield>
+      <subfield code="c">v.61 (Jan.-Mar. 1963)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768727</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902880003811</subfield>
+      <subfield code="c">v.36 (Oct.-Dec. 1950)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768883</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903010003811</subfield>
+      <subfield code="c">v.30 (Jul.-Sep. 1947)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769717</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901350003811</subfield>
+      <subfield code="c">v.121 (Jan.-Mar. 1993)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769774</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901380003811</subfield>
+      <subfield code="c">v.116 (Oct.-Dec. 1990)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770517</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901710003811</subfield>
+      <subfield code="c">v.98 (Jul.-Sep. 1981)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770038</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901160003811</subfield>
+      <subfield code="c">v.131 (Jan.-Mar. 1998)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020770491</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901740003811</subfield>
+      <subfield code="c">v.95 (May-Jun. 1980)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768925</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903040003811</subfield>
+      <subfield code="c">v.29 (Jan.-Mar. 1947)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726451</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902660003811</subfield>
+      <subfield code="c">v.49 (Jan.-Mar. 1957)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767547</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902690003811</subfield>
+      <subfield code="c">v.47 (Apr.-Jun. 1956)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769006</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903090003811</subfield>
+      <subfield code="c">v.26 (Oct.-Dec. 1945)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769592</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901300003811</subfield>
+      <subfield code="c">v.124 (Oct.-Nov. 1993)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769246</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901790003811</subfield>
+      <subfield code="c">v.92 (Nov.-Dec. 1978)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767976</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903400003811</subfield>
+      <subfield code="c">v.6 (Jul.-Dec. 1935)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768669</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902800003811</subfield>
+      <subfield code="c">v.41 (Jan.-Mar. 1953)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020768636</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902830003811</subfield>
+      <subfield code="c">v.39 (Jan.-Mar. 1952)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726337</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901520003811</subfield>
+      <subfield code="c">v.109 (Jan.-Mar. 1987)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726394</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901570003811</subfield>
+      <subfield code="c">v.106 (Oct.-Dec. 1985)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769055</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903230003811</subfield>
+      <subfield code="c">v.19 (Apr.-Jun. 1942)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769022</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903260003811</subfield>
+      <subfield code="c">v.18 (Oct.-Dec. 1941)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726568</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902140003811</subfield>
+      <subfield code="c">v.76 (Jul.-Sep. 1970)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767430</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902500003811</subfield>
+      <subfield code="c">v.57 (Jan.-Mar. 1961)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074017515362</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900840003811</subfield>
+      <subfield code="c">v.147 (Jan.-Mar. 2006)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020726576</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902250003811</subfield>
+      <subfield code="c">v.71 (Jan.-Mar. 1968)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727616</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900950003811</subfield>
+      <subfield code="c">v.141 (Apr.-Jun. 2003)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767505</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902610003811</subfield>
+      <subfield code="c">v.51 (Apr.-Jun. 1958)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074024551913</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311903450003811</subfield>
+      <subfield code="c">v.155 (Apr.-Jul.5, 2010)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769493</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902030003811</subfield>
+      <subfield code="c">v.81 (Jan.-Mar. 1973)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767463</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902470003811</subfield>
+      <subfield code="c">v.58 (Oct.-Dec. 1961)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020769345</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901930003811</subfield>
+      <subfield code="c">v.86 (Jul.-Sep. 1975)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020727541</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311901050003811</subfield>
+      <subfield code="c">v.136 (Oct.-Dec. 2000)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767539</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902580003811</subfield>
+      <subfield code="c">v.53 (Apr.-Jun. 1959)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074020767349</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311902360003811</subfield>
+      <subfield code="c">v.64 (Oct.-Dec. 1964)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311900640003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">stacks</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074011355708</subfield>
+      <subfield code="e">stacks</subfield>
+      <subfield code="8">23311900620003811</subfield>
+      <subfield code="c">v.97 (Jan. - June 1981)</subfield>
+      <subfield code="a">0</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">AMBLER</subfield>
+      <subfield code="f">AMBLER</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="ITM">
+      <subfield code="r">22311903550003811</subfield>
+      <subfield code="b">1</subfield>
+      <subfield code="h">0</subfield>
+      <subfield code="g">p_remote</subfield>
+      <subfield code="t">ISSUE</subfield>
+      <subfield code="9">39074027801000</subfield>
+      <subfield code="e">p_remote</subfield>
+      <subfield code="8">23311900730003811</subfield>
+      <subfield code="c">v.159 (Jan.-Apr.2012)</subfield>
+      <subfield code="a">2</subfield>
+      <subfield code="q">2017-06-20 11:31:38</subfield>
+      <subfield code="i">AP2 .N6772</subfield>
+      <subfield code="d">KARDON</subfield>
+      <subfield code="f">KARDON</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -644,6 +644,37 @@ RSpec.describe Traject::Macros::Custom do
     end
   end
 
+  describe "#extract_genre_display" do
+    before do
+      subject.instance_eval do
+        to_field "genre_display", extract_genre_display
+        settings do
+          provide "marc_source.type", "xml"
+        end
+      end
+    end
+
+    context "when a record doesn't have genres" do
+      let(:path) { "genre_display.xml" }
+      it "does not map a genre_display" do
+        expect(subject.map_record(records[0])).to eq({})
+      end
+    end
+
+    context "when a record has genres" do
+      let(:path) { "genre_display.xml" }
+      it "maps data from 655 fields in expected way" do
+        expected = [
+          "Documentary films",
+          "Foreign language films — Chinese"
+        ]
+        expect(subject.map_record(records[1])).to eq(
+          "genre_display" => expected
+        )
+      end
+    end
+  end
+
   describe "#extract_subject_topic_facet" do
     before do
       subject.instance_eval do


### PR DESCRIPTION
Genre fields were previously included in the subject_display field on individual record pages.  
- separates genre from subject and gives them their own display field
- new helper method and facet_field created to generate exact links for genres from a record page (display mappings are different than the current genre_facet mappings and need to remain different)
- removes genre fields from subject_facets so that they are not included in advanced subject searches
- Adds a new dropdown option for genre advanced search