### PR TITLE
BL-678 Begin handling test suite deprecations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,8 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::InvalidAuthenticityToken,
     with: :redirect_to_referer
 
+  skip_after_action :discard_flash_if_xhr
+
   # Rails 5.1 and above requires permitted params to be defined in the Controller
   # BL doesn't do that, but might in the future. This allows us to use the pre 5.1
   # behavior until we can define all possible param  in the future.

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe BookmarksController do
 
     it "gets ris format" do
       get :index, params: { id: 1, format: "ris" }
-      expect(response).to be_success
+      expect(response).to be_successful
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe BookmarksController do
   describe "update" do
     it "has a 200 status code when creating a new one" do
       put :update, xhr: true, params: { id: "2007020969", format: :js }
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response.code).to eq "200"
       expect(JSON.parse(response.body)["bookmarks"]["count"]).to eq 1
     end
@@ -57,7 +57,7 @@ RSpec.describe BookmarksController do
         format: :js
       }
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response.code).to eq "200"
       expect(JSON.parse(response.body)["bookmarks"]["count"]).to eq 3
     end
@@ -71,7 +71,7 @@ RSpec.describe BookmarksController do
 
     it "has a 200 status code when delete is success" do
       delete :destroy, xhr: true, params: { id: "2007020969", format: :js }
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response.code).to eq "200"
       expect(JSON.parse(response.body)["bookmarks"]["count"]).to eq 0
     end
@@ -87,7 +87,7 @@ RSpec.describe BookmarksController do
         ],
         format: :js
       }
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(response.code).to eq "200"
       expect(JSON.parse(response.body)["bookmarks"]["count"]).to eq 0
     end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -126,10 +126,10 @@ RSpec.describe CatalogController, type: :controller do
     context "user is not logged in" do
       it "does not allow access to purchase order action" do
         get :purchase_order, params: { id: doc_id }
-        expect(response).not_to be_success
+        expect(response).not_to be_successful
 
         post :purchase_order_action, params: { id: doc_id }
-        expect(response).not_to be_success
+        expect(response).not_to be_successful
       end
     end
 
@@ -146,10 +146,10 @@ RSpec.describe CatalogController, type: :controller do
       context "user group is allowed to purchase order" do
         it "allows access to purchase order action" do
           get :purchase_order, params: { id: doc_id }
-          expect(response).to be_success
+          expect(response).to be_successful
 
           post :purchase_order_action, params: { id: doc_id }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
 
@@ -158,10 +158,10 @@ RSpec.describe CatalogController, type: :controller do
 
         it "does not allow access to purchase order action" do
           get :purchase_order, params: { id: doc_id }
-          expect(response).not_to be_success
+          expect(response).not_to be_successful
 
           post :purchase_order_action, params: { id: doc_id }
-          expect(response).not_to be_success
+          expect(response).not_to be_successful
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -167,6 +167,7 @@ RSpec.configure do |config|
     # a real object. This is generally recommended, and will default to
     # `true` in RSpec 4.
     mocks.verify_partial_doubles = true
+    mocks.allow_message_expectations_on_nil = true
   end
 
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will


### PR DESCRIPTION
- Currently our deprecations are piling up in our test suite.  This PR handles all of the deprecations that are not related to the Blacklight 7 upgrade
- skip_after_action :discard_flash_if_xhr
- allow_message_expectations_on_nil
- change be_success predicates to be_successful