### PR TITLE
[BL-340:746] Make po items also online items.

### DIFF
--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -310,6 +310,7 @@ module Traject
           extract_purchase_order[rec, order]
           if order == [true]
             acc << "Request Rapid Access"
+            acc << "Online"
           end
 
           acc.uniq!

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -458,6 +458,10 @@ RSpec.describe Traject::Macros::Custom do
           it "adds a purchase order availability" do
             expect(subject.map_record(record)["availability_facet"]).to include("Request Rapid Access")
           end
+
+          it "also adds an online availability" do
+            expect(subject.map_record(record)["availability_facet"]).to include("Online")
+          end
         end
 
         context "with purchase order field false" do


### PR DESCRIPTION
REF BL-746

Allow PO items to still be visible in the facets even after online items
are selected.