### PR TITLE
BL-747 Remove item limits from request descriptions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tulibraries/alma_rb.git
-  revision: 48db945998a3e41db95c82cf64e89d391b2b430b
+  revision: bff94514f426dcbc5d4c89cf6a14d1d2816a234d
   branch: master
   specs:
     alma (0.2.8)
@@ -220,7 +220,8 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.1.1)
     http_parser.rb (0.6.0)
-    httparty (0.16.2)
+    httparty (0.16.3)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (1.1.1)
@@ -268,6 +269,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mimemagic (0.3.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)

--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -109,8 +109,7 @@ module CobAlma
     end
 
     def self.descriptions(items_list)
-      descriptions = items_list.map { |item| item["item_data"]["description"] }
-
+      descriptions = items_list.all.map(&:description)
       if descriptions.any?
         descriptions.each do |desc|
           desc

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,7 +52,7 @@ RSpec.configure do |config|
         body: File.open(SPEC_ROOT + "/fixtures/alma_data/bib_items_ambler_only.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/.*\/holdings\/.*\/items/).
-        with(query: hash_including({offset: "100" })).
+        with(query: hash_including(offset: "100")).
         to_return(status: 200,
         body: JSON.dump({}))
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,11 @@ RSpec.configure do |config|
         to_return(status: 200,
         body: File.open(SPEC_ROOT + "/fixtures/alma_data/bib_items_ambler_only.json"))
 
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/.*\/holdings\/.*\/items/).
+        with(query: hash_including({offset: "100" })).
+        to_return(status: 200,
+        body: JSON.dump({}))
+
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/same_campus\/holdings\/.*\/items/).
         to_return(status: 200,
         body: File.open(SPEC_ROOT + "/fixtures/alma_data/presser_and_paley.json"))


### PR DESCRIPTION
Currently we are limited to only 100 item descriptions, so if a patron wants to request something from a larger set of records, they may not be able to choose the item they want.  This now returns all items in the request dropdown menus.