### PR TITLE
BL-789 xml views for books and journals

### DIFF
--- a/app/helpers/blacklight_marc_helper.rb
+++ b/app/helpers/blacklight_marc_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module BlacklightMarcHelper
+  # This method is brought over from the Blacklight Marc gem so that we can include the links for books and journals
+  def refworks_export_url(params = {})
+    "http://www.refworks.com/express/expressimport.asp?vendor=#{CGI.escape(params[:vendor] || application_name)}&filter=#{CGI.escape(params[:filter] || "MARC Format")}&encoding=65001" + (("&url=#{CGI.escape(params[:url])}" if params[:url]) || "")
+  end
+
+  # Overrides the original method in Blacklight Marc so that we only use this link for catalog items
+  def refworks_solr_document_path(opts = {})
+    if opts[:id] && controller_name == "catalog"
+      refworks_export_url(url: solr_document_url(opts[:id], format: :refworks_marc_txt))
+    end
+  end
+
+  # Replicates the refworks_solr_document_path method for books and journals
+  def refworks_solr_book_document_path(opts = {})
+    if opts[:id] && controller_name == "books"
+      refworks_export_url(url: solr_book_document_path(opts[:id], format: :refworks_marc_txt))
+    end
+  end
+
+  def refworks_solr_journal_document_path(opts = {})
+    if opts[:id] && controller_name == "journals"
+      refworks_export_url(url: solr_journal_document_path(opts[:id], format: :refworks_marc_txt))
+    end
+  end
+end

--- a/app/models/solr_book_document.rb
+++ b/app/models/solr_book_document.rb
@@ -3,4 +3,11 @@
 class SolrBookDocument < SolrDocument
   use_extension(Blacklight::Document::Email)
   use_extension(Blacklight::Document::Sms)
+
+  # Add Blacklight-Marc extension:
+  SolrBookDocument.use_extension(Blacklight::Solr::Document::Marc) do |doc|
+    doc.has_field? "marc_display_raw"
+  end
+  SolrBookDocument.extension_parameters[:marc_source_field] = "marc_display_raw"
+  SolrBookDocument.extension_parameters[:marc_format_type] = :marcxml
 end

--- a/app/models/solr_journal_document.rb
+++ b/app/models/solr_journal_document.rb
@@ -3,4 +3,10 @@
 class SolrJournalDocument < SolrDocument
   use_extension(Blacklight::Document::Email)
   use_extension(Blacklight::Document::Sms)
+
+  SolrJournalDocument.use_extension(Blacklight::Solr::Document::Marc) do |doc|
+    doc.has_field? "marc_display_raw"
+  end
+  SolrJournalDocument.extension_parameters[:marc_source_field] = "marc_display_raw"
+  SolrJournalDocument.extension_parameters[:marc_format_type] = :marcxml
 end


### PR DESCRIPTION
- xml views and refworks are not currently available for books and journals. 
- Adds the refworks_marc_txt to each model 
- Adds helper methods for the refworks links