### PR TITLE
Enable suggestions for solr searches.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -204,7 +204,12 @@ class CatalogController < ApplicationController
         subject_addl_t^10
       ].join(" "),
       facet: "true",
-      spellcheck: "false",
+      spellcheck: "true",
+      "spellcheck.extendedResults": "true",
+      "spellcheck.collate": "true",
+      "spellcheck.collateParam.q.op": "AND",
+      "spellcheck.collateParam.mm": "100%",
+      "spellcheck.maxCollations": 3,
       sow: "false",
       bq: [
           "pub_date_tdt:[NOW/DAY-10YEAR TO NOW/DAY]^3500",

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -416,4 +416,10 @@ module CatalogHelper
   def bookmarked?(document)
     current_bookmarks.any? { |x| x.document_id == document.id }
   end
+
+  def suggestions
+    (@response.dig("spellcheck", "collations") || [])
+      .each_slice(2)
+      .map { |_, phrase| link_to_query(phrase) }
+  end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -12,6 +12,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   self.default_processor_chain +=
     %i[ add_advanced_parse_q_to_solr
         add_advanced_search_to_solr
+        spellcheck
         limit_facets ]
 
   if ENV["SOLR_SEARCH_TWEAK_ENABLE"] == "on"
@@ -22,6 +23,12 @@ class SearchBuilder < Blacklight::SearchBuilder
     # The negative query will work even when items are not indexed.
     # We can refactor to use a positive query once indexing occurs.
     solr_params["fq"] = solr_params["fq"].push("-purchase_order:true")
+  end
+
+  def spellcheck(solr_parameters)
+    if is_advanced_search?
+      solr_parameters["spellcheck"] = false
+    end
   end
 
   def limit_facets(solr_parameters)

--- a/app/views/catalog/_did_you_mean.html.erb
+++ b/app/views/catalog/_did_you_mean.html.erb
@@ -1,0 +1,7 @@
+<% # Overridden from Blacklight in order to use collations. %>
+
+<% if should_show_spellcheck_suggestions? @response %>
+  <div id="spell">
+    <h4 class="suggest"><em><%= t('blacklight.did_you_mean', :options => safe_join(suggestions, " #{t('blacklight.or')} ")).html_safe %></em></h4>
+  </div>
+<% end %>

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -92,6 +92,29 @@ RSpec.describe SearchBuilder , type: :model do
     end
   end
 
+  describe "#spellcheck" do
+    let(:solr_parameters) {
+      sp = Blacklight::Solr::Request.new
+      sp["qf"] = "foo"
+      sp
+    }
+
+    before(:example) do
+      allow(search_builder).to receive(:blacklight_params).and_return(params)
+      allow(search_builder).to receive(:is_advanced_search?).and_return(is_advanced_search?)
+
+      subject.spellcheck(solr_parameters)
+    end
+
+    context "is advanced search" do
+      let(:is_advanced_search?)  { true }
+
+      it "disables spellcheck" do
+        expect(solr_parameters["spellcheck"]).to eq(false)
+      end
+    end
+  end
+
   describe "#process_begins_with" do
     it "can handle nil gracefully" do
       expect(subject.process_begins_with(nil, nil)).to be_nil


### PR DESCRIPTION
REF BL-316

* Makes suggestions on entire phrase (not just per word)
* Max suggestions is 3 (default is 1)
* Disables suggestions for advanced search (does not work)