### PR TITLE
Use key as default location description.

### DIFF
--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -53,15 +53,15 @@ module AlmaDataHelper
   end
 
   def location_status(item)
-    Rails.configuration.locations.dig(item.library, item.location)
+    location_name_from_short_code(item)
+  end
+
+  def location_name_from_short_code(item)
+    Rails.configuration.locations.dig(item.library, item.location) || item.location
   end
 
   def library_name_from_short_code(short_code)
     Rails.configuration.libraries[short_code]
-  end
-
-  def location_name_from_short_code(item)
-    Rails.configuration.locations.dig(item.library, item.location)
   end
 
   def alternative_call_number(item)


### PR DESCRIPTION
REF BL-786
Honeybadger Ref: https://app.honeybadger.io/projects/56250/faults/44436938#notice-summary

When we do not have a location mapped in `Rails.configuration.libraries`
then the `location_name_from_short_code` method returns `nil` and in
turn causes an error to be raised by the `sort_order_for_holdings`
helper method.

* This PR fixes the issue by defaulting to the key when no map is
present for a specific location.

* This PR also aliases `location_status` to
`location_name_from_short_code` for backwards compatibility because they
are in fact the same method.