### PR TITLE
BL-781 Reserve item status

### DIFF
--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -7,7 +7,7 @@ module AlmaDataHelper
 
   def availability_status(item)
     if item.in_place? && item.item_data["requested"] == false
-      if item.non_circulating?
+      if item.non_circulating? || item.location == "reserve"
         content_tag(:span, "", class: "check") + "Library Use Only"
       else
         content_tag(:span, "", class: "check") + "Available"

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -21,6 +21,26 @@ RSpec.describe AlmaDataHelper, type: :helper do
       end
     end
 
+    context "item is located in reserves" do
+      let(:item) do
+        Alma::BibItem.new("item_data" =>
+          {
+            "base_status" =>
+              { "value" => "1" },
+            "policy" =>
+              { "desc" => "" },
+            "location" =>
+              { "value" => "reserve" },
+            "requested" => false,
+          }
+       )
+      end
+
+      it "displays library use only" do
+        expect(availability_status(item)).to eq "<span class=\"check\"></span>Library Use Only"
+      end
+    end
+
     context "item base_status is 1 and item is requested" do
       let(:item) do
         Alma::BibItem.new("item_data" =>


### PR DESCRIPTION
- It can be confusing to users to see reserve items listed as available since they can only be checked out for a few hours and must remain in the library.  
- Updates the item status to display library use only