### PR TITLE
[BL-814] Override the default catalog URL.

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,6 +5,7 @@ class BooksController < CatalogController
   add_breadcrumb "Record", :solr_book_document_path, only: [ :show ]
 
   configure_blacklight do |config|
+    config.show.route = { controller: "books" }
     config.search_builder_class = BooksSearchBuilder
     config.document_model = ::SolrBookDocument
     # Do not allow any further filtering on type.

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -7,6 +7,7 @@ class JournalsController < CatalogController
   add_breadcrumb "Record", :solr_journal_document_path, only: [ :show ]
 
   configure_blacklight do |config|
+    config.show.route = { controller: "journals" }
     config.search_builder_class = JournalsSearchBuilder
     config.document_model = SolrJournalDocument
     # Do not allow any further filtering on type.


### PR DESCRIPTION
Blacklight has a way to override the default routing behavior for
indexed document via configurations. @see
Blacklight::SearchState.url_for_document. This commit updates the
configurations for books_controller and journals_controller to point
index urls to the right place.