### PR TITLE
[BL-340:767] Update purchase order email.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -644,7 +644,10 @@ class CatalogController < ApplicationController
   def purchase_order_action
     (_, document) = fetch(params["id"])
 
-    from = current_user&.email || params[:to]
+    email = current_user&.email || params[:to]
+    name = current_user&.name
+
+    from = { email: email, name: name }
 
     mail = PurchaseOrderMailer.purchase_order(document, { from: from, message: params[:message] }, url_options)
     if mail.respond_to? :deliver_now
@@ -653,7 +656,7 @@ class CatalogController < ApplicationController
       mail.deliver
     end
 
-    redirect_back(fallback_location: root_path)
+    redirect_back(fallback_location: root_path, success: "Your request has been submitted.")
   end
 
   # Overrides Blackligt::Catalog.sms_action.

--- a/app/models/purchase_order_mailer.rb
+++ b/app/models/purchase_order_mailer.rb
@@ -7,13 +7,13 @@ class PurchaseOrderMailer < RecordMailer
             rescue
               I18n.t("blacklight.email.text.default_title")
             end
-    subject = "Purchase Order: " + title.first
+    subject = "Purchase on Demand: " + title.first
 
     @document       = document
     @message        = details[:message]
     @url_gen_params = url_gen_params
-    @from_email     = details[:from]
+    @from           = details[:from]
 
-    mail(to: "orders@temple.edu",  subject: subject)
+    mail(to: "orders@temple.edu", cc: @from[:email], subject: subject)
   end
 end

--- a/app/views/purchase_order_mailer/purchase_order.text.erb
+++ b/app/views/purchase_order_mailer/purchase_order.text.erb
@@ -1,6 +1,8 @@
 Temple University Libraries Purchase Order Request:
 
-Requested by: <%= "#{@from_email}" %>
+Requested by <%= "#{@from[:name]}" %>
+Email: <%= "#{@from[:email]}" %>
+
 <%= @document.to_email_text %>
 <%= t('blacklight.email.text.url', :url =>polymorphic_url(@document, @url_gen_params)) %>
 <%= t('blacklight.email.text.message', :message => @message) %>


### PR DESCRIPTION
REF BL-767

  * Update email subject header  from "Purchase Order:" to "Purchase on Demand:"
  * Include the patron's name in the email
  * Would it be possible to send a copy of the email be sent to the requester and/or a confirmation screen pop-up saying the request submission was successful?