### PR TITLE
[BL-800] Fix solr search breaks on unknown sort field.

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -115,6 +115,28 @@ class SearchBuilder < Blacklight::SearchBuilder
     end
   end
 
+  # Overrides parent:sort using BL-7 definition.
+  #
+  # This can be removed once we officially upgrade to BL-7.
+  # Decode the user provided 'sort' parameter into a sort string that can be
+  # passed to the search.  This sanitizes the input by ensuring only
+  # configured search values are passed through to the search.
+  # @return [String] the field/fields to sort by
+  def sort
+    sort_field =
+      if blacklight_params[:sort].blank?
+        # no sort param provided, use default
+        blacklight_config.default_sort_field
+      else
+        # check for sort field key
+        blacklight_config.sort_fields[blacklight_params[:sort]]
+      end
+    return sort_field.sort if sort_field.present?
+
+    Blacklight.logger.warn "Invalid sort field: '#{blacklight_params[:sort]}' was provided."
+    nil
+  end
+
   private
     # Updates in place the query values in params by folding the named
     # procedures passed in through the values.


### PR DESCRIPTION
REF BL-800

 ## Description:
  1. Start with an articles advanced search
  2. Once you get some results, click on “More” to switch view.
  3. “More” results page errors out.

  This also happens when switching to Books or Journals. The reverse behavior (Books/Journals/Catalog advanced search to Articles) works as expected.

 ## Solution
 Patched with BL-7 `def sort` which does not attempt to pass unknown
 sorting fields to solr.