### PR TITLE
[Bl-809] Databases AZ updates.

### DIFF
--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -39,12 +39,14 @@ class DatabasesController < CatalogController
     config.add_show_field "id", label: "Database Record ID"
 
     # Search fields
+    config.add_search_field "all_fields", label: "All Fields"
+
     config.add_search_field("title") do |field|
       # solr_parameters hash are sent to Solr as ordinary url query params.
       field.solr_parameters = { 'spellcheck.dictionary': "title" }
       field.solr_local_parameters = {
-        qf: "$title_qf",
-        pf: "$title_pf"
+        qf: "$title_t_qf $alt_names_t_qf",
+        pf: "$title_t_pf $alt_names_t_pf"
       }
     end
 
@@ -52,10 +54,15 @@ class DatabasesController < CatalogController
       field.solr_parameters = { 'spellcheck.dictionary': "subject" }
       field.qt = "search"
       field.solr_local_parameters = {
-        qf: "$subject_qf",
-        pf: "$subject_pf"
+        qf: "$subject_facet_qf",
+        pf: "$subject_facet_pf"
       }
     end
+
+    # Sort fields.
+    config.add_sort_field "score desc, title_sort asc", label: "relevance"
+    config.add_sort_field "title_sort asc", label: "title (A to Z)"
+    config.add_sort_field "title_sort desc", label: "title (Z to A)"
   end
 
   def join(args)

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -110,6 +110,8 @@ module AdvancedHelper
       search_journals_path
     elsif current_page? articles_advanced_search_path
       search_path
+    elsif current_page? databases_advanced_search_path
+      search_databases_path
     else
       search_catalog_path
     end
@@ -128,6 +130,12 @@ module AdvancedHelper
       t(:databases_advanced_search)
     else
       t(:catalog_advanced_search)
+    end
+  end
+
+  def render_pub_date_range
+    if blacklight_config.facet_fields["pub_date_sort"]
+      render "pub_date_sort_facet"
     end
   end
 end

--- a/app/views/advanced/_advanced_search_facets.html.erb
+++ b/app/views/advanced/_advanced_search_facets.html.erb
@@ -20,28 +20,4 @@
   </div>
 <% end %>
 </div>
-<div class="container">
-<div class="row">
-
-    <div class="col col-sm-3 control-label">
-      <%= label_tag "range_pub_date_sort_begin" do %>
-        Publication Year
-      <% end %>
-    </div>
-    <div class="col-sm-8 d-flex justify-content-between">
-    <div class="advanced-pub-date">
-      <span class="sr-only">Publication date range (starting year)</span>
-      <%= render_range_input("pub_date_sort", :begin) %>
-    </div>
-    <div class="pub-date-separator align-self-center">
-      <%= label_tag "range_pub_date_sort_end" do %>
-        to
-      <% end %>
-    </div>
-    <div class="advanced-pub-date">
-      <span class="sr-only">Publication date range (ending year)</span>
-      <%= render_range_input("pub_date_sort", :end) %>
-    </div>
-  </div>
-</div>
-</div>
+<%= render_pub_date_range %>

--- a/app/views/advanced/_pub_date_sort_facet.html.erb
+++ b/app/views/advanced/_pub_date_sort_facet.html.erb
@@ -1,0 +1,25 @@
+<div class="container">
+<div class="row">
+
+    <div class="col col-sm-3 control-label">
+      <%= label_tag "range_pub_date_sort_begin" do %>
+        Publication Year
+      <% end %>
+    </div>
+    <div class="col-sm-8 d-flex justify-content-between">
+    <div class="advanced-pub-date">
+      <span class="sr-only">Publication date range (starting year)</span>
+      <%= render_range_input("pub_date_sort", :begin) %>
+    </div>
+    <div class="pub-date-separator align-self-center">
+      <%= label_tag "range_pub_date_sort_end" do %>
+        to
+      <% end %>
+    </div>
+    <div class="advanced-pub-date">
+      <span class="sr-only">Publication date range (ending year)</span>
+      <%= render_range_input("pub_date_sort", :end) %>
+    </div>
+  </div>
+</div>
+</div>

--- a/lib/traject/databases_az_indexer_config.rb
+++ b/lib/traject/databases_az_indexer_config.rb
@@ -35,6 +35,8 @@ to_field "format", ->(rec, acc) {
   types.each { |type| acc << type["name"] }
 }
 to_field "title_t", extract_json("$.name")
+to_field "title_sort", extract_json("$.name")
+to_field "alt_names_t", extract_json("$.alt_names")
 to_field "title_statement_display", extract_json("$.name")
 to_field "az_vendor_id_display", extract_json("$.az_vendor_id")
 to_field "az_vendor_name_display", extract_json("$.az_vendor_name")

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe AdvancedHelper, type: :helper do
       allow(helper).to receive(:current_page?).with("/books/advanced") { false }
       allow(helper).to receive(:current_page?).with("/journals/advanced") { false }
       allow(helper).to receive(:current_page?).with("/articles/advanced") { false }
+      allow(helper).to receive(:current_page?).with("/databases/advanced") { false }
     end
 
     context "on the advanced catalog search page" do
@@ -132,6 +133,13 @@ RSpec.describe AdvancedHelper, type: :helper do
       it "renders the link to the articles search" do
         allow(helper).to receive(:current_page?).with("/articles/advanced") { true }
         expect(helper.basic_search_path).to eq("/articles")
+      end
+    end
+
+    context "on the advanced databases page" do
+      it "renders the link to the databases search" do
+        allow(helper).to receive(:current_page?).with("/databases/advanced") { true }
+        expect(helper.basic_search_path).to eq("/databases")
       end
     end
 


### PR DESCRIPTION
Makes the following changes:

* Adds an “All Fields” search option as default for basic search and add database description, subject, and id fields to search index, if not already present (basically all fields should be searchable, like the MARCXML record in the catalog)

* Fixes “Subject” drop-down option for basic search

* Fix advanced search goes to wrong path on submit

* Remove pub_date_sort facet search from databases advanced search form

* Add an alphabetical title sort

* Add AZ alternate title field to search index.