### PR TITLE
BL-776 Capitalization bug in dropdown title search

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -205,15 +205,15 @@
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.FlattenGraphFilterFactory"/>
-        <filter class="solr.StopFilterFactory" words="stopwords_en.txt" />
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt" />
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
       <analyzer type="query">
         <charFilter class="solr.MappingCharFilterFactory" mapping="char-filter-mapping.txt"/>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt" />
         <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.StopFilterFactory" words="stopwords_en.txt" />
       </analyzer>
     </fieldType>
 
@@ -228,7 +228,7 @@
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.FlattenGraphFilterFactory"/>
-        <filter class="solr.StopFilterFactory" words="stopwords_en.txt" />
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt" />
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.EnglishPossessiveFilterFactory"/>
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
@@ -239,7 +239,7 @@
         <charFilter class="solr.MappingCharFilterFactory" mapping="char-filter-mapping.txt"/>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory" words="stopwords_en.txt" />
+        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt" />
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.EnglishPossessiveFilterFactory"/>
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>


### PR DESCRIPTION
- The way our current solr schema is set up, stop words are case sensitive, so when a user searches with 'The' no results are found.  
- Adds caseInsensitive='true' to StopFilterFactory
- Move LowerCaseFilterFactory after StopFilterFactory