### PR TITLE
[DevOps] Add a rake task to open up docker app in browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ bundle exec rails server
 rake docker:up
 ```
 
+* To open up your local app or solr in the browser
+```bash
+rake docker:open
+
+rake docker:open_solr
+```
+
+
 ### Start the Application with some sample data for Development
 
 If you want to quickly get the application running for development with a minimal

--- a/lib/tasks/docker.rb
+++ b/lib/tasks/docker.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "json"
+
 # rubocop:disable BlockLength
 namespace :docker do
   task :up do
@@ -13,5 +15,24 @@ namespace :docker do
 
   task :ps do
     print `docker-compose ps`
+  end
+
+  def get_local_port(service = "app", port = 3000)
+    (docker, _) = JSON.parse(`docker inspect $(docker-compose ps --quiet #{service})`)
+
+    docker&.dig("NetworkSettings", "Ports", "#{port}/tcp")
+      &.first
+      &.dig("HostPort")
+  end
+
+  task :open do
+    port = get_local_port("app", "3000")
+    `open http://localhost:#{port}`
+  end
+
+
+  task :open_solr do
+    port = get_local_port("solr", 8983)
+    `open http://localhost:#{port}`
   end
 end


### PR DESCRIPTION
Adds a `rake docker:open` and `rake docker:open_solr` that opens up the
app or solr in the browser.  Makes it easier to develop with docker
because you don't have to search the IP address to open up the app in
a browser locally.