### PR TITLE
[BL-810] Update AZ database display.

### DIFF
--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -28,14 +28,16 @@ class DatabasesController < CatalogController
 
     # Index fields
     config.add_index_field "id", label: "AZ ID"
-    config.add_index_field "az_vendor_id_display", label: "AZ Vendor ID"
-    config.add_index_field "note_display", label: "Note", raw: true, helper_method: :join
+    config.add_index_field "az_vendor_name_display", label: "AZ Vendor ID"
+    config.add_index_field "note_display", label: "Description", raw: true, helper_method: :join
+    config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :separate_formats
     config.add_index_field "availability"
 
     # Show fields
-    config.add_show_field "id", label: "AZ ID"
-    config.add_show_field "note_display", label: "Note", raw: true, helper_method: :join
+    config.add_show_field "id", label: "Database Record ID"
+    config.add_show_field "note_display", label: "Description", raw: true, helper_method: :join
     config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :check_for_full_http_link, if: false
+    config.add_show_field "subject_display", label: "Subject", helper_method: :subject_links, multi: true
 
     # Search fields
     config.add_search_field("title") do |field|

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -252,7 +252,7 @@ module CatalogHelper
 
   def subject_links(args)
     args[:document][args[:field]].map do |subject|
-      link_to(subject.sub("— — ", "— "), "#{search_catalog_path}?f[subject_facet][]=#{CGI.escape subject}")
+      link_to(subject.sub("— — ", "— "), "#{base_path}?f[subject_facet][]=#{CGI.escape subject}")
     end
   end
 

--- a/lib/traject/databases_az_indexer_config.rb
+++ b/lib/traject/databases_az_indexer_config.rb
@@ -29,10 +29,13 @@ each_record do |record, context|
 end
 
 to_field "id", extract_json("$.id")
-to_field "format", ->(rec, acc) { acc << "Database" }
+to_field "format", ->(rec, acc) {
+  rec["az_types"]&.each { |type| acc << type["name"] } || acc << "Database"
+}
 to_field "title_t", extract_json("$.name")
 to_field "title_statement_display", extract_json("$.name")
 to_field "az_vendor_id_display", extract_json("$.az_vendor_id")
+to_field "az_vendor_name_display", extract_json("$.az_vendor_name")
 
 to_field "note_display", extract_json("$.description")
 to_field "note_t", extract_json("$.description")

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -369,6 +369,12 @@ RSpec.describe CatalogHelper, type: :helper do
   end
 
   describe "#subject_links(args)" do
+    let(:base_path) { "foo" }
+
+    before do
+      allow(helper).to receive(:base_path) { base_path }
+    end
+
     context "links to exact subject facet string" do
       let(:args) {
           {
@@ -381,10 +387,10 @@ RSpec.describe CatalogHelper, type: :helper do
         }
 
       it "includes link to exact subject" do
-        expect(subject_links(args).first).to have_link("Middle East", href: "#{search_catalog_path}?f[subject_facet][]=Middle+East")
+        expect(subject_links(args).first).to have_link("Middle East", href: "#{base_path}?f[subject_facet][]=Middle+East")
       end
       it "does not link to only part of the subject" do
-        expect(subject_links(args).first).to have_no_link("Middle East", href: "#{search_catalog_path}?f[subject_facet][]=Middle")
+        expect(subject_links(args).first).to have_no_link("Middle East", href: "#{base_path}?f[subject_facet][]=Middle")
       end
     end
 
@@ -399,7 +405,7 @@ RSpec.describe CatalogHelper, type: :helper do
           }
         }
       it "includes link to whole subject string" do
-        expect(subject_links(args).first).to have_link("Regions & Countries - Asia & the Middle East", href: "#{search_catalog_path}?f[subject_facet][]=Regions+%26+Countries+-+Asia+%26+the+Middle+East")
+        expect(subject_links(args).first).to have_link("Regions & Countries - Asia & the Middle East", href: "#{base_path}?f[subject_facet][]=Regions+%26+Countries+-+Asia+%26+the+Middle+East")
       end
     end
 


### PR DESCRIPTION
* AZ Vendor ID display field: We need to either remove the AZ Vendor ID from display or replace it with the text value. The latter would require retrieving data for a translation map from vendor ID’s to vendor names – can this be done systematically, or would it need to be maintained manually?

* Note display field: change label from “Note” to “Description” for all displays

* For brief results display: remove ID fields, add resource type field/icon (see indexing section for details)

* For full record page display : add subject_display, with links back to search, and resource type field/icon; update label “AZ ID” to “Database Record ID” and move to bottom