### PR TITLE
BL-835 Remove dropdown from bento view

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,6 +4,7 @@ class SearchController < CatalogController
   include CatalogConfigReinit
 
   blacklight_config.configure do |config|
+    config.add_search_field "all_fields", label: "All Fields"
     config.response_model = Search::Solr::Response
 
     config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :index_translate_resource_type_code, no_label: true

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,7 +4,6 @@ class SearchController < CatalogController
   include CatalogConfigReinit
 
   blacklight_config.configure do |config|
-    config.search_fields = CatalogController.blacklight_config.search_fields
     config.response_model = Search::Solr::Response
 
     config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :index_translate_resource_type_code, no_label: true

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -6,10 +6,12 @@
     <% end %>
 
     <div class="input-group d-flex">
-      <% if search_fields.length > 1 %>
-        <%= select_tag(:search_field, options_for_select(search_fields, h(search_params[:search_field])), title: t("blacklight.search.form.search_field.title"), id: "search_field", class: " custom-select search-field flex-shrink-1") %>
-      <% elsif search_fields.length == 1 %>
-        <%= hidden_field_tag :search_field, search_fields.first.last %>
+      <% if controller_name != "search" %>
+        <% if search_fields.length > 1 %>
+          <%= select_tag(:search_field, options_for_select(search_fields, h(search_params[:search_field])), title: t("blacklight.search.form.search_field.title"), id: "search_field", class: " custom-select search-field flex-shrink-1") %>
+        <% elsif search_fields.length == 1 %>
+          <%= hidden_field_tag :search_field, search_fields.first.last %>
+        <% end %>
       <% end %>
 
     <label for="q" class="sr-only"><%= t("blacklight.search.form.search.label") %></label>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -6,12 +6,10 @@
     <% end %>
 
     <div class="input-group d-flex">
-      <% if controller_name != "search" %>
-        <% if search_fields.length > 1 %>
-          <%= select_tag(:search_field, options_for_select(search_fields, h(search_params[:search_field])), title: t("blacklight.search.form.search_field.title"), id: "search_field", class: " custom-select search-field flex-shrink-1") %>
-        <% elsif search_fields.length == 1 %>
-          <%= hidden_field_tag :search_field, search_fields.first.last %>
-        <% end %>
+      <% if search_fields.length > 1 %>
+        <%= select_tag(:search_field, options_for_select(search_fields, h(search_params[:search_field])), title: t("blacklight.search.form.search_field.title"), id: "search_field", class: " custom-select search-field flex-shrink-1") %>
+      <% elsif search_fields.length == 1 %>
+        <%= hidden_field_tag :search_field, search_fields.first.last %>
       <% end %>
 
     <label for="q" class="sr-only"><%= t("blacklight.search.form.search.label") %></label>

--- a/spec/features/bento_search_spec.rb
+++ b/spec/features/bento_search_spec.rb
@@ -34,4 +34,12 @@ RSpec.feature "Bento Searches" do
       end
     end
   end
+
+  feature "Search Field dropdown should not appear in bento view" do
+    it "does not have a search field dropdown menu" do
+      visit "/"
+      expect(page).to_not have_css("#search_field")
+    end
+  end
+
 end


### PR DESCRIPTION
- The search fields select menu was accidentially introduced to the bento view.  It doesn't work properly, so it should be hidden for bento searches