### PR TITLE
[BL-347:769] Remove dash for electronic resource.

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -266,12 +266,16 @@ module CatalogHelper
   def electronic_resource_link_builder(field)
     return if field.empty?
     return if field["availability"] == "Not Available"
+
     title = field.fetch("title", "Find it online")
-
     electronic_notes = render_electronic_notes(field)
-    additional_notes = [ field["subtitle"], electronic_notes ].compact.join(" ")
 
-    electronic_resource_list_item(field["portfolio_id"], title, additional_notes)
+    item_html = [render_alma_eresource_link(field["portfolio_id"], title), field["subtitle"]]
+      .select(&:present?).join(" - ")
+    item_html = [item_html, electronic_notes]
+      .select(&:present?).join(" ").html_safe
+
+    content_tag(:td, item_html , class: " electronic_links online-list-items")
   end
 
   def render_electronic_notes(field)
@@ -284,12 +288,6 @@ module CatalogHelper
     if collection_notes.present? || service_notes.present?
       render partial: "electronic_notes", locals: { collection_notes: collection_notes, service_notes: service_notes }
     end
-  end
-
-  def electronic_resource_list_item(portfolio_pid, db_name, addl_info)
-    item_parts = [render_alma_eresource_link(portfolio_pid, db_name), addl_info]
-    item_html = item_parts.select(&:present?).join(" - ").html_safe
-    content_tag(:td, item_html , class: " electronic_links online-list-items")
   end
 
   def render_alma_eresource_link(portfolio_pid, db_name)

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -209,6 +209,15 @@ RSpec.describe CatalogHelper, type: :helper do
       end
     end
 
+    context "only electronic note and title are present" do
+      let(:field) { { "portfolio_id" => "77777", "title" => "Sample Name" } }
+
+      it "does not contain a separator" do
+        allow(helper).to receive(:render_electronic_notes) { "Hello World" }
+        expect(electronic_resource_link_builder(field)).to_not have_text(" - ")
+      end
+    end
+
     context "porfolio_id, title, and subtitle are present" do
       let(:field) { {
         "portfolio_id" => "77777", "title" => "Sample Name", "subtitle" => "Sample Text"


### PR DESCRIPTION
REF BL-769

Refactors electronic_resource_link_builder so that it only adds dashes
after additional notes not if only an electronic note is present.