### PR TITLE
[BL-438] Fix blacklight_config method error.

### DIFF
--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -5,7 +5,7 @@ module BentoSearch
     include BentoSearch::SearchEngine
     include Blacklight::SearchHelper
 
-    delegate :blacklight_config, to: SearchController
+    delegate :blacklight_config, to: ::SearchController
 
     def search_implementation(args)
       query = args.fetch(:query, "")

--- a/app/search_engines/bento_search/cdm_engine.rb
+++ b/app/search_engines/bento_search/cdm_engine.rb
@@ -4,6 +4,8 @@ module BentoSearch
   class CDMEngine
     include BentoSearch::SearchEngine
 
+    delegate :blacklight_config, to: ::SearchController
+
     def search_implementation(args)
       query = args.fetch(:query, "")
 


### PR DESCRIPTION
Fixes no method `blacklight_config` for BentoSearch::SearchController on
libqa.