### PR TITLE
BL-705 Add item descriptions to comments

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -132,7 +132,7 @@ class AlmawsController < CatalogController
       target_destination: { value: "DIGI_DEPT_INST" },
       partial_digitization: true,
       last_interest_date: date,
-      comment: params[:digitization_comment] || "",
+      comment: [params[:digitization_comment], params[:digitization_description]].compact.join("\n"),
       required_pages_range: [{
         from_page: params[:from_page], to_page: params[:to_page]
       }]


### PR DESCRIPTION
- Currently when partial digitization requests are made, the citation information(item-level description) is not being passed through to Alma.  This adds the descprition to the comments so that the people filling the request can easily see which item is needed.