### PR TITLE
Makes articles document diggable.

### DIFF
--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -8,6 +8,13 @@ module Blacklight::PrimoCentral::Document
 
   delegate :url_helpers, to: "Rails.application.routes"
 
+  delegate :dig, :[], to: :@_source
+
+  def []=(key, value)
+    @_source = @_source.merge("#{key}": value)
+  end
+
+
   attr_reader :blacklight_config
 
   def initialize(doc, options = {})

--- a/app/models/concerns/diggable.rb
+++ b/app/models/concerns/diggable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Add hash like properties to our documents lost in BL-7.
+module Diggable
+  extend ActiveSupport::Concern
+
+  included do
+    delegate :dig, :[], to: :@_source
+  end
+
+
+  def []=(key, value)
+    @_source = @_source.merge("#{key}": value)
+  end
+end

--- a/app/models/primo_central_document.rb
+++ b/app/models/primo_central_document.rb
@@ -5,6 +5,7 @@ class PrimoCentralDocument
 
   include Blacklight::PrimoCentral::Document
   include Citable
+  include Diggable
 
   # Email uses semantic field mappings below to generate the body of an email.
   self.unique_key = :pnxId

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -5,15 +5,9 @@ class SolrDocument
   include Blacklight::Solr::Document::RisFields
   include AlmaDataHelper
   include Citable
+  include Diggable
 
   use_extension(Blacklight::Solr::Document::RisExport)
-
-  delegate :dig, :[], to: :@_source
-
-  def []=(key, value)
-    @_source = @_source.merge("#{key}": value)
-  end
-
 
   # self.unique_key = "id"
   field_semantics.merge!(


### PR DESCRIPTION
Articles were breaking because BL7 does not allow []= for document obj.