### PR TITLE
[BL-438] Update digital collection label for ordering.

### DIFF
--- a/app/assets/stylesheets/icons.css.erb
+++ b/app/assets/stylesheets/icons.css.erb
@@ -76,7 +76,7 @@ span.archival_material, a.facet_archival_material {
   padding-left: 26px;
 }
 span.visual_material, a.facet_visual_material, a.facet_visual_materials
-span.cdm, a.facet_cdm, span.facet_cdm
+span.digital_collections, a.facet_digital_collections, span.facet_digital_collections
 {
   background: transparent url(<%= asset_path 'icons/visual_material.png' %>) no-repeat top left;
   padding-left: 26px;

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -49,7 +49,7 @@ class SearchController < CatalogController
         items.display_configuration = results["more"].display_configuration
 
         resource_types = results["more"].last
-        resource_types.custom_data.merge_facet(name: "format", value: "cdm", hits: cdm_total_items)
+        resource_types.custom_data.merge_facet(name: "format", value: "digital_collections", hits: cdm_total_items)
 
         resource_types.engine_id = "resource_types"
         resource_types = ::BentoSearch::Results.new([resource_types])

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -7,7 +7,7 @@ module SearchHelper
   # @param [String] item
   # @return [String]
   def path_for_more_facet(facet_field, item)
-    if item.value == "cdm"
+    if item.value == "digital_collections"
       "https://digital.library.temple.edu/digital/search/searchterm/#{params[:q]}/order/nosort"
     else
       search_catalog_url(search_state.add_facet_params_and_redirect(facet_field, item))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,7 +251,7 @@ en:
     text_resource: "Text Resource"
     websites: "Website"
     website: "Website"
-    cdm: "Digital Collections"
+    digital_collections: "Digital Collections"
   language_code:
     ar: "Afar"
     abk: "Abkhaz"

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SearchController, type: :controller do
 
       it "merges content-dm totals with resource types format facets" do
         facets = subject["resource_types"].first.custom_data.facet_fields
-        expect(facets).to eq("format" => [ "cdm", "415" ])
+        expect(facets).to eq("format" => [ "digital_collections", "415" ])
       end
 
     end


### PR DESCRIPTION
Sort is using cdm instead of digital_collection so "Digital Collection"
appears before "C" in the sorted list.