### PR TITLE
BL-357 Show requested status for availability

### DIFF
--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -6,7 +6,7 @@ module AlmaDataHelper
   PHYSICAL_TYPE_EXCLUSIONS = /BOOK|ISSUE|SCORE|KIT|MAP|ISSBD|GOVRECORD|OTHER/i
 
   def availability_status(item)
-    if item.in_place?
+    if item.in_place? && item.item_data["requested"] == false
       if item.non_circulating?
         content_tag(:span, "", class: "check") + "Library Use Only"
       else
@@ -18,9 +18,13 @@ module AlmaDataHelper
   end
 
   def unavailable_items(item)
-    if item.has_process_type?
+    if item.item_data["requested"] == true
+      process_type = "Requested"
+      content_tag(:span, "", class: "close-icon") + process_type
+    elsif item.has_process_type?
       process_type = Rails.configuration.process_types[item.process_type] || "Checked out or currently unavailable"
       content_tag(:span, "", class: "close-icon") + process_type
+
     else
       content_tag(:span, "", class: "close-icon") + "Checked out or currently unavailable"
     end

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe AlmaDataHelper, type: :helper do
            { "base_status" =>
              { "value" => "1" },
              "policy" =>
-             { "desc" => "Non-circulating" }
+             { "desc" => "Non-circulating" },
+             "requested" => false,
            }
          )
       end
@@ -20,13 +21,31 @@ RSpec.describe AlmaDataHelper, type: :helper do
       end
     end
 
+    context "item base_status is 1 and item is requested" do
+      let(:item) do
+        Alma::BibItem.new("item_data" =>
+           { "base_status" =>
+             { "value" => "1" },
+             "policy" =>
+             { "desc" => "Non-circulating" },
+             "requested" => true,
+           }
+         )
+      end
+
+      it "displays requested" do
+        expect(availability_status(item)).to eq "<span class=\"close-icon\"></span>Requested"
+      end
+    end
+
     context "item base_status is 1" do
       let(:item) do
         Alma::BibItem.new("item_data" =>
            { "base_status" =>
              { "value" => "1" },
              "policy" =>
-             { "desc" => "" }
+             { "desc" => "" },
+             "requested" => false,
            }
          )
       end
@@ -69,6 +88,18 @@ RSpec.describe AlmaDataHelper, type: :helper do
       end
     end
 
+    context "item is requested" do
+      let(:item) do
+        Alma::BibItem.new("item_data" =>
+           { "requested" => true }
+         )
+      end
+
+      it "displays requested" do
+        expect(unavailable_items(item)).to eq "<span class=\"close-icon\"></span>Requested"
+      end
+    end
+
     context "item includes process_type not found in mappings" do
       let(:item) do
         Alma::BibItem.new("item_data" =>
@@ -78,6 +109,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
            }
          )
       end
+
       it "displays default message" do
         expect(unavailable_items(item)).to eq "<span class=\"close-icon\"></span>Checked out or currently unavailable"
       end
@@ -91,6 +123,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
            }
          )
       end
+
       it "displays default message" do
         expect(unavailable_items(item)).to eq "<span class=\"close-icon\"></span>Checked out or currently unavailable"
       end


### PR DESCRIPTION
A bug in the alma api was preventing us from being able to use the requested boolean key in item_data.  The December release fixed the issue, so we can now display requested items as unavailable.