### PR TITLE
[BL-779] Log API requests even on failure.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tulibraries/alma_rb.git
-  revision: bff94514f426dcbc5d4c89cf6a14d1d2816a234d
+  revision: f71e1672c7d067018776ddbed3e1b7a886d64243
   branch: master
   specs:
     alma (0.2.8)
@@ -32,7 +32,7 @@ GIT
 
 GIT
   remote: https://github.com/tulibraries/primo
-  revision: a7b2998bdbf4996db5a83d86b747b9b75e461e84
+  revision: 06e423aa9573b20cc6c4f5d592c3ef0eef1016b7
   specs:
     primo (0.1.0)
       httparty
@@ -277,7 +277,7 @@ GEM
     mime-types-data (3.2018.0812)
     mimemagic (0.3.2)
     mini_mime (1.0.1)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.2.4)
     multi_json (1.13.1)
@@ -286,8 +286,8 @@ GEM
     mysql2 (0.4.10)
     nenv (0.3.0)
     nio4r (2.3.1)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.0)
+      mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)

--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -50,7 +50,7 @@ class AlmawsController < CatalogController
       log = { type: "item_request_options", mms_id: @mms_id, holding_id: @holding_id, item_pid: @item_pid, user: current_user.id }
       @item_level_holdings = CobAlma::Requests.item_holding_ids(@items)
       @request_options = @item_level_holdings.map { |holding_id, item_pid|
-        json_request_logger(log) { Alma::ItemRequestOptions.get(@mms_id, holding_id, item_pid, user_id: @user_id) }
+        do_with_json_logger(log) { Alma::ItemRequestOptions.get(@mms_id, holding_id, item_pid, user_id: @user_id) }
       }
         .sort_by { |r| r.raw_response.parsed_response.count }
         .last

--- a/app/controllers/concerns/json_logger.rb
+++ b/app/controllers/concerns/json_logger.rb
@@ -7,4 +7,21 @@ module JsonLogger
   def json_request_logger(params = {})
     LogUtils.json_request_logger(logger, params)
   end
+
+  def do_with_json_logger(log = {})
+    start = { start: Time.now }
+    begin
+      response = yield if block_given?
+
+      loggable = (response.loggable rescue {}) || {}
+
+      json_request_logger(log.merge(loggable).merge(start))
+    rescue Exception => e
+      error = JSON.parse(e.message) rescue { error: e.message }
+      json_request_logger(log.merge(error).merge(start))
+      raise e
+    end
+
+    response
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  include JsonLogger
+
   def account
     no_cache
     @user = current_user
@@ -38,7 +40,8 @@ class UsersController < ApplicationController
   end
 
   def renew
-    lib_user = Alma::User.find(user_id: current_user.uid)
+    log = { type: "alma_user", uid: current_user.uid }
+    lib_user = do_with_json_logger(log) { Alma::User.find(current_user.uid) }
 
     # Pass loan_id and loan status to view
     @loan_id = params[:loan_id]

--- a/config/initializers/alma.rb
+++ b/config/initializers/alma.rb
@@ -3,7 +3,7 @@
 Alma.configure do |config|
   # You have to set te apikey
   config.apikey = Rails.configuration.alma[:apikey]
-
+  config.enable_loggable = true
 end
 ENV["ALMA_API_KEY"] ||= Rails.configuration.alma[:apikey]
 ENV["ALMA_DELIVERY_DOMAIN"] ||= Rails.configuration.alma[:delivery_domain]

--- a/config/initializers/primo.rb
+++ b/config/initializers/primo.rb
@@ -5,4 +5,5 @@ Primo.configure do |config|
   config.context = :PC
   config.vid     = "TULI"
   config.scope   = "pci_scope"
+  config.enable_loggable = true
 end

--- a/spec/helpers/almaws_helper_spec.rb
+++ b/spec/helpers/almaws_helper_spec.rb
@@ -3,6 +3,17 @@
 require "rails_helper"
 
 RSpec.describe AlmawsHelper, type: :helper do
+  let(:json) { {}.to_json }
+  let(:request_options) { Alma::RequestOptions.get("foo") }
+
+  before do
+    helper.instance_variable_set(:@equipment, [])
+    stub_request(:any, /request-options/).
+      and_return(headers: { "Content-Type" => "application/json" },
+                 body: json,
+                 status: 200)
+  end
+
   describe "#hold_allowed_partial" do
     let(:json) {
       { request_option:
@@ -12,12 +23,6 @@ RSpec.describe AlmawsHelper, type: :helper do
         }]
       }.to_json
     }
-    let(:response) { OpenStruct.new(body: json) }
-    let(:request_options) { Alma::RequestOptions.new(response) }
-
-    before do
-      helper.instance_variable_set(:@equipment, [])
-    end
 
     context "hold can be placed on an item" do
       it "renders the hold partial" do
@@ -50,8 +55,6 @@ RSpec.describe AlmawsHelper, type: :helper do
         }]
       }.to_json
     }
-    let(:response) { OpenStruct.new(body: json) }
-    let(:request_options) { Alma::RequestOptions.new(response) }
 
     context "An item can be requested to be scanned" do
       it "renders the digitization_allowed partial" do
@@ -84,8 +87,6 @@ RSpec.describe AlmawsHelper, type: :helper do
         }]
       }.to_json
     }
-    let(:response) { OpenStruct.new(body: json) }
-    let(:request_options) { Alma::RequestOptions.new(response) }
 
     context "booking can be placed on an item" do
       it "renders the booking_allowed partial" do
@@ -123,8 +124,6 @@ RSpec.describe AlmawsHelper, type: :helper do
         }]
       }.to_json
     }
-    let(:response) { OpenStruct.new(body: json) }
-    let(:request_options) { Alma::RequestOptions.new(response) }
     let(:books) { "BOOK" }
 
     context "item can be requested through ez-borrow" do
@@ -158,8 +157,6 @@ RSpec.describe AlmawsHelper, type: :helper do
         }]
       }.to_json
     }
-    let(:response) { OpenStruct.new(body: json) }
-    let(:request_options) { Alma::RequestOptions.new(response) }
     let(:books) { "BOOK" }
 
     context "there are no Temple request options available" do
@@ -194,8 +191,6 @@ RSpec.describe AlmawsHelper, type: :helper do
           }]
         }.to_json
       }
-      let(:response) { OpenStruct.new(body: json) }
-      let(:request_options) { Alma::RequestOptions.new(response) }
 
       it "is true" do
         expect(helper.only_one_option_allowed(request_options)).to be true
@@ -211,8 +206,6 @@ RSpec.describe AlmawsHelper, type: :helper do
           }]
         }.to_json
       }
-      let(:response) { OpenStruct.new(body: json) }
-      let(:request_options) { Alma::RequestOptions.new(response) }
 
       it "is true" do
         expect(helper.only_one_option_allowed(request_options)).to be true
@@ -223,32 +216,29 @@ RSpec.describe AlmawsHelper, type: :helper do
       let(:json) {
         {
           "request_option": [
-        {
-            "type": {
+            {
+              "type": {
                 "value": "HOLD",
                 "desc": "Hold"
+              },
+              "request_url": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/users/915602377/requests/"
             },
-            "request_url": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/users/915602377/requests/"
-        },
-        {
-            "type": {
+            {
+              "type": {
                 "value": "BOOKING",
                 "desc": "Booking"
+              },
+              "request_url": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/users/915602377/requests/"
             },
-            "request_url": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/users/915602377/requests/"
-        },
-        {
-            "type": {
+            {
+              "type": {
                 "value": "PURCHASE",
                 "desc": "Purchase"
+              }
             }
-        }
           ]
-      }.to_json
+        }.to_json
       }
-
-      let(:response) { OpenStruct.new(body: json) }
-      let(:request_options) { Alma::RequestOptions.new(response) }
 
       it "is false" do
         expect(helper.only_one_option_allowed(request_options)).to be false

--- a/spec/models/almaws_response_spec.rb
+++ b/spec/models/almaws_response_spec.rb
@@ -4,9 +4,16 @@ require "rails_helper"
 
 RSpec.describe Blacklight::Alma::Response, type: :model  do
   let (:json) { { bib: [], total_record_count: 101 }.to_json }
-  let (:raw_response) { OpenStruct.new(body: json) }
-  let (:bib_items) { Alma::BibItemSet.new(raw_response) }
+  let (:bib_items) { Alma::BibItem.find("foo") }
   let (:response) { Blacklight::Alma::Response.new(bib_items) }
+
+  before do
+    stub_request(:any, /holdings/).
+      and_return(headers: { "Content-Type" => "application/json" },
+                 body: json,
+                 status: 200)
+  end
+
 
   describe "#limit_value" do
     it "has a default limit value" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,107 +43,134 @@ RSpec.configure do |config|
   config.before(:each) do
 
     # JUst so we don't send our request when testing controllers
-    stub_request(:get, /.*almaws\/v1\/bibs\/.*/).to_return(status: 200, body: JSON.dump({}))
-    stub_request(:post, /.*almaws\/v1\/bibs\/.*\/request-options?.*/).to_return(status: 200)
-    stub_request(:post, /.*almaws\/v1\/bibs\/.*\/requests?.*/).to_return(status: 200)
+    stub_request(:get, /.*almaws\/v1\/bibs\/.*/).
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: JSON.dump({}))
+
+    stub_request(:post, /.*almaws\/v1\/bibs\/.*\/request-options?.*/).
+      to_return(status: 200)
+
+    stub_request(:post, /.*almaws\/v1\/bibs\/.*\/requests?.*/)
+      .to_return(status: 200)
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/.*\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/alma_data/bib_items_ambler_only.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/alma_data/bib_items_ambler_only.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/.*\/holdings\/.*\/items/).
-        #with(query: hash_including(offset: "100")).
-        to_return(status: 200,
-        body: JSON.dump({}))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: JSON.dump({}))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/same_campus\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/alma_data/presser_and_paley.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/alma_data/presser_and_paley.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/ambler_presser\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/alma_data/ambler_presser.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/alma_data/ambler_presser.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/kardon_paley\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/alma_data/kardon_paley.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/alma_data/kardon_paley.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/only_paley_reserves\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/only_paley_reserves.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/only_paley_reserves.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/paley_reserves_and_remote_storage\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/paley_reserves_and_remote_storage.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/paley_reserves_and_remote_storage.json"))
 
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/paley_reserves_and_remote_storage\/holdings\/.*\/items/).
-        with(query: hash_including(offset: "100")).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+      with(query: hash_including(offset: "100")).
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/no_reserve_or_reference\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/no_reserve_or_reference.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/no_reserve_or_reference.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/both_reserve\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/both_reserve.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/both_reserve.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/desc_with_no_libraries\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/desc_with_no_libraries.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/desc_with_no_libraries.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/desc_with_no_libraries\/holdings\/.*\/items/).
-        with(query: hash_including(offset: "100")).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+      with(query: hash_including(offset: "100")).
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/desc_with_multiple_libraries\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/desc_with_multiple_libraries.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/desc_with_multiple_libraries.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/desc_with_multiple_libraries\/holdings\/.*\/items/).
-        with(query: hash_including(offset: "100")).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+      with(query: hash_including(offset: "100")).
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/empty_descriptions\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_descriptions.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/empty_descriptions.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/empty_descriptions\/holdings\/.*\/items/).
-        with(query: hash_including(offset: "100")).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+      with(query: hash_including(offset: "100")).
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/empty_and_description\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_and_description.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/empty_and_description.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/empty_hash\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/empty_and_description\/holdings\/.*\/items/).
-        with(query: hash_including(offset: "100")).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+      with(query: hash_including(offset: "100")).
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/multiple_descriptions\/holdings\/.*\/items/).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/multiple_descriptions.json"))
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/multiple_descriptions.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/multiple_descriptions\/holdings\/.*\/items/).
-        with(query: hash_including(offset: "100")).
-        to_return(status: 200,
-        body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+      with(query: hash_including(offset: "100")).
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs/).
-        with(query: hash_including(expand: "p_avail,e_avail,d_avail", mms_id: "1,2")).
-        to_return(status: 200,
-                  body: File.open(SPEC_ROOT + "/fixtures/availability_response.xml").read,
-                  headers: { "content-type" => ["application/xml;charset=UTF-8"] })
+      with(query: hash_including(expand: "p_avail,e_avail,d_avail", mms_id: "1,2")).
+      to_return(status: 200,
+                body: File.open(SPEC_ROOT + "/fixtures/availability_response.xml").read,
+                headers: { "content-type" => ["application/xml;charset=UTF-8"] })
 
   end
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
REF BL-779

## Depends on
- [x] https://github.com/tulibraries/primo/pull/24
- [x] https://github.com/tulibraries/alma_rb/pull/37

## Description

When we make API calls we log the response process in order to obtain
metrics on these API requests.  However when the request raises an
exception we fail to log the event.  We need to make sure that logging
happens even in the event of a raised exception.

This change updates the `json_request_logger` method to accept a block.
When a block is passed it gets yielded before logging happens and if an
exception is raised it is caught, logged and then released so that we do
not interrupt the proper behavior of the app just for logging.