### PR TITLE
[BL-726] Add az-database.

### DIFF
--- a/.docker/solr/Dockerfile
+++ b/.docker/solr/Dockerfile
@@ -1,2 +1,3 @@
 FROM solr:6.6.1
 COPY ./solr/conf /opt/solr/conf
+RUN precreate-core az-database /opt/solr/conf

--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ gem "httparty"
 gem "breadcrumbs_on_rails"
 
 gem "traject", "~> 3.0"
+gem "traject_plus"
 
 group :production do
   gem "mysql2", "~> 0.4.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,9 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
+    jsonpath (0.9.7)
+      multi_json
+      to_regexp (~> 0.2.1)
     jwt (1.5.6)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -432,6 +435,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    to_regexp (0.2.1)
     traject (3.0.0)
       concurrent-ruby (>= 0.8.0)
       dot-properties (>= 0.1.1)
@@ -443,6 +447,10 @@ GEM
       nokogiri (~> 1.0)
       slop (>= 3.4.5, < 4.0)
       yell
+    traject_plus (0.1.0)
+      activesupport
+      jsonpath
+      traject (~> 3.0)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -542,6 +550,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   sqlite3
   traject (~> 3.0)
+  traject_plus
   turbolinks (~> 5)
   twilio-ruby
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -202,3 +202,12 @@ can also provide a path  and filename with the `--save_to` command line flag.
 ```
 
 
+#### Ingest LibGuide AZ documents
+Locally you will need to add 'az-database' core to solr (handled automatically for docker/libqa/production)
+
+Ingest AZ database documents by running
+
+```
+./bin/libguide_cache.rb
+./bin/ingest-libguides.sh
+```

--- a/app/controllers/databases_advanced_controller.rb
+++ b/app/controllers/databases_advanced_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class DatabasesAdvancedController < AdvancedController
+  copy_blacklight_config_from(DatabasesController)
+
+  add_breadcrumb "Databases", :back_to_databases_path, options: { id: "breadcrumbs_databases" }
+  add_breadcrumb I18n.t(:databases_advanced_search), :databases_advanced_search_path,
+    only: [ :index ]
+
+  protected
+    def search_action_url(options = {})
+      databases_advanced_search_path(options.merge(action: "index"))
+    end
+end

--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class DatabasesController < CatalogController
+  include CatalogConfigReinit
+
+  helper_method :join
+
+  add_breadcrumb "Databases", :back_to_databases_path, options: { id: "breadcrumbs_database" }, only: [ :show ]
+  add_breadcrumb "Record", :solr_database_document_path, only: [ :show ]
+
+  configure_blacklight do |config|
+    config.document_model = SolrDatabaseDocument
+    config.connection_config = config.connection_config.dup
+    config.connection_config[:url] = config.connection_config[:az_url]
+    config.default_solr_params = {
+        wt: "json",
+        fl: %w[
+          *
+          url_finding_aid_display:[json]
+          url_more_links_display:[json]
+          electronic_resource_display:[json] ].join(",")
+    }
+
+
+    # Facet fields
+    config.add_facet_field "availability_facet", label: "Availability", home: true, collapse: false
+    config.add_facet_field "subject_facet", label: "Subject", limit: true, show: true
+    config.add_index_field "availability"
+
+    # Index fields
+    config.add_index_field "id", label: "AZ ID"
+    config.add_index_field "az_vendor_id_display", label: "AZ Vendor ID"
+    config.add_index_field "note_display", label: "Note", raw: true, helper_method: :join
+
+    # Show fields
+    config.add_show_field "id", label: "AZ ID"
+    config.add_show_field "note_display", label: "Note", raw: true, helper_method: :join
+    config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :check_for_full_http_link, if: false
+
+    # Search fields
+    config.add_search_field("title") do |field|
+      # solr_parameters hash are sent to Solr as ordinary url query params.
+      field.solr_parameters = { 'spellcheck.dictionary': "title" }
+      field.solr_local_parameters = {
+        qf: "$title_qf",
+        pf: "$title_pf"
+      }
+    end
+
+    config.add_search_field("subject") do |field|
+      field.solr_parameters = { 'spellcheck.dictionary': "subject" }
+      field.qt = "search"
+      field.solr_local_parameters = {
+        qf: "$subject_qf",
+        pf: "$subject_pf"
+      }
+    end
+  end
+
+  def join(args)
+    args[:value].join
+  end
+end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -12,7 +12,7 @@ class SearchController < CatalogController
   def index
     @per_page = 3
     if params[:q]
-      engines = %i( books articles journals more )
+      engines = %i( books articles journals databases more )
       searcher = BentoSearch::ConcurrentSearcher.new(*engines)
       searcher.search(params[:q], per_page: @per_page, semantic_search_field: params[:field])
       @results = split_more(searcher.results)

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -75,6 +75,9 @@ module AdvancedHelper
     elsif current_page? search_path
       id = :articles_advanced_search
       url = articles_advanced_search_path(query)
+    elsif current_page? search_databases_path
+      id = :databases_advanced_search
+      url = databases_advanced_search_path(query)
     end
 
     link_to(t(id), url, class: "advanced_search", id: id) if id
@@ -103,6 +106,8 @@ module AdvancedHelper
       t(:journals_advanced_search)
     elsif current_page? articles_advanced_search_path
       t(:articles_advanced_search)
+    elsif current_page? databases_advanced_search_path
+      t(:databases_advanced_search)
     else
       t(:catalog_advanced_search)
     end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -175,6 +175,10 @@ module CatalogHelper
     search_path(search_params)
   end
 
+  def back_to_databases_path
+    search_databases_path(search_params)
+  end
+
   def get_search_params(field, query)
     case field
     when "title_uniform_display", "title_addl_display"

--- a/app/models/solr_database_document.rb
+++ b/app/models/solr_database_document.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class SolrDatabaseDocument < SolrDocument
+  use_extension(Blacklight::Document::Email)
+  use_extension(Blacklight::Document::Sms)
+end

--- a/app/search_engines/bento_search/databases_engine.rb
+++ b/app/search_engines/bento_search/databases_engine.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module BentoSearch
+  class DatabasesEngine < BlacklightEngine
+    delegate :blacklight_config, to: DatabasesController
+
+    def doc_link(id)
+      Rails.application.routes.url_helpers.solr_database_document_path(id)
+    end
+
+    def url(helper)
+      params = helper.params
+      helper.search_databases_path(q: params[:q])
+    end
+
+    def view_link(total = nil, helper)
+      url = url(helper)
+      helper.link_to "View all #{total} databases", url, class: "full-results"
+    end
+  end
+end

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -6,6 +6,7 @@
           <%= render_nav_link(:everything_path, "Everything", "navbar_everything") %>
           <%= render_nav_link(:search_books_path, "Books", "navbar_books") %>
           <%= render_nav_link(:search_path, "Articles", "navbar_articles") %>
+          <%= render_nav_link(:search_databases_path, "Databases", "navbar_databases") %>
           <%= render_nav_link(:search_journals_path, "Journals", "navbar_journals") %>
           <%= render_nav_link(:search_catalog_path, "More", "navbar_more") %>
         </ul>

--- a/app/views/bento_search/_no_database_results.html.erb
+++ b/app/views/bento_search/_no_database_results.html.erb
@@ -1,0 +1,4 @@
+<h3><%= t("no_results.title", engine: "database") %></h3>
+<hr />
+
+TBD

--- a/bin/ingest-libguides.sh
+++ b/bin/ingest-libguides.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/env bash
+
+SOLR_URL=$SOLR_AZ_URL SOLR_DISABLE_UPDATE_DATE_CHECK=yes traject -c lib/traject/databases_az_indexer_config.rb tmp/cache/databases.json
+
+curl $SOLR_AZ_URL/update?commit=true

--- a/bin/libguide_cache.rb
+++ b/bin/libguide_cache.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+#
+# A script for retrieving a local repository of libguide databases.
+#
+
+require "httparty"
+
+client_id = ENV["AZ_CLIENT_ID"]
+client_secret = ENV["AZ_CLIENT_SECRET"]
+endpoint = "https://lgapi-us.libapps.com/1.2/oauth/token"
+
+response = HTTParty.post(endpoint, body: { client_id: client_id, client_secret: client_secret, grant_type: "client_credentials" })
+cred = JSON.parse(response)
+
+endpoint = "https://lgapi-us.libapps.com/1.2/az"
+token = cred["access_token"]
+response = HTTParty.get(endpoint, headers: { Authorization: "Bearer #{token}" }, query: { expand: "subjects,icons,friendly_url,az_types,az_props,permitted_uses" })
+
+File.open "tmp/cache/databases.json", "w+" do |file|
+  file.write(response.body)
+end

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -13,9 +13,12 @@
 development:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core-dev" %>
+  az_url: <%= ENV['SOLR_AZ_URL'] || "http://127.0.0.1:8983/solr/az-database" %>
 test: &test
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8985}/solr/blacklight-core-test" %>
+  az_url: <%= ENV['SOLR_AZ_URL'] || "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8985}/solr/az-database" %>
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+  az_url: <%= ENV['SOLR_AZ_URL'] || "http://127.0.0.1:8983/solr/az-database" %>

--- a/config/initializers/bento_search.rb
+++ b/config/initializers/bento_search.rb
@@ -23,6 +23,14 @@ BentoSearch.register_engine("books") do |conf|
   end
 end
 
+BentoSearch.register_engine("databases") do |conf|
+  conf.engine = "BentoSearch::DatabasesEngine"
+  conf.for_display do |display|
+    display.decorator = "TulDecorator"
+    display.no_results_partial = "bento_search/no_database_results"
+  end
+end
+
 BentoSearch.register_engine("more") do |conf|
   conf.engine = "BentoSearch::MoreEngine"
   conf.for_display do |display|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,6 +147,7 @@ en:
   books_advanced_search: "Advanced Books Search"
   journals_advanced_search: "Advanced Journals Search"
   articles_advanced_search: "Advanced Articles Search"
+  databases_advanced_search: "Advanced Databases Search"
   ask_librarian: "Ask a Librarian"
 
   no_results:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   # advanced forms
   match "/books/advanced", to: "books_advanced#index", as: "books_advanced_search", via: [:get, :post]
   match "journals/advanced", to: "journals_advanced#index", as: "journals_advanced_search", via: [:get, :post]
+  match "databases/advanced", to: "databases_advanced#index", as: "databases_advanced_search", via: [:get, :post]
   match "articles/advanced", to: "primo_advanced#index", as: "articles_advanced_search", via: [:get, :post]
   match "catalog/advanced", to: "advanced#index", as: "advanced_search", via: [:get, :post]
   match "catalog/:id/purchase_order", to: "catalog#purchase_order_action", via: [:post], as: "purchase_order_action"
@@ -36,6 +37,11 @@ Rails.application.routes.draw do
     concerns :range_searchable
   end
 
+  resource :databases, only: [:index], as: "databases", path: "/databases", controller: "databases" do
+    concerns :searchable
+    concerns :range_searchable
+  end
+
   resources :solr_documents, only: [:show], path: "/catalog", controller: "catalog" do
     concerns :exportable
   end
@@ -45,6 +51,10 @@ Rails.application.routes.draw do
   end
 
   resources :solr_journal_documents, only: [:show], path: "/journals", controller: "journals" do
+    concerns :exportable
+  end
+
+  resources :solr_database_documents, only: [:show], path: "/databases", controller: "databases" do
     concerns :exportable
   end
 
@@ -64,6 +74,7 @@ Rails.application.routes.draw do
   post "articles/:id/track" => "primo_central#track", as: :track_primo_central
   post "books/:id/track" => "book#track"
   post "journals/:id/track" => "journal#track"
+  post "databases/:id/track" => "databases#track"
 
   devise_for :users, controllers: { sessions: "sessions", omniauth_callbacks: "users/omniauth_callbacks" }
 
@@ -98,6 +109,7 @@ Rails.application.routes.draw do
   get "catalog/:id/index_item", to: "catalog#index_item", as: "index_item"
   get "books/:id/index_item", to: "books#index_item", as: "book_item"
   get "journals/:id/index_item", to: "journals#index_item", as: "journal_item"
+  get "databases/:id/index_item", to: "databases#index_item", as: "database_item"
   get "articles/:id/index_item", to: "primo_central#index_item", as: "articles_index_item"
   get "catalog/:id/purchase_order", to: "catalog#purchase_order", as: "purchase_order"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       SOLR_SEARCH_TWEAK_ENABLE: "on"
       SOLR_URL: "http://solr:8983/solr/blacklight"
+      SOLR_AZ_URL: "http://solr:8983/solr/az-database"
       LC_ALL: "C.UTF-8"
     labels:
       - "traefik.enable=true"

--- a/lib/traject/databases_az_indexer_config.rb
+++ b/lib/traject/databases_az_indexer_config.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "traject_plus"
+require "traject_plus/json_reader.rb"
+require "traject_plus/macros"
+require "traject_plus/macros/json"
+
+extend TrajectPlus::Macros
+extend TrajectPlus::Macros::JSON
+
+solr_config = YAML.load_file("config/blacklight.yml")[(ENV["RAILS_ENV"] || "development")]
+
+solr_url = ERB.new(solr_config["url"]).result
+
+settings do
+  provide "reader_class_name", "TrajectPlus::JsonReader"
+  provide "solr_writer.commit_timeout", (15 * 60)
+  provide "solr.url", solr_url
+  provide "solr_writer.commit_on_close", "false"
+
+  # set this to be non-negative if threshold should be enforced
+  provide "solr_writer.max_skipped", -1
+end
+
+each_record do |record, context|
+  if record["enable_hidden"].to_s == "1"
+    context.skip!("Skipping hidden database.")
+  end
+end
+
+to_field "id", extract_json("$.id")
+to_field "format", ->(rec, acc) { acc << "Database" }
+to_field "title_t", extract_json("$.name")
+to_field "title_statement_display", extract_json("$.name")
+to_field "az_vendor_id_display", extract_json("$.az_vendor_id")
+
+to_field "note_display", extract_json("$.description")
+to_field "note_t", extract_json("$.description")
+to_field "availability_facet", -> (rec, acc) {
+  if rec["enable_trial"].to_s == "1"
+    acc << "Trial"
+  end
+}
+
+to_field "electronic_resource_display", -> (rec, acc) {
+  url =
+    if rec.dig("meta", "enable_proxy") == 1
+      "http://libproxy.temple.edu/login?url=#{rec['url']}"
+    else
+      rec["url"]
+    end
+  acc << { title: rec["name"], url: url }.to_json
+}
+
+to_field "record_update_date", extract_json("$.updated")
+
+to_field "subject_display", -> (rec, acc) {
+  rec["subjects"]&.each { |subject| acc << subject["name"] }
+}
+
+to_field "subject_facet", -> (rec, acc) {
+  rec["subjects"]&.each { |subject| acc << subject["name"] }
+}
+
+each_record do |record, context|
+  if ENV["SOLR_DISABLE_UPDATE_DATE_CHECK"] == "yes"
+    context.output_hash["record_update_date"] = [ Time.now.to_s ]
+  end
+end

--- a/spec/controllers/databases_advanced_controller_spec.rb
+++ b/spec/controllers/databases_advanced_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DatabasesAdvancedController, type: :controller do
+
+  it "overrides the document model" do
+    expect(controller.blacklight_config.document_model).to eq(SolrDatabaseDocument)
+  end
+
+  it "overrides the search_action_url" do
+    expect(controller.send(:search_action_url)).to eq("/databases/advanced")
+  end
+
+  it "overrides the config connection url" do
+    url = controller.blacklight_config.connection_config[:url]
+    az_url = controller.blacklight_config.connection_config[:az_url]
+    expect(url).to eq(az_url)
+  end
+end

--- a/spec/controllers/databases_controller_spec.rb
+++ b/spec/controllers/databases_controller_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DatabasesController, type: :controller do
+  it "overrides the document model" do
+    expect(controller.blacklight_config.document_model).to eq(SolrDatabaseDocument)
+  end
+
+  it "overrides the config connection url" do
+    url = controller.blacklight_config.connection_config[:url]
+    az_url = controller.blacklight_config.connection_config[:az_url]
+    expect(url).to eq(az_url)
+  end
+end

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe AdvancedHelper, type: :helper do
       allow(helper).to receive(:current_page?).with("/books") { false }
       allow(helper).to receive(:current_page?).with("/journals") { false }
       allow(helper).to receive(:current_page?).with("/articles") { false }
+      allow(helper).to receive(:current_page?).with("/databases") { false }
       allow(helper).to receive(:params) { { q: "foo", controller: "bar" } }
     end
 
@@ -82,6 +83,14 @@ RSpec.describe AdvancedHelper, type: :helper do
       it "renders the link to the advanced articles form" do
         allow(helper).to receive(:current_page?).with("/articles") { true }
         link = "<a class=\"advanced_search\" id=\"articles_advanced_search\" href=\"/articles/advanced?q=foo\">Advanced Articles Search</a>"
+        expect(helper.render_advanced_search_link).to eq(link)
+      end
+    end
+
+    context "on the databases search page" do
+      it "renders the link to the advanced databases form" do
+        allow(helper).to receive(:current_page?).with("/databases") { true }
+        link = "<a class=\"advanced_search\" id=\"databases_advanced_search\" href=\"/databases/advanced?q=foo\">Advanced Databases Search</a>"
         expect(helper.render_advanced_search_link).to eq(link)
       end
     end
@@ -137,6 +146,7 @@ RSpec.describe AdvancedHelper, type: :helper do
       allow(helper).to receive(:current_page?).with("/books/advanced") { false }
       allow(helper).to receive(:current_page?).with("/journals/advanced") { false }
       allow(helper).to receive(:current_page?).with("/articles/advanced") { false }
+      allow(helper).to receive(:current_page?).with("/databases/advanced") { false }
     end
 
     context "on the advanced catalog search page" do
@@ -167,11 +177,19 @@ RSpec.describe AdvancedHelper, type: :helper do
       end
     end
 
+    context "on the advanced databases page" do
+      it "renders the link to the databasees search" do
+        allow(helper).to receive(:current_page?).with("/databases/advanced") { true }
+        expect(helper.advanced_search_form_title).to eq("Advanced Databases Search")
+      end
+    end
+
     context "on some unknown page" do
       it "renders the link to the everything search" do
         allow(helper).to receive(:current_page?).with("/foo/advanced") { true }
         expect(helper.advanced_search_form_title).to eq("Advanced Search")
       end
     end
+
   end
 end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe CatalogHelper, type: :helper do
     let(:doc) { SolrDocument.new(purchase_order: true) }
     let(:presenter) { CatalogIndexPresenter.new(doc, self) }
     let(:blacklight_config) { CatalogController.blacklight_config }
-    let(:user) { FactoryBot.create(:user) }
+    let(:user) { FactoryBot.build(:user) }
 
     before(:each) do
       allow(presenter).to receive(:purchase_order_button) { "purchase_order_button" }


### PR DESCRIPTION
In addition to the catalog and the article index, we are next going to integrate the Databases A-Z list into Blacklight. The existing Databases A-Z list is found in [http://guides.temple.edu/az.php] and is built on a Springshare platform. That interface offers both search and browse – we will be focusing on implementing/replicating just the *search*.

  The major components of this are:

  * Adding a column for Databases to the bento box design
  * Adding a "Databases" menu option in navigation menu
  * Adding Databases search interface, with facet and advanced search options

  The most important use case is searching for known database titles, such as "JStor" or "Academic Search Complete," which are not included in the Alma catalog.

  +Requirements+

  * Connect with Springshare API and replicate search results in Blacklight
  * Define and implement metadata mappings for record displays and facets in Blacklight, which does not need to be a one-to-one match with the catalog/article index (see attachment)
  * Once the above requirements have been completed, integrate with the rest of Blacklight site, including the bento box and navigation menu (may want to consult with Jackie)

  A-Z resources API info is found at [https://temple.libapps.com/libguides/api.php] (need an account with correct permissions)

  +Additional options+ (not core requirements)

  * Adding the "Best Bets" option used in the A-Z list – Once all of the above is done, we can create a separate task or sub-task for this.