### PR TITLE
[BL-340:766] Update purchase order buttons.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -312,7 +312,7 @@ class CatalogController < ApplicationController
     config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :separate_formats
     config.add_index_field "url_finding_aid_display", label: "Finding Aid", helper_method: :check_for_full_http_link
     config.add_index_field "availability"
-    config.add_index_field "purchase_order_availability", field: "purchase_order", if: false, helper_method: :render_purchase_order_availability
+    config.add_index_field "purchase_order_availability", field: "purchase_order", if: false, helper_method: :render_purchase_order_availability, with_po_link: true
 
 
     # solr fields to be displayed in the show (single result) view
@@ -405,7 +405,8 @@ class CatalogController < ApplicationController
     config.add_show_field "bound_with_ids", display: false
 
     config.add_show_field "po_link", field: "purchase_order", if: false, helper_method: :render_purchase_order_show_link
-    config.add_show_field "purchase_order_availability", field: "purchase_order", if: false, helper_method: :render_purchase_order_availability
+    config.add_show_field "purchase_order_availability", label: "Request Rapid Access", field: "purchase_order", if: false, helper_method: :render_purchase_order_availability, with_panel: true
+
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/views/catalog/_availability_panel.html.erb
+++ b/app/views/catalog/_availability_panel.html.erb
@@ -1,0 +1,12 @@
+<div class="panel-body online-panel">
+  <table id="record-page-online" class="table table-responsive border-bottom">
+    <h5 class="online-panel-heading"><%= label %></h5>
+    <tbody>
+      <% rows.each do |value| %>
+        <tr class="online-list-items">
+          <td><%= value %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -1,4 +1,4 @@
-<% doc_presenter = show_presenter(document) %>
+<% doc_presenter = index_presenter(document) %>
 <div class="blacklight-availability availability-ajax-load" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" >
 </div>
 

--- a/app/views/catalog/_purchase_order_anonymous_button.html.erb
+++ b/app/views/catalog/_purchase_order_anonymous_button.html.erb
@@ -2,12 +2,14 @@
 <button class="btn btn-sm btn-danger collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document.id %>" id="many_links_online">
   <span class="avail-label" aria-expanded="false">Request Rapid Access</span>
 </button>
+
+<span class="requests-container"><%= link %></span>
+
 <div id="online-document-<%= document.id %>" class="collapse online_resources">
   <table class="list_elec_links search_results_table">
 
-    <%= link %>
 
-    <div class="availability"><%= t("purchase_order_allowed") %></div>
+    <td class="electronic_links online-list-items"><%= t("purchase_order_allowed") %></a></td>
 
     <span class="border-bottom"></span>
   </table>


### PR DESCRIPTION
On search results page:

  * When *not* logged in: Add “Request Rapid Access” button with “>”; when clicking on button, add drop-down with following link “Log in to access request form” in right of button and the following text below the button: “This online material is available for purchase on demand. The option to request rapid access is limited to Temple University students, faculty, and staff. Once requested, access will generally be enabled within 2 business days.”; use box styling used for electronic resources in drop-down
  * When logged in: Leave functionality as is.

  On full record page:

  * When *not* logged in: Add link “Log in to access request form” (same placement as “Log in to see request options” for other record types; Add header “Request Rapid Access” and text “This online material is available for purchase on demand. The option to request rapid access is limited to Temple University students, faculty, and staff. Once requested, access will generally be enabled within 2 business days.”; use header and text styling used for electronic resources
  * When logged in: Replace link with “Request Rapid Access” button; otherwise, replicate view used for anonymous users