### PR TITLE
BL-795 Advanced search sort options displaying

### DIFF
--- a/app/views/advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/advanced/_advanced_search_submit_btns.html.erb
@@ -2,7 +2,7 @@
   <div class="col-xs-12 col-sm-6">
     <div class="sort-buttons pull-left">
       <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "control-label") %>
-      <%= sort_fields = active_sort_fields.values.map { |field_config| [sort_field_label(field_config.key), field_config.key] } %>
+      <% sort_fields = active_sort_fields.values.map { |field_config| [sort_field_label(field_config.key), field_config.key] } %>
       <%= select_tag(:sort, options_for_select(sort_fields, h(current_sort_field && current_sort_field.key)), :class => "form-control sort-select") %>
       <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
     </div>


### PR DESCRIPTION
- Remove equal sign for the sort_fields variable so that it isn't displayed in the template