### PR TITLE
BL-694 Remove link to refworks

### DIFF
--- a/app/views/bookmarks/_show_tools.html.erb
+++ b/app/views/bookmarks/_show_tools.html.erb
@@ -31,7 +31,6 @@
                 </div>
               <% end %>
               <div class="sendto-item dropdown-item">
-                <%= render :partial => "catalog/refworks_form", :locals => {:documents=> @document_list} %>
               </div>
             </div>
           </div>


### PR DESCRIPTION
- Refworks export is not working properly for bookmarked items.  Remove until we get it fixed.