### PR TITLE
[BL-814] Fix issue with book bookmark items.

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -407,4 +407,13 @@ module CatalogHelper
   def doc_redirect_url(id)
     new_user_session_with_redirect_path("#{request.url}##{doc_id(id)}")
   end
+
+  ##
+  # Overrides Blacklight::BlacklightHelperBehavior.boomarked? so that books and
+  # journal items are marked as bookmarked.
+  #
+  # Check if the document is in the user's bookmarks
+  def bookmarked?(document)
+    current_bookmarks.any? { |x| x.document_id == document.id }
+  end
 end


### PR DESCRIPTION
REF BL-814

 ## Description:

When items are bookmarked from the book or journal index pages they
do not appear as being bookmarked when viewing the bookmarked items.

This happens because of a conflict between the document.class and
bookmark.class.  For now we can fix this by just not checking against
that field as all our Solr document ids are uniq by default.