### PR TITLE
Add privacy features to event tracking and pageviews.

### DIFF
--- a/app/assets/javascripts/listeners.js
+++ b/app/assets/javascripts/listeners.js
@@ -53,7 +53,9 @@ $(document).ready(function(){
       ga('send', 'event', {
         eventCategory: 'Click Event',
         eventAction: 'click',
-        eventLabel: event
+        eventLabel: event,
+        forceSSL: true,
+        anonymizeIp: true
       });
     }
   }

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -27,7 +27,7 @@
     <%= javascript_pack_tag "application", 'data-turbolinks-track': 'reload', defer: true %>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
-    <%= analytics_init if GoogleAnalytics.valid_tracker? %>
+    <%= analytics_init({anonymize: true}) if GoogleAnalytics.valid_tracker? %>
   </head>
   <body class="<%= render_body_class %>">
     <div id="page-wrapper">


### PR DESCRIPTION
The google-analytics-rails gem does not have the forceSSL option.