### PR TITLE
Fix send to email from books and journals.

### DIFF
--- a/app/models/solr_book_document.rb
+++ b/app/models/solr_book_document.rb
@@ -1,13 +1,3 @@
 # frozen_string_literal: true
 
-class SolrBookDocument < SolrDocument
-  use_extension(Blacklight::Document::Email)
-  use_extension(Blacklight::Document::Sms)
-
-  # Add Blacklight-Marc extension:
-  SolrBookDocument.use_extension(Blacklight::Solr::Document::Marc) do |doc|
-    doc.has_field? "marc_display_raw"
-  end
-  SolrBookDocument.extension_parameters[:marc_source_field] = "marc_display_raw"
-  SolrBookDocument.extension_parameters[:marc_format_type] = :marcxml
-end
+SolrBookDocument = SolrDocument

--- a/app/models/solr_journal_document.rb
+++ b/app/models/solr_journal_document.rb
@@ -1,12 +1,3 @@
 # frozen_string_literal: true
 
-class SolrJournalDocument < SolrDocument
-  use_extension(Blacklight::Document::Email)
-  use_extension(Blacklight::Document::Sms)
-
-  SolrJournalDocument.use_extension(Blacklight::Solr::Document::Marc) do |doc|
-    doc.has_field? "marc_display_raw"
-  end
-  SolrJournalDocument.extension_parameters[:marc_source_field] = "marc_display_raw"
-  SolrJournalDocument.extension_parameters[:marc_format_type] = :marcxml
-end
+SolrJournalDocument = SolrDocument


### PR DESCRIPTION
REF BL-822

Send to email is broken from books and journal page because those
document classes are not being extended properly.

Since these classes should act as aliases to SolrDocument anyway,
updating them to equal SolrDocument fixes the issue.