### PR TITLE
[BL-10:BL-808] Add resource type facet to databases.

### DIFF
--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -21,10 +21,10 @@ class DatabasesController < CatalogController
           electronic_resource_display:[json] ].join(",")
     }
 
-
     # Facet fields
     config.add_facet_field "availability_facet", label: "Availability", home: true, collapse: false
     config.add_facet_field "subject_facet", label: "Subject", limit: true, show: true
+    config.add_facet_field "format", label: "Resource Type", limit: -1, show: true, home: true
 
     # Index fields
     config.add_index_field "id", label: "AZ ID"


### PR DESCRIPTION
* Add secondary value for “Resource Type” field – by default, all records will have a value of “Database”; but there should also be secondary resource type values mapped from the AZ field for “type” (ex. image). We will need to change translation map from raw AZ values to standard resource type values in the Library Search.

* Add “Resource Type” facet, but exclude main “Database” value from display and show only secondary resource type values (see indexing section for details)