### PR TITLE
[BL-666] Override the advanced form params.

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -60,8 +60,8 @@ module AdvancedHelper
     blacklight_config.fetch(:advanced_search, {})
   end
 
-  def render_advanced_search_link
-    query = params.except(:controller, :action).to_h
+  def render_advanced_search_link(my_params = params)
+    query = advanced_params(my_params)
 
     if current_page? search_catalog_path
       id = :catalog_advanced_search
@@ -81,6 +81,18 @@ module AdvancedHelper
     end
 
     link_to(t(id), url, class: "advanced_search", id: id) if id
+  end
+
+  def advanced_params(my_params)
+    my_params.except(:controller, :action)
+      .select { |k, v|
+      # Sometimes is_advanced_search? does not return true|false answer.
+      if !(is_advanced_search? == true)
+        !k.match?(/^(q|op|f)_/)
+      else
+        true
+      end
+    }.to_h
   end
 
   def basic_search_path

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -53,6 +53,9 @@ RSpec.describe AdvancedHelper, type: :helper do
       allow(helper).to receive(:current_page?).with("/articles") { false }
       allow(helper).to receive(:current_page?).with("/databases") { false }
       allow(helper).to receive(:params) { { q: "foo", controller: "bar" } }
+      without_partial_double_verification do
+        allow(helper).to receive(:is_advanced_search?) { true }
+      end
     end
 
     context "on the catalog search page" do


### PR DESCRIPTION
When overriding an advanced search from basic search we should also
override the original advanced search terms with new basic search term.