### PR TITLE
[BL-833] Fix everything search fails for some queries.

### DIFF
--- a/app/views/search/_blacklight_availability.html.erb
+++ b/app/views/search/_blacklight_availability.html.erb
@@ -2,5 +2,4 @@
   <%= link_to "Online", bento_single_link(item.custom_data["electronic_resource_display"]), class:"btn btn-sm bento-avail-btn", title:"This link opens the resource in a new tab.", target:"_blank", id: "one_online_button" %>
 <% elsif has_many_electronic_resources?(item.custom_data) %>
   <%= link_to "Online", solr_document_url(item.custom_data["id"]), class:"btn btn-sm bento-avail-btn", id: "many_online_button" %>
-<% elsif item.custom_data.has_direct_link? %>
 <% end %>


### PR DESCRIPTION
When searching for "Development and validation of the children’s
constructive conflict resolution scale" on libqa or production an error
is thrown due to not method found.

We are fixing this by removing the call to this method from a shared
template.  The call is not required since nothing happens even if it is
evaluated.