### PR TITLE
[BL-438] Sort facet items on merges.

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -9,7 +9,7 @@ class SearchController < CatalogController
     config.response_model = Search::Solr::Response
 
     config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :index_translate_resource_type_code, no_label: true
-    config.add_facet_field "format", label: "Resource Type", url_method: :path_for_more_facet, helper_method: :translate_resource_type_code, show: true, limit: -1, sort_method: nil
+    config.add_facet_field "format", label: "Resource Type", url_method: :path_for_more_facet, helper_method: :translate_resource_type_code, show: true, limit: -1
   end
 
   def index

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -9,7 +9,7 @@ class SearchController < CatalogController
     config.response_model = Search::Solr::Response
 
     config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :index_translate_resource_type_code, no_label: true
-    config.add_facet_field "format", label: "Resource Type", url_method: :path_for_more_facet, helper_method: :translate_resource_type_code, show: true
+    config.add_facet_field "format", label: "Resource Type", url_method: :path_for_more_facet, helper_method: :translate_resource_type_code, show: true, limit: -1, sort_method: nil
   end
 
   def index

--- a/app/models/search/solr/response.rb
+++ b/app/models/search/solr/response.rb
@@ -4,7 +4,14 @@ module Search::Solr
   class Response < Blacklight::Solr::Response
     def merge_facet(name:, value:, hits: nil)
       if self.dig("facet_counts", "facet_fields", name)
-        self["facet_counts"]["facet_fields"][name].append(value, hits)
+        # We need to sort on merge or facet item always appends to list.
+        sort_proc = blacklight_config.facet_fields[name].sort_proc ||
+          -> (f) { (v, _) = f; -v.titleize }
+
+        merged = Hash[*facet_fields[name]]
+          .merge(value => hits).sort_by(&sort_proc)
+
+        self["facet_counts"]["facet_fields"][name] = merged.to_a.flatten
       else
         self["facet_counts"]["facet_fields"][name] = [ value, hits ]
       end

--- a/app/models/search/solr/response.rb
+++ b/app/models/search/solr/response.rb
@@ -5,7 +5,7 @@ module Search::Solr
     def merge_facet(name:, value:, hits: nil)
       if self.dig("facet_counts", "facet_fields", name)
         # We need to sort on merge or facet item always appends to list.
-        sort_proc = blacklight_config.facet_fields[name].sort_proc ||
+        sort_proc = blacklight_config.facet_fields[name]&.sort_proc ||
           -> (f) { (v, _) = f; -v.titleize }
 
         merged = Hash[*facet_fields[name]]

--- a/spec/models/search/solr/response_spec.rb
+++ b/spec/models/search/solr/response_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Search::Solr::Response, type: :model do
     context "when a sorting procedure is provided" do
       let(:facet) { { name: "cat", value: "bar", hits: 1 } }
       let(:config) {
-        bc = CatalogController.blacklight_config
+        bc = Blacklight::Configuration.new
         bc.add_facet_field "cat", sort_proc: -> (f) { (_, h) = f; -h }
         bc
       }

--- a/spec/models/search/solr/response_spec.rb
+++ b/spec/models/search/solr/response_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe Search::Solr::Response, type: :model do
 
   describe ".merge_facet" do
-    let(:response) { Search::Solr::Response.new(facet_counts, {}, {}) }
+    let(:config) { CatalogController.blacklight_config }
+    let(:response) { Search::Solr::Response.new(facet_counts, {}, { blacklight_config: config }) }
     let(:facet) { { name: "foo", value: "bar", hits: 1 } }
 
     before  do
@@ -21,18 +22,31 @@ RSpec.describe Search::Solr::Response, type: :model do
     context "facet exists but field does not exist" do
       let(:facet) { { name: "cat", value: "bar", hits: 1 } }
 
-      it "appends the new field name and value" do
-        expect(response.facet_fields["cat"]).to eq(["memory", 3, "card", 2, "bar", 1])
+      it "merges the new field name and sorts by value asc" do
+        expect(response.facet_fields["cat"]).to eq(["bar", 1, "card", 2, "memory", 3])
       end
     end
 
     context "facet exists and field exists" do
       let(:facet) { { name: "cat", value: "memory", hits: 4 } }
 
-      it "appends the new field name and value and aggregations uses new value" do
+      it "merges the new field overriding the old value" do
         expect(response.aggregations["cat"].items.count).to eq(2)
-        expect(response.aggregations["cat"].items.first.value).to eq("memory")
-        expect(response.aggregations["cat"].items.first.hits).to eq(4)
+        expect(response.aggregations["cat"].items.last.value).to eq("memory")
+        expect(response.aggregations["cat"].items.last.hits).to eq(4)
+      end
+    end
+
+    context "when a sorting procedure is provided" do
+      let(:facet) { { name: "cat", value: "bar", hits: 1 } }
+      let(:config) {
+        bc = CatalogController.blacklight_config
+        bc.add_facet_field "cat", sort_proc: -> (f) { (_, h) = f; -h }
+        bc
+      }
+
+      it "uses the defining sorting proc to do the sorting" do
+        expect(response.facet_fields["cat"]).to eq(["memory", 3, "card", 2, "bar", 1])
       end
     end
 


### PR DESCRIPTION
If we do not sort a merged facet item then the item will just appear at
the end of the list.  By providing a default sorting order with the
possibility to overriding we can merge new facets without braking the
expected behavior.