### PR TITLE
BL-747 Add all descriptions to pickup_locations dropdown

### DIFF
--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -63,7 +63,7 @@ module CobAlma
     def self.item_level_locations(items_list)
       pickup_locations = self.possible_pickup_locations
 
-      items_list.reduce({}) { |libraries, item|
+      items_list.all.reduce({}) { |libraries, item|
         desc = item.description
         campus = determine_campus(item.library)
 

--- a/spec/fixtures/requests/empty_hash.json
+++ b/spec/fixtures/requests/empty_hash.json
@@ -1,0 +1,4 @@
+{
+  "item": [],
+  "total_record_count": 2
+}

--- a/spec/lib/cob_alma/requests.rb
+++ b/spec/lib/cob_alma/requests.rb
@@ -68,7 +68,7 @@ RSpec.describe CobAlma::Requests do
   end
 
   describe "#item_level_locations" do
-    let(:items_list) { {} }
+    let(:items_list) { Alma::BibItem.find("empty_hash") }
     let(:subject) { described_class.item_level_locations(items_list) }
 
     context "empty hash" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,7 +52,7 @@ RSpec.configure do |config|
         body: File.open(SPEC_ROOT + "/fixtures/alma_data/bib_items_ambler_only.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/.*\/holdings\/.*\/items/).
-        with(query: hash_including(offset: "100")).
+        #with(query: hash_including(offset: "100")).
         to_return(status: 200,
         body: JSON.dump({}))
 
@@ -76,6 +76,12 @@ RSpec.configure do |config|
         to_return(status: 200,
         body: File.open(SPEC_ROOT + "/fixtures/requests/paley_reserves_and_remote_storage.json"))
 
+
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/paley_reserves_and_remote_storage\/holdings\/.*\/items/).
+        with(query: hash_including(offset: "100")).
+        to_return(status: 200,
+        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/no_reserve_or_reference\/holdings\/.*\/items/).
         to_return(status: 200,
         body: File.open(SPEC_ROOT + "/fixtures/requests/no_reserve_or_reference.json"))
@@ -88,21 +94,50 @@ RSpec.configure do |config|
         to_return(status: 200,
         body: File.open(SPEC_ROOT + "/fixtures/requests/desc_with_no_libraries.json"))
 
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/desc_with_no_libraries\/holdings\/.*\/items/).
+        with(query: hash_including(offset: "100")).
+        to_return(status: 200,
+        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/desc_with_multiple_libraries\/holdings\/.*\/items/).
         to_return(status: 200,
         body: File.open(SPEC_ROOT + "/fixtures/requests/desc_with_multiple_libraries.json"))
+
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/desc_with_multiple_libraries\/holdings\/.*\/items/).
+        with(query: hash_including(offset: "100")).
+        to_return(status: 200,
+        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/empty_descriptions\/holdings\/.*\/items/).
         to_return(status: 200,
         body: File.open(SPEC_ROOT + "/fixtures/requests/empty_descriptions.json"))
 
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/empty_descriptions\/holdings\/.*\/items/).
+        with(query: hash_including(offset: "100")).
+        to_return(status: 200,
+        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/empty_and_description\/holdings\/.*\/items/).
         to_return(status: 200,
         body: File.open(SPEC_ROOT + "/fixtures/requests/empty_and_description.json"))
 
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/empty_hash\/holdings\/.*\/items/).
+        to_return(status: 200,
+        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/empty_and_description\/holdings\/.*\/items/).
+        with(query: hash_including(offset: "100")).
+        to_return(status: 200,
+        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/multiple_descriptions\/holdings\/.*\/items/).
         to_return(status: 200,
         body: File.open(SPEC_ROOT + "/fixtures/requests/multiple_descriptions.json"))
+
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/multiple_descriptions\/holdings\/.*\/items/).
+        with(query: hash_including(offset: "100")).
+        to_return(status: 200,
+        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs/).
         with(query: hash_including(expand: "p_avail,e_avail,d_avail", mms_id: "1,2")).


### PR DESCRIPTION
When more than 100 items were present, the pickup locations dropdown was still limited to the first 100.  