### PR TITLE
[BL-814] Fix bookmark not working from book or journal.

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -408,15 +408,6 @@ module CatalogHelper
     new_user_session_with_redirect_path("#{request.url}##{doc_id(id)}")
   end
 
-  ##
-  # Overrides Blacklight::BlacklightHelperBehavior.boomarked? so that books and
-  # journal items are marked as bookmarked.
-  #
-  # Check if the document is in the user's bookmarks
-  def bookmarked?(document)
-    current_bookmarks.any? { |x| x.document_id == document.id }
-  end
-
   def suggestions
     (@response.dig("spellcheck", "collations") || [])
       .each_slice(2)

--- a/app/models/solr_book_document.rb
+++ b/app/models/solr_book_document.rb
@@ -1,13 +1,3 @@
 # frozen_string_literal: true
 
-class SolrBookDocument < SolrDocument
-  use_extension(Blacklight::Document::Email)
-  use_extension(Blacklight::Document::Sms)
-
-  # Add Blacklight-Marc extension:
-  SolrBookDocument.use_extension(Blacklight::Solr::Document::Marc) do |doc|
-    doc.has_field? "marc_display_raw"
-  end
-  SolrBookDocument.extension_parameters[:marc_source_field] = "marc_display_raw"
-  SolrBookDocument.extension_parameters[:marc_format_type] = :marcxml
-end
+SolrBookDocument = SolrDocument

--- a/app/models/solr_journal_document.rb
+++ b/app/models/solr_journal_document.rb
@@ -1,12 +1,3 @@
 # frozen_string_literal: true
 
-class SolrJournalDocument < SolrDocument
-  use_extension(Blacklight::Document::Email)
-  use_extension(Blacklight::Document::Sms)
-
-  SolrJournalDocument.use_extension(Blacklight::Solr::Document::Marc) do |doc|
-    doc.has_field? "marc_display_raw"
-  end
-  SolrJournalDocument.extension_parameters[:marc_source_field] = "marc_display_raw"
-  SolrJournalDocument.extension_parameters[:marc_format_type] = :marcxml
-end
+SolrJournalDocument = SolrDocument

--- a/lib/tasks/temporary/bookmarks.rake
+++ b/lib/tasks/temporary/bookmarks.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+namespace :bookmarks do
+  desc "Updates to boomark data."
+
+  task update_bookmark_document_type: :environment do
+    bookmarks = Bookmark.where("document_type LIKE ?", "Solr%Document")
+
+    puts "Going to update #{bookmarks.count} bookmarks"
+
+    ActiveRecord::Base.transaction do
+      bookmarks.update(document_type: "SolrDocument")
+    end
+
+    puts "Finished updating bookmarks."
+  end
+end


### PR DESCRIPTION
REF BL-814
REF BL-822

Having books and journal documents be represented by different models
SolrBookDocument and SolrJournalDocument that derive from the
SolrDocument is causing both the bookmark and email functionality for
these documents to fail when actions occur from the bookmark or journal
index pages.

This is partly do to a misconfiguration.  Although we need these models
in order to have correct paths .. they should be equal to SolrDocument
not derive from.

Updating them to equal SolrDocument fixes both the issues with
bookmarking and the issue with sending emails.

## Depends on

* Also adds temporary rake task to fix old data in the bookmarks table.
- [ ] This rake task needs to be run in order for fix to take full effect