### PR TITLE
[BL-780] Redirect back to specific document on log in.

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -169,8 +169,8 @@ module CatalogHelper
     return unless args[:document].purchase_order?
 
     if !current_user
-      redirect_url = new_user_session_with_redirect_path(request.url)
-      link_to("Log in to access request form", redirect_url, data: { "ajax-modal": "trigger" })
+      id = args[:document].id
+      link_to("Log in to access request form", doc_redirect_url(id), data: { "ajax-modal": "trigger" })
     elsif current_user.can_purchase_order?
       render_purchase_order_button(args)
     end
@@ -397,5 +397,13 @@ module CatalogHelper
     else
       alma_electronic_resource_direct_link(field["portfolio_id"])
     end
+  end
+
+  def doc_id(id)
+    "doc-#{id}"
+  end
+
+  def doc_redirect_url(id)
+    new_user_session_with_redirect_path("#{request.url}##{doc_id(id)}")
   end
 end

--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,7 +1,7 @@
 <% # container for a single doc -%>
 <% toggle_document_context(document) %>
 
-<div <%= index_controller(document, document_counter) %> class="document  <%= render_document_class document %> document-position-<%= document_counter%> " data-document-counter="<%= document_counter %>" itemscope itemtype="<%= document.itemtype %>">
+<div id="<%= doc_id(document.id) %>" <%= index_controller(document, document_counter) %> class="document  <%= render_document_class document %> document-position-<%= document_counter%> " data-document-counter="<%= document_counter %>" itemscope itemtype="<%= document.itemtype %>">
   <%= render_document_partials document, blacklight_config.view_config(document_index_view_type).partials, :document_counter => document_counter %>
 </div>
 <% toggle_document_context %>

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -21,7 +21,7 @@
           <% if user_signed_in? %>
             <%= request_modal(document.id, document.id, @pickup_locations, @request_level) %>
           <% else %>
-            <%= link_to(t("requests.log_in"), new_user_session_with_redirect_path(request.url),  data: {"ajax-modal": "trigger"}, class: "log-in-link") %>
+            <%= link_to(t("requests.log_in"), doc_redirect_url(document.id),  data: {"ajax-modal": "trigger"}, class: "log-in-link") %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
REF BL-780

When forced to log in in order to make a request the redirect link is not
document specific.  Therefore, when you are logged back in you get
redirected with focus on top of page.  This forces user to scroll back
down if they redirected from a lower section of the window.

This update adds target specific redirect links so that the browser scrolls
to the correct part of the window on log in.