### PR TITLE
Fix xml json error page throws exception.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -615,6 +615,11 @@ class CatalogController < ApplicationController
   #
   # Overridden so that we can use our own 404 error handling setup.
   def invalid_document_id_error(exception)
+    error_info = {
+      "status" => "404",
+      "error"  => "#{exception.class}: #{exception.message}"
+    }
+
     respond_to do |format|
       format.xml  { render xml: error_info, status: 404 }
       format.json { render json: error_info, stautus: 404 }


### PR DESCRIPTION
REF BL-777

REF
https://app.honeybadger.io/projects/56250/faults/41903589#notice-summary

Define error_info for xml and json document not found error page.