### PR TITLE
[BL-836] Default to false when is_advanced_search? not available.

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -93,7 +93,8 @@ module AdvancedHelper
     my_params.except(:controller, :action)
       .select { |k, v|
       # Sometimes is_advanced_search? does not return true|false answer.
-      if !(is_advanced_search? == true)
+      # And, sometimes is_advanced_search? is not available at all.
+      if begin !(is_advanced_search? == true) rescue false end
         !k.match?(/^(q|op|f)_/)
       else
         true


### PR DESCRIPTION
Fixes error being caught in production where the method
is_advanced_search? is not present.  I cannot reproduce this locally but
regardless this method should assume that when that method is not
available then the search is not advanced.