### PR TITLE
[BL-347] Fix exception thrown.

### DIFF
--- a/bin/alma_electronic_db.rb
+++ b/bin/alma_electronic_db.rb
@@ -13,9 +13,9 @@ filename = "spec/fixtures/electronic-collections-ids.csv"
 
 ids = File.readlines(filename)
   .map(&:to_i).select(&:nonzero?)
-  .map { |id| { collection_id: id } }
+  .map { |id| { collection_id: id.to_s } }
 
-batch = Alma::Electronic::BatchProcess.new(ids: ids)
+batch = Alma::Electronic::BatchUtils.new(ids: ids)
 
 batch.get_notes(type: "collection")
   .print_notes

--- a/lib/alma/electronic/batch_utils.rb
+++ b/lib/alma/electronic/batch_utils.rb
@@ -84,7 +84,7 @@ module Alma
         begin
           item = Alma::Electronic.get(params)
           item["electronic_service"].each { |service|
-            service_id = { service_id: service["id"] }
+            service_id = { service_id: service["id"].to_s }
             log params
               .merge(start: start, tag: tag)
               .merge(service_id)
@@ -164,7 +164,7 @@ module Alma
     end
 
     def make_collection_ids(ids)
-      ids.map { |id| { collection_id: id } }
+      ids.map { |id| { collection_id: id.to_s } }
     end
 
     # Returns JSON parsed list of logged items


### PR DESCRIPTION
The script to get electronic notes is throwing some exceptions do to
name error and type error.

This commit fixes those bugs.