### PR TITLE
BL-790 Navigation tabs when active

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -151,3 +151,8 @@ $(document).on('turbolinks:load', function() {
     $(this).find('span#facet-icons').toggleClass('open-facet-icon').toggleClass('remove-facet-icon');
 	});
  });
+
+ $(".header-links").on("click", function(){
+    $(".nav-header-links").find(".active").removeClass("active");
+    $(this).addClass("active");
+ });

--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -228,7 +228,7 @@ a.advanced_search {
 }
 
 /* HEADER WITH EVERYTHING/CATALOG TOGGLES */
-.header-links a.nav-link {
+.header-links a {
   color: $black;
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -184,10 +184,9 @@ module ApplicationHelper
   def render_nav_link(path, name, analytics_id = nil)
     active = is_active?(path) ? [ "active" ] : []
     button_class = ([ "nav-btn header-links" ] + active).join(" ")
-    link_class = ([ "nav-link" ] + active).join(" ")
 
     content_tag :li, class: button_class do
-      link_to(name, send(path, search_params), class: link_class, id: analytics_id)
+      link_to(name, send(path, search_params), id: analytics_id)
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context "path not current page" do
       it "renders a link without the active class" do
-        link = "<li class=\"nav-btn header-links\"><a class=\"nav-link\" href=\"/catalog\">More</a></li>"
+        link = "<li class=\"nav-btn header-links\"><a href=\"/catalog\">More</a></li>"
         expect(helper.render_nav_link(:search_catalog_path, "More")).to eq(link)
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     context "path is current page" do
       let(:request) { OpenStruct.new(original_fullpath: "/catalog") }
       it "renders a link with the active class" do
-        link = "<li class=\"nav-btn header-links active\"><a class=\"nav-link active\" href=\"/catalog\">More</a></li>"
+        link = "<li class=\"nav-btn header-links active\"><a href=\"/catalog\">More</a></li>"
         expect(helper.render_nav_link(:search_catalog_path, "More")).to eq(link)
       end
     end
@@ -43,7 +43,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:current_search_session) { OpenStruct.new(query_params: { q: "foo" }) }
 
       it "gets the query added to the generated link" do
-        link = "<li class=\"nav-btn header-links\"><a class=\"nav-link\" href=\"/catalog?q=foo\">More</a></li>"
+        link = "<li class=\"nav-btn header-links\"><a href=\"/catalog?q=foo\">More</a></li>"
         expect(helper.render_nav_link(:search_catalog_path, "More")).to eq(link)
       end
     end


### PR DESCRIPTION
- There is a significant delay in the transition between searches, resulting in the active class being present on both links.  This is especially a problem on mobile devices.
- Use javascript to remove and reassign "active" class faster
- We were assigning the active class to both the list item and the link itself. Now the active class is only assigned to the list item.