### PR TITLE
[BL-348] Implement Content DM API integration.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ gem "rsolr", "~> 1.0"
 gem "devise"
 gem "devise-guests", "~> 0.5"
 gem "alma", git: "https://github.com/tulibraries/alma_rb.git", branch: "master"
+gem "cdm", git: "https://github.com/tulibraries/cdm_rb.git", branch: "master"
 # 1/31/17 - Hashie 3.5.0 breaks omniauth, so peg to previous
 gem "hashie", "~>3.4.6"
 gem "omniauth"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,15 @@ GIT
       rails (>= 4.2, < 6)
 
 GIT
+  remote: https://github.com/tulibraries/cdm_rb.git
+  revision: d20d9c1adee7c29c3e471a79c63168dba34dbc26
+  branch: master
+  specs:
+    cdm (0.1.0)
+      httparty
+      nokogiri
+
+GIT
   remote: https://github.com/tulibraries/primo
   revision: 06e423aa9573b20cc6c4f5d592c3ef0eef1016b7
   specs:
@@ -513,6 +522,7 @@ DEPENDENCIES
   browser
   byebug
   capybara
+  cdm!
   coffee-rails (~> 4.2)
   database_cleaner
   devise

--- a/app/assets/stylesheets/icons.css.erb
+++ b/app/assets/stylesheets/icons.css.erb
@@ -75,7 +75,9 @@ span.archival_material, a.facet_archival_material {
   background: transparent url(<%= asset_path 'icons/box.png' %>) no-repeat top left;
   padding-left: 26px;
 }
-span.visual_material, a.facet_visual_material, a.facet_visual_materials {
+span.visual_material, a.facet_visual_material, a.facet_visual_materials
+span.cdm, a.facet_cdm, span.facet_cdm
+{
   background: transparent url(<%= asset_path 'icons/visual_material.png' %>) no-repeat top left;
   padding-left: 26px;
 }

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -5,17 +5,20 @@ class SearchController < CatalogController
   include CatalogConfigReinit
 
   blacklight_config.configure do |config|
+    config.search_fields = CatalogController.blacklight_config.search_fields
+    config.response_model = Search::Solr::Response
+
     config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :index_translate_resource_type_code, no_label: true
-    config.add_facet_field "format", label: "Resource Type", url_method: :path_for_more_facet
+    config.add_facet_field "format", label: "Resource Type", url_method: :path_for_more_facet, helper_method: :translate_resource_type_code, show: true
   end
 
   def index
     @per_page = 3
     if params[:q]
-      engines = %i( books articles journals databases more )
+      engines = %i( books articles journals databases more cdm)
       searcher = BentoSearch::ConcurrentSearcher.new(*engines)
       searcher.search(params[:q], per_page: @per_page, semantic_search_field: params[:field])
-      @results = split_more(searcher.results)
+      @results = split_and_merge(searcher.results)
       @response = @results["resource_types"]&.first&.custom_data
     end
 
@@ -32,27 +35,34 @@ class SearchController < CatalogController
     end
   end
 
-  # Splits results for the more engine into two bento_boxes.
-  def split_more(results)
-    unless results["more"].nil? || results["more"].empty?
-      items = results["more"][0...-1]
-      items.engine_id = results["more"].engine_id
-      items.total_items = results["more"].total_items
-      items.display_configuration = results["more"].display_configuration
+  private
+    # Splits results for the more engine into two bento_boxes.
+    # Merges cdm totals with more results.
+    def split_and_merge(results)
+      # We only care about cdm results count not bento box.
+      cdm_total_items = results["cdm"]&.total_items
 
-      resource_types = results["more"].last
-      resource_types.engine_id = "resource_types"
-      resource_types = ::BentoSearch::Results.new([resource_types])
-      resource_types.engine_id = "resource_types"
-      resource_types.total_items = results["more"].total_items
-      resource_types.display_configuration = BentoSearch.get_engine("resource_types").configuration[:for_display]
+      unless false #results["more"].blank? || cdm_total_items.nil?
+        items = results["more"][0...-1]
+        items.engine_id = results["more"].engine_id
+        items.total_items = results["more"].total_items
+        items.display_configuration = results["more"].display_configuration
 
-      results.merge(
-        "more" => items,
-        "resource_types" => resource_types,
-        )
-    else
-      results
+        resource_types = results["more"].last
+        resource_types.custom_data.merge_facet(name: "format", value: "cdm", hits: cdm_total_items)
+
+        resource_types = ::BentoSearch::Results.new([resource_types])
+        resource_types.engine_id = "resource_types"
+        resource_types.engine_id = "resource_types"
+        resource_types.total_items = 2 #results["more"].total_items
+        resource_types.display_configuration = BentoSearch.get_engine("resource_types").configuration[:for_display]
+
+        results.merge(
+          "more" => items,
+          "resource_types" => resource_types,
+          ).except("cdm")
+      else
+        results.except("cdm")
+      end
     end
-  end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -2,12 +2,16 @@
 
 module SearchHelper
   ##
-  # Links More bento block facet back to catalog.
+  # Links More bento block facet back to catalog or content DM link.
   # @param [Blacklight::Solr::Response::Facets::FacetField] facet_field
   # @param [String] item
   # @return [String]
   def path_for_more_facet(facet_field, item)
-    search_catalog_url(search_state.add_facet_params_and_redirect(facet_field, item))
+    if item.value == "cdm"
+      "https://digital.library.temple.edu/digital/search/searchterm/#{params[:q]}/order/nosort"
+    else
+      search_catalog_url(search_state.add_facet_params_and_redirect(facet_field, item))
+    end
   end
 
   def renderable_results(results = @results, options = {})
@@ -29,6 +33,7 @@ module SearchHelper
   def render_bento_results(results = @results, options = {})
     results_class = options[:results_class] || "row centered-bento bento-results"
     comp_class = options[:comp_class] || "col-xl-3 col-lg-3 col-md-3 col-sm-8 col-xs-12 bento_compartment"
+
     render partial: "bento_results", locals: {
       results_class: results_class,
       comp_class: comp_class,

--- a/app/models/search/solr/response.rb
+++ b/app/models/search/solr/response.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Search::Solr
+  class Response < Blacklight::Solr::Response
+    def merge_facet(name:, value:, hits: nil)
+      if self.dig("facet_counts", "facet_fields", name)
+        self["facet_counts"]["facet_fields"][name].append(value, hits)
+      else
+        self["facet_counts"]["facet_fields"][name] = [ value, hits ]
+      end
+    end
+  end
+end

--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -5,7 +5,7 @@ module BentoSearch
     include BentoSearch::SearchEngine
     include Blacklight::SearchHelper
 
-    delegate :blacklight_config, to: CatalogController
+    delegate :blacklight_config, to: SearchController
 
     def search_implementation(args)
       query = args.fetch(:query, "")

--- a/app/search_engines/bento_search/cdm_engine.rb
+++ b/app/search_engines/bento_search/cdm_engine.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module BentoSearch
+  class CDMEngine
+    include BentoSearch::SearchEngine
+
+    def search_implementation(args)
+      query = args.fetch(:query, "")
+
+      # Avoid making a costly call for no reason.
+      if query.empty?
+        response = { "docs" => [] }
+      else
+        response = CDM::find(query)
+      end
+
+      results = BentoSearch::Results.new
+      results.total_items = response.dig("results", "pager", "total") || 0
+      results << BentoSearch::ResultItem.new(custom_data: response)
+
+      results
+    end
+  end
+end

--- a/config/initializers/bento_search.rb
+++ b/config/initializers/bento_search.rb
@@ -54,3 +54,11 @@ BentoSearch.register_engine("articles") do |conf|
     display.no_results_partial = "bento_search/no_article_results"
   end
 end
+
+BentoSearch.register_engine("cdm") do |conf|
+  conf.engine = "BentoSearch::CDMEngine"
+  conf.for_display do |display|
+    display.decorator = "TulDecorator"
+    display.no_results_partial = "bento_search/no_article_results"
+  end
+end

--- a/config/initializers/cdm.rb
+++ b/config/initializers/cdm.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+CDM.configure do |config|
+  config.server_url = "https://server16002.contentdm.oclc.org"
+  config.max_recs = "1"
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,6 +251,7 @@ en:
     text_resource: "Text Resource"
     websites: "Website"
     website: "Website"
+    cdm: "Digital Collections"
   language_code:
     ar: "Afar"
     abk: "Abkhaz"

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SearchController, type: :controller do
+
+  describe "#split_and_merge" do
+    let(:results) { BentoSearch::ConcurrentSearcher.new(:more, :cdm).search("foo").results }
+    let(:subject) { controller.send(:split_and_merge, results) }
+
+    before {
+      stub_request(:get, /contentdm/)
+        .to_return(status: 200,
+                  headers: { "Content-Type" => "application/json" },
+                  body: JSON.dump(content_dm_results))
+    }
+
+    context "content dm and regular results are present" do
+
+      it "merges content-dm totals with resource types format facets" do
+        facets = subject["resource_types"].first.custom_data.facet_fields
+        expect(facets).to eq("format" => [ "cdm", "415" ])
+      end
+
+    end
+  end
+
+  def content_dm_results
+    { "results" => { "pager" => { "total" => "415" } } }
+  end
+end

--- a/spec/models/search/solr/response_spec.rb
+++ b/spec/models/search/solr/response_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Search::Solr::Response, type: :model do
       end
     end
 
-    context "facet exits and field exists" do
+    context "facet exists and field exists" do
       let(:facet) { { name: "cat", value: "memory", hits: 4 } }
 
       it "appends the new field name and value and aggregations uses new value" do

--- a/spec/models/search/solr/response_spec.rb
+++ b/spec/models/search/solr/response_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Search::Solr::Response, type: :model do
+
+  let (:config) { SearchController.blacklight_config }
+  let (:response) { Search::Solr::Response.new(facet_counts, {}, { blacklight_config: config }) }
+  let (:facet) { { name: "foo", value: "bar", hits: 1 } }
+
+
+  describe ".merge_facet" do
+    before  do
+      response.merge_facet(facet)
+    end
+
+    context "facet does not already exist" do
+      it "adds the facet and appends the new field name and value" do
+        expect(response.facet_fields["foo"]).to eq(["bar", 1])
+      end
+    end
+
+    context "facet exists but field does not exist" do
+      let(:facet) { { name: "cat", value: "bar", hits: 1 } }
+
+      it "appends the new field name and value" do
+        expect(response.facet_fields["cat"]).to eq(["memory", 3, "card", 2, "bar", 1])
+      end
+    end
+
+    context "facet exits and field exists" do
+      let(:facet) { { name: "cat", value: "memory", hits: 4 } }
+
+      it "appends the new field name and value and aggregations uses new value" do
+        expect(response.aggregations["cat"].items.count).to eq(2)
+        expect(response.aggregations["cat"].items.first.value).to eq("memory")
+        expect(response.aggregations["cat"].items.first.hits).to eq(4)
+      end
+    end
+  end
+
+  def facet_counts
+    { "facet_counts" =>
+      { "facet_fields" => {
+        "cat" => [ "memory", 3, "card", 2 ],
+        "manu" => [ "belkin", 2, "canon", 2 ] } } }
+  end
+
+end

--- a/spec/search_engines/cdm_seach_spec.rb
+++ b/spec/search_engines/cdm_seach_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "cdm search engine", type: :search_engine do
+
+  let(:search_results) { BentoSearch.get_engine("cdm").search("foo") }
+  let(:content_dm_results) { { "results" => { "pager" => { "total" => "415" } } } }
+
+  it "sets the total found items" do
+    stub_request(:get, /contentdm/)
+      .to_return(status: 200,
+    headers: { "Content-Type" => "application/json" },
+    body: JSON.dump(content_dm_results))
+
+    expect(search_results.total_items).to eq("415")
+  end
+end


### PR DESCRIPTION
REF BL-348

 ## Requirements

 * In the "Resource Type" column of the bento box, add Resource type
 value for "Digital Collections"

 * This value should include the number of results that there are for
 that query in ContentDM, accessed via ContentDM API

 * The facet link itself should open the search results for ContentDM,
 with the basic query from the Library Search.