### PR TITLE
[BL-666] Do not add always add advanced constraints.

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -202,7 +202,12 @@ module BlacklightAdvancedSearch
     # We need this in order to render multiple clearable buttons on advanced searches.
 
     def render_constraints_query(my_params = params)
-      buttons = guided_search.map { |s|
+      # Short circuit if this is not an advanced query.
+      if advanced_query.nil? || advanced_query.keyword_queries.empty?
+        return super(my_params)
+      end
+
+      buttons = guided_search(my_params).map { |s|
         label, query, action = s
 
         render_constraint_element(

--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -68,7 +68,7 @@ module Blacklight::PrimoCentral
 
     def process_advanced_search(primo_central_parameters)
       if is_advanced_search?
-        rows_count = @scope.helpers.advanced_search_config[:fields_row_count]
+        rows_count = blacklight_config.advanced_search[:fields_row_count]
 
         build_query = (1..rows_count).map do |count|
           value = blacklight_params["q_#{count}"]
@@ -172,7 +172,7 @@ module Blacklight::PrimoCentral
 
       def is_advanced_search?
         blacklight_params[:controller] == "primo_advanced" ||
-          blacklight_params[:q_1]
+          !(@scope.advanced_query.nil? || @scope.advanced_query.keyword_queries.empty? rescue false)
       end
   end
 end


### PR DESCRIPTION
* Updates constraints element rendering code to short circuit the
advanced elements constraints when not doing an advanced search.

* Adds check to primo search builder to verify if regular advanced
search has been created (i.e. also do advanced search in primo)