### PR TITLE
[BL-346] Fix electronic notes script.

### DIFF
--- a/bin/alma_electronic_db.rb
+++ b/bin/alma_electronic_db.rb
@@ -17,8 +17,10 @@ ids = File.readlines(filename)
 
 batch = Alma::Electronic::BatchUtils.new(ids: ids)
 
-batch.get_notes(type: "collection")
+batch.get_collection_notes
+  .get_collection_notes(ids: batch.build_failed_ids(type: "collection"))
   .print_notes
 
-batch.get_notes(type: "service")
-  .print_notes
+batch.get_service_notes
+  .get_service_notes(ids: batch.build_failed_ids(type: "service"))
+  .print_notes(type: "service")


### PR DESCRIPTION
The script for downloading electronic notes is failing to download
service notes properly do to some bugs.  This commit fixes the error and
adds some new tests to help prevent problems in the future.