### PR TITLE
Clear availability panel to avoid mobile bug.

### DIFF
--- a/app/assets/stylesheets/partials/_availability.scss
+++ b/app/assets/stylesheets/partials/_availability.scss
@@ -60,6 +60,7 @@
 
 div.physical-holding-panel {
   padding: 0 !important;
+  clear: both;
 }
 
 .show_page_records dd {


### PR DESCRIPTION
REF BL-785

Clearing phisical-holding-panel div avoids log-in link taking up space
next to panel and causing panel to get obscured.