### PR TITLE
BL-784 Request options display

### DIFF
--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -28,7 +28,7 @@ module AlmawsHelper
   end
 
   def no_temple_request_options_available(request_options, books)
-    if !@request_options.hold_allowed? && !@request_options.digitization_allowed? && !@request_options.booking_allowed? 
+    if !@request_options.hold_allowed? && !@request_options.digitization_allowed? && !@request_options.booking_allowed?
       render partial: "no_request_options", locals: { request_options: request_options, books: books }
     end
   end

--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -28,7 +28,7 @@ module AlmawsHelper
   end
 
   def no_temple_request_options_available(request_options, books)
-    if !@request_options.hold_allowed? && !@request_options.digitization_allowed? && !@request_options.booking_allowed? && !books.present?
+    if !@request_options.hold_allowed? && !@request_options.digitization_allowed? && !@request_options.booking_allowed? 
       render partial: "no_request_options", locals: { request_options: request_options, books: books }
     end
   end


### PR DESCRIPTION
- We were accidentally limiting the text for no request options to items that were not books.  This removes that logic so that the default text displays for all item types.