### PR TITLE
Fix primo advanced articles search breaks.

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -3,6 +3,12 @@
 module AdvancedHelper
   include BlacklightAdvancedSearch::AdvancedHelperBehavior
 
+  def sort_fields
+    active_sort_fields.values.map { |field_config|
+      [sort_field_label(field_config.key), field_config.key]
+    }
+  end
+
   def label_tag_default_for(key)
     unless params[key]
       if ("f_1" == key)

--- a/app/views/advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/advanced/_advanced_search_submit_btns.html.erb
@@ -2,7 +2,7 @@
   <div class="col-xs-12 col-sm-6">
     <div class="sort-buttons pull-left">
       <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "control-label") %>
-      <% sort_fields = active_sort_fields.values.map { |field_config| [sort_field_label(field_config.key), field_config.key] } %>
+
       <%= select_tag(:sort, options_for_select(sort_fields, h(current_sort_field && current_sort_field.key)), :class => "form-control sort-select") %>
       <%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
     </div>

--- a/app/views/primo_advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/primo_advanced/_advanced_search_submit_btns.html.erb
@@ -1,5 +1,7 @@
 <div class="row">
   <div class="col-xs-12 col-sm-6">
+      <% sort_fields = active_sort_fields.values.map { |field_config| [sort_field_label(field_config.key), field_config.key] } %>
+
     <% if !sort_fields.empty? %>
     <div class="sort-buttons pull-left">
         <%= label_tag(:sort, t('blacklight_advanced_search.form.sort_label'), :class => "control-label") %>

--- a/app/views/primo_advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/primo_advanced/_advanced_search_submit_btns.html.erb
@@ -1,6 +1,5 @@
 <div class="row">
   <div class="col-xs-12 col-sm-6">
-      <% sort_fields = active_sort_fields.values.map { |field_config| [sort_field_label(field_config.key), field_config.key] } %>
 
     <% if !sort_fields.empty? %>
     <div class="sort-buttons pull-left">


### PR DESCRIPTION
* Add missing helper method `sort_fields`
* Replace views level definitions with helper method.