### PR TITLE
[BL-399] Fix database show page broken after BL-7 upgrade.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -217,4 +217,10 @@ module ApplicationHelper
       format = "Chicago Notes & Bibliography (15th)/Turabian (6th)"
     end
   end
+
+  def presenter_field_value(presenter, field)
+    if blacklight_config.show_fields[field]
+      presenter.field_value(blacklight_config.show_fields[field])
+    end
+  end
 end

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -5,7 +5,7 @@
   <div class="availability-card-heading card-title d-inline-flex justify-content-between align-items-center">
     <h4 id="availability-heading">Availability</h4>
     <div id="heading-request">
-      <%= doc_presenter.field_value(blacklight_config.show_fields["po_link"]) %>
+      <%= presenter_field_value(doc_presenter, "po_link") %>
 
       <div id="requests-container" class="hidden">
         <% if user_signed_in? %>
@@ -14,7 +14,7 @@
           <%= link_to(t("requests.log_in"), new_user_session_with_redirect_path(request.url),  data: {"blacklight-modal": "trigger"}, id: "request_options") %>
         <% end %>
       </div>
-    </div>
+    </div
   </div>
 
   <%= render_online_availability(doc_presenter) %>


### PR DESCRIPTION
A change in the way BL-7 adds fields to show page is causing a nil error
to now break databases show pages.

This commit adds a helper method to guard against nil values in this
context and fixes the issue with the databases show page.