### PR TITLE
[DevOps] Allow multiple ingest of the same file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ You can also pass in their path to a separate file you would like to ingest as a
 bundle exec rake ingest[/some/other/path.xml]
 ```
 
+If you need to ingest a file multiple times locally an not have it rejected by SOLR do to update_date you can set `SOLR_DISABLE_UPDATE_DATE_CHECK=yes`:
+
+```bash
+SOLR_DISABLE_UPDATE_DATE_CHECK=yes rake ingest[spec/fixtures/purchase_online_bibs.xml]
+```
 
 Under the hood, that command uses [traject](https://github.com/traject/traject), with hard coded defaults. If you need to override a default to ingest your data, You can call traject directly:
 

--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -263,4 +263,8 @@ each_record do |record, context|
   if context.output_hash["record_update_date"].nil? || context.output_hash["record_update_date"] == []
     context.output_hash["record_update_date"] = ["2002-02-02 02:02:02"]
   end
+
+  if ENV["SOLR_DISABLE_UPDATE_DATE_CHECK"] == "yes"
+    context.output_hash["record_update_date"] = [ Time.now.to_s ]
+  end
 end


### PR DESCRIPTION
Now that we have configured solr to check the update date before
ingesting a file, it has been necessary locally to dump our solr
document before doing a re-ingest.  This step can become cumbersome if
we need to ingest the same file many times over during a development
session.

This commit adds a way to override this feature by setting the update
date to the current Time, thus guarantying that the update date is
always newer and effectively disable the Solr feature.