### PR TITLE
Bl 815 physical item data

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -22,7 +22,7 @@ class AlmawsController < CatalogController
     @response = Blacklight::Alma::Response.new(bib_items, params)
 
     @items = bib_items.filter_missing_and_lost.grouped_by_library
-    @merged_response = helpers.document_and_api_merged_results(@document, @items)
+    @document_and_api_items = helpers.document_and_api_merged_results(@document, @items)
     #@holdings_summary = helpers.build_holdings_summary(@items, @document)
     #@items is mutated by unsuppressed_holdings and filter_unwanted_locations
     #helpers.filter_unwanted_locations(@items)

--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -22,10 +22,11 @@ class AlmawsController < CatalogController
     @response = Blacklight::Alma::Response.new(bib_items, params)
 
     @items = bib_items.filter_missing_and_lost.grouped_by_library
-    @holdings_summary = helpers.build_holdings_summary(@items, @document)
+    @merged_response = helpers.document_and_api_merged_results(@document, @items)
+    #@holdings_summary = helpers.build_holdings_summary(@items, @document)
     #@items is mutated by unsuppressed_holdings and filter_unwanted_locations
-    helpers.filter_unwanted_locations(@items)
-    helpers.unsuppressed_holdings(@items, @document)
+    #helpers.filter_unwanted_locations(@items)
+    #helpers.unsuppressed_holdings(@items, @document)
     @pickup_locations = CobAlma::Requests.valid_pickup_locations(@items).join(",")
     @request_level = has_desc?(bib_items) ? "item" : "bib"
     @redirect_to = params[:redirect_to]

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -239,6 +239,7 @@ class CatalogController < ApplicationController
         wt: "json",
         fl: %w[
           *
+          items_json_display:[json]
           url_finding_aid_display:[json]
           url_more_links_display:[json]
           electronic_resource_display:[json] ].join(",")

--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -100,7 +100,7 @@ module AlmaDataHelper
 
   def sort_order_for_holdings(grouped_items)
     sorted_library_hash = {}
-    sorted_library_hash.merge!("MAIN" => grouped_items.delete("MAIN")) if grouped_items.has_value?("MAIN")
+    sorted_library_hash.merge!("MAIN" => grouped_items.delete("MAIN")) if grouped_items.has_key?("MAIN")
     items_hash = grouped_items.sort_by { |k, v| library_name_from_short_code(k) }.to_h
     sorted_library_hash = sorted_library_hash.merge!(items_hash)
     sorted_library_hash.each do |lib, items|

--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -31,43 +31,54 @@ module AlmaDataHelper
   end
 
   def description(item)
-    if item.description.present?
-      return "Description: " + item.description
-    end
+    item["description"] ? "Description: #{item['description']}" : ""
   end
 
   def physical_material_type(item)
-    return  unless item.physical_material_type.present?
+    return unless item["material_type"].present?
 
-    type = item.physical_material_type["value"].to_s
+    type = item["material_type"]
 
     if !type.match(PHYSICAL_TYPE_EXCLUSIONS)
-      return item.physical_material_type["desc"]
+      return item["material_type"]
     end
   end
 
   def public_note(item)
-    if item.public_note.present?
-      return "Note: " + item.public_note
+    item["public_note"] ? "Note: #{item['public_note']}" : ""
+  end
+
+  def library(item)
+    item["current_library"] ? item["current_library"] : item["permanent_library"]
     end
-  end
 
-  def location_status(item)
-    location_name_from_short_code(item)
-  end
-
-  def location_name_from_short_code(item)
-    Rails.configuration.locations.dig(item.library, item.location) || item.location
+  def grouped_by_library(document)
+    group_by(&:library)
   end
 
   def library_name_from_short_code(short_code)
     Rails.configuration.libraries[short_code]
   end
 
-  def alternative_call_number(item)
-    if item.has_alt_call_number?
-      "(Also found under #{item.alt_call_number})"
+  def location(item)
+    item["current_location"] ? item["current_location"] : item["permanent_location"]
     end
+
+  def location_status(item)
+    location_name_from_short_code(item)
+  end
+
+  def location_name_from_short_code(item)
+    Rails.configuration.locations.dig(library(item), location(item)) || location(item)
+  end
+
+
+  def call_number(item)
+    item["temp_call_number"] ? item["temp_call_number"] : item["call_number"]
+  end
+
+  def alternative_call_number(item)
+    item["alt_call_number"] ? item["alt_call_number"] : call_number(item)
   end
 
   def sort_order_for_holdings(grouped_items)

--- a/app/helpers/alma_data_helper.rb
+++ b/app/helpers/alma_data_helper.rb
@@ -48,6 +48,11 @@ module AlmaDataHelper
     item["public_note"] ? "Note: #{item['public_note']}" : ""
   end
 
+  def missing_or_lost?(item)
+    process_type = item.fetch("process_type", "")
+    !!process_type.match(/MISSING|LOST_LOAN/)
+  end
+
   def library(item)
     item["current_library"] ? item["current_library"] : item["permanent_library"]
     end
@@ -95,6 +100,7 @@ module AlmaDataHelper
           }.compact
       }
       .flatten
+      .reject { |item| missing_or_lost?(item) }
       .group_by { |item| library(item) }
   end
 

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -9,7 +9,7 @@
     <% render :partial => "paginate_compact", :object => @response %>
   </div>
 
-  <% sort_order_for_holdings(@merged_response).each do |key, items| %>
+  <% sort_order_for_holdings(@document_and_api_items).each do |key, items| %>
     <div id="availability-container" class="m-0">
       <div class="modal-body d-lg-flex table-heading ml-0 mb-0 border-bottom border-top border-tan-border justify-content-lg-between">
         <div class="library-name card-title col-sm-12 col-lg-4"><%= library_name_from_short_code(key) %></div>

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -4,22 +4,18 @@
 
 <div id="request-url-data-<%= @mms_id %>" class="hidden" data-requests-url="<%= request_options_path(@mms_id, @pickup_locations, @request_level) %>"></div>
 
-<% unless @items.values.all?(&:empty?) %>
-  <div class="availability-modal">
-    <div class="modal-only">
-      <%= render :partial => "paginate_compact", :object => @response %>
-    </div>
-    <% sort_order_for_holdings(@items).each do |key,items| %>
+<div class="availability-modal">
+  <div class="modal-only">
+    <% render :partial => "paginate_compact", :object => @response %>
+  </div>
+
+  <% sort_order_for_holdings(@merged_response).each do |key, items| %>
     <div id="availability-container" class="m-0">
       <div class="modal-body d-lg-flex table-heading ml-0 mb-0 border-bottom border-top border-tan-border justify-content-lg-between">
-        <div id="<%= key %>" class="library-name card-title col-sm-12 col-lg-4"><%= library_name_from_short_code(key) %></div>
-          <% if @document["holdings_summary_display"] %>
-            <div class="holdings-summary col-sm-12"><%= @holdings_summary[key] %></div>
-          <% end %>
-        <div class="aeon-request"><%= aeon_request_button(items) %></div>
+        <div class="library-name card-title col-sm-12 col-lg-4"><%= library_name_from_short_code(key) %></div>
       </div>
 
-      <% @document.fetch("items_json_display", []).each do |item| %>
+      <% items.each do |item| %>
         <div class="row avail-info-rows border-bottom border-tan-border">
           <div id="<%= location_name_from_short_code(item) %>" class="col-sm-12 col-md-2"><strong><%= location_status(item) %></strong></div>
           <div id="call_num" class="col-sm-12 col-md-2"><%= alternative_call_number(item) %></div>
@@ -28,24 +24,11 @@
             <span id="note"><%= public_note(item) %></span>
             <span id="material type"><%= physical_material_type(item) %></span>
           </div>
+          <div id="status" class="col-sm-12 col-md-3"><%= item.fetch("availability", "") %></div>
         </div>
-      <% end %>
-
-      <% items.each do |avail| %>
-        <div id="status" class="col-sm-12 col-md-3"><%= availability_status(avail) %></div>
-      <% end %>
     </div>
     <% end %>
     <%= render :partial => "paginate_compact", :object => @response %>
   </div>
-
-  <% else %>
-
-    <% unless @document["holdings_widiv_no_items_display"] %>
-      <div class="border-bottom no-holdings border border-tan-border">
-        <div class="no-item-info">
-          <%= render_holdings_summary(@document) %>
-        </div>
-      </div>
-    <% end %>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -11,46 +11,41 @@
     </div>
     <% sort_order_for_holdings(@items).each do |key,items| %>
     <div id="availability-container" class="m-0">
-      <div>
-        <div class="avail-headers row sr-only">
-            <div id="location">Item Location</div>
-            <div id="callnum">Call Number</div>
-            <div id="desc">Description</div>
-            <div id="type">Material Type</div>
-            <div id="note">Public Note</div>
-            <div id="status">Availability Status</div>
-        </div>
-      </div>
       <div class="modal-body d-lg-flex table-heading ml-0 mb-0 border-bottom border-top border-tan-border justify-content-lg-between">
         <div id="<%= key %>" class="library-name card-title col-sm-12 col-lg-4"><%= library_name_from_short_code(key) %></div>
-        <% if @document["holdings_summary_display"] %>
-          <div class="holdings-summary col-sm-12"><%= @holdings_summary[key] %></div>
-        <% end %>
+          <% if @document["holdings_summary_display"] %>
+            <div class="holdings-summary col-sm-12"><%= @holdings_summary[key] %></div>
+          <% end %>
         <div class="aeon-request"><%= aeon_request_button(items) %></div>
       </div>
-      <% items.each do |item| %>
+
+      <% @document.fetch("items_json_display", []).each do |item| %>
         <div class="row avail-info-rows border-bottom border-tan-border">
-          <div id="<%= location_status(item) %>" class="col-sm-12 col-md-2"><strong><%= location_status(item) %></strong></div>
-          <div class="col-sm-12 col-md-2"><%= item.call_number %> <%= alternative_call_number(item) %></div>
+          <div id="<%= location_name_from_short_code(item) %>" class="col-sm-12 col-md-2"><strong><%= location_status(item) %></strong></div>
+          <div id="call_num" class="col-sm-12 col-md-2"><%= alternative_call_number(item) %></div>
           <div class="col-sm-12 col-md-5">
-            <%= description(item) %>
-            <%= public_note(item) %>
-            <%= physical_material_type(item) %>
+            <span id="description"><%= description(item) %></span>
+            <span id="note"><%= public_note(item) %></span>
+            <span id="material type"><%= physical_material_type(item) %></span>
           </div>
-          <div class="col-sm-12 col-md-3"><%= availability_status(item) %></div>
         </div>
+      <% end %>
+
+      <% items.each do |avail| %>
+        <div id="status" class="col-sm-12 col-md-3"><%= availability_status(avail) %></div>
       <% end %>
     </div>
     <% end %>
     <%= render :partial => "paginate_compact", :object => @response %>
   </div>
+
   <% else %>
 
-  <% unless @document["holdings_widiv_no_items_display"] %>
-    <div class="border-bottom no-holdings border border-tan-border">
-      <div class="no-item-info">
+    <% unless @document["holdings_widiv_no_items_display"] %>
+      <div class="border-bottom no-holdings border border-tan-border">
+        <div class="no-item-info">
           <%= render_holdings_summary(@document) %>
+        </div>
       </div>
-    </div>
-  <% end %>
+    <% end %>
 <% end %>

--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -211,6 +211,7 @@ to_field "holdings_display", extract_marc("HLD8")
 to_field "holdings_with_no_items_display", extract_holdings_with_no_items
 to_field "suppress_items_b", suppress_items
 to_field "holdings_summary_display", extract_holdings_summary
+to_field "items_json_display", extract_item_info
 
 # Identifier fields
 to_field("isbn_display",  extract_marc("020a", separator: nil), &normalize_isbn)

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -554,6 +554,35 @@ module Traject
         end
       end
 
+      def extract_item_info
+        lambda do |rec, acc, context|
+          rec.fields("ITM").each do |f|
+            selected_subfields = {
+              item_pid: f["8"],
+              item_policy: f["a"],
+              description: f["c"],
+              permanent_library: f["d"],
+              permanent_location: f["e"],
+              current_library: f["f"],
+              current_location: f["g"],
+              call_number_type: f["h"],
+              call_number: f["i"],
+              alt_call_number_type: f["j"],
+              alt_call_number: f["k"],
+              temp_call_number_type: f["l"],
+              temp_call_number: f["m"],
+              public_note: f["o"],
+              due_back_date: f["p"],
+              holding_id: f["r"],
+              material_type: f["t"],
+              process_type: f["u"] }
+              .delete_if { |k, v| v.blank? }
+              .to_json
+            acc << selected_subfields
+          end
+        end
+      end
+
       # In order to reduce the relevance of certain libraries, we need to boost every other library
       # Make sure we still boost records what have holdings in less relevant libraries and also in another library
       LIBRARIES_TO_NOT_BOOST = [ "PRESSER", "CLAEDTECH" ]

--- a/spec/fixtures/alma_data/merge_document_and_api.json
+++ b/spec/fixtures/alma_data/merge_document_and_api.json
@@ -1,0 +1,132 @@
+{
+    "item": [
+        {
+            "bib_data": {
+                "mms_id": "991000673139703811",
+                "title": "King Solomon's mines",
+                "author": "Markowitz, Russ.",
+                "issn": null,
+                "isbn": null,
+                "complete_edition": "",
+                "network_number": [
+                    "(OCLC)ocm56451984",
+                    "ocm56451984",
+                    "(OCoLC)ocn867826752",
+                    "(PPT)b55352169-01tuli_inst"
+                ],
+                "place_of_publication": "[United States] :",
+                "date_of_publication": "[2004]",
+                "publisher_const": "Distributed by Lions Gate Home Entertainment",
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991000673139703811"
+            },
+            "holding_data": {
+                "holding_id": "22237957750003811",
+                "call_number_type": {
+                    "value": "8",
+                    "desc": "Other scheme"
+                },
+                "call_number": "DVD 13 A165",
+                "accession_number": "",
+                "copy_id": "1",
+                "in_temp_location": false,
+                "temp_library": {
+                    "value": null,
+                    "desc": null
+                },
+                "temp_location": {
+                    "value": null,
+                    "desc": null
+                },
+                "temp_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "temp_call_number": "",
+                "temp_policy": {
+                    "value": "",
+                    "desc": null
+                },
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991000673139703811/holdings/22237957750003811"
+            },
+            "item_data": {
+                "pid": "23237957740003811",
+                "barcode": "39074028545416",
+                "creation_date": "2017-06-20Z",
+                "modification_date": "2018-01-23Z",
+                "base_status": {
+                    "value": "1",
+                    "desc": "Item in place"
+                },
+                "physical_material_type": {
+                    "value": "DVD",
+                    "desc": "DVD"
+                },
+                "policy": {
+                    "value": "5",
+                    "desc": "Media"
+                },
+                "provenance": {
+                    "value": "",
+                    "desc": null
+                },
+                "po_line": "",
+                "is_magnetic": false,
+                "arrival_date": "2013-12-17Z",
+                "year_of_issue": "",
+                "enumeration_a": "",
+                "enumeration_b": "",
+                "enumeration_c": "",
+                "enumeration_d": "",
+                "enumeration_e": "",
+                "enumeration_f": "",
+                "enumeration_g": "",
+                "enumeration_h": "",
+                "chronology_i": "",
+                "chronology_j": "",
+                "chronology_k": "",
+                "chronology_l": "",
+                "chronology_m": "",
+                "description": "",
+                "receiving_operator": "import",
+                "process_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "library": {
+                    "value": "AMBLER",
+                    "desc": "Ambler Campus Library"
+                },
+                "location": {
+                    "value": "media",
+                    "desc": "Ambler Media"
+                },
+                "alternative_call_number": "",
+                "alternative_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "storage_location_id": "",
+                "pages": "",
+                "pieces": "$0.00",
+                "public_note": "",
+                "fulfillment_note": "MESSAGE(ITEM): Check container for DVD.",
+                "internal_note_1": "",
+                "internal_note_2": "",
+                "internal_note_3": "ITEM LOC: avid",
+                "statistics_note_1": "TOT RENEW: 1",
+                "statistics_note_2": "LYCIRC: 0",
+                "statistics_note_3": "",
+                "requested": false,
+                "edition": null,
+                "imprint": null,
+                "language": null,
+                "physical_condition": {
+                    "value": null,
+                    "desc": null
+                }
+            },
+            "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991000673139703811/holdings/22237957750003811/items/23237957740003811"
+        }
+    ],
+    "total_record_count": 1
+}

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -384,28 +384,28 @@ RSpec.describe AlmaDataHelper, type: :helper do
 
     context "items in Kardon sort by Remote Storage, not KARDON" do
       let(:grouped_items) do {
-      "KARDON"=>
-        [{"item_pid"=>"23243718620003811",
-         "item_policy"=>"0",
-         "permanent_library"=>"KARDON",
-         "permanent_location"=>"p_remote",
-         "current_library"=>"KARDON",
-         "current_location"=>"p_remote",
-         "call_number_type"=>"0",
-         "call_number"=>"N6853.S49 A4 2001",
-         "holding_id"=>"22243718630003811",
-         "availability"=>"<span class=\"check\"></span>Available"}],
-      "MAIN"=>
-         [{"item_pid"=>"23243718640003811",
-         "item_policy"=>"0",
-         "permanent_library"=>"MAIN",
-         "permanent_location"=>"stacks",
-         "current_library"=>"MAIN",
-         "current_location"=>"stacks",
-         "call_number_type"=>"0",
-         "call_number"=>"N6853.S49 A4 2001",
-         "holding_id"=>"22243718650003811",
-         "availability"=>"<span class=\"check\"></span>Available"}]}
+      "KARDON" =>
+        [{ "item_pid" => "23243718620003811",
+         "item_policy" => "0",
+         "permanent_library" => "KARDON",
+         "permanent_location" => "p_remote",
+         "current_library" => "KARDON",
+         "current_location" => "p_remote",
+         "call_number_type" => "0",
+         "call_number" => "N6853.S49 A4 2001",
+         "holding_id" => "22243718630003811",
+         "availability" => "<span class=\"check\"></span>Available" }],
+      "MAIN" =>
+         [{ "item_pid" => "23243718640003811",
+         "item_policy" => "0",
+         "permanent_library" => "MAIN",
+         "permanent_location" => "stacks",
+         "current_library" => "MAIN",
+         "current_location" => "stacks",
+         "call_number_type" => "0",
+         "call_number" => "N6853.S49 A4 2001",
+         "holding_id" => "22243718650003811",
+         "availability" => "<span class=\"check\"></span>Available" }] }
       end
 
       it "returns Media before Kardon" do
@@ -415,132 +415,132 @@ RSpec.describe AlmaDataHelper, type: :helper do
 
     context "Items are ordered by location after library name" do
       let(:grouped_items) do
-        {"MAIN"=>
-          [{"item_pid"=>"23242235660003811",
-          "item_policy"=>"12",
-          "description"=>"1992-94",
-          "permanent_library"=>"MAIN",
-          "permanent_location"=>"stacks",
-          "current_library"=>"MAIN",
-          "current_location"=>"stacks",
-          "call_number_type"=>"0",
-          "call_number"=>"HV696.F6F624",
-          "holding_id"=>"22242235730003811",
-          "availability"=>"<span class=\"check\"></span>Library Use Only"},
-         {"item_pid"=>"23242235720003811",
-          "item_policy"=>"12",
-          "description"=>"1983-1986",
-          "permanent_library"=>"MAIN",
-          "permanent_location"=>"reference",
-          "current_library"=>"MAIN",
-          "current_location"=>"reference",
-          "call_number_type"=>"0",
-          "call_number"=>"HV696.F6F624",
-          "holding_id"=>"22242235730003811",
-          "availability"=>"<span class=\"check\"></span>Library Use Only"},
-         {"item_pid"=>"23242235710003811",
-          "item_policy"=>"12",
-          "description"=>"1987-89",
-          "permanent_library"=>"MAIN",
-          "permanent_location"=>"serials",
-          "current_library"=>"MAIN",
-          "current_location"=>"serials",
-          "call_number_type"=>"0",
-          "call_number"=>"HV696.F6F624",
-          "holding_id"=>"22242235730003811",
-          "availability"=>"<span class=\"check\"></span>Library Use Only"}]}
+        { "MAIN" =>
+          [{ "item_pid" => "23242235660003811",
+          "item_policy" => "12",
+          "description" => "1992-94",
+          "permanent_library" => "MAIN",
+          "permanent_location" => "stacks",
+          "current_library" => "MAIN",
+          "current_location" => "stacks",
+          "call_number_type" => "0",
+          "call_number" => "HV696.F6F624",
+          "holding_id" => "22242235730003811",
+          "availability" => "<span class=\"check\"></span>Library Use Only" },
+         { "item_pid" => "23242235720003811",
+          "item_policy" => "12",
+          "description" => "1983-1986",
+          "permanent_library" => "MAIN",
+          "permanent_location" => "reference",
+          "current_library" => "MAIN",
+          "current_location" => "reference",
+          "call_number_type" => "0",
+          "call_number" => "HV696.F6F624",
+          "holding_id" => "22242235730003811",
+          "availability" => "<span class=\"check\"></span>Library Use Only" },
+         { "item_pid" => "23242235710003811",
+          "item_policy" => "12",
+          "description" => "1987-89",
+          "permanent_library" => "MAIN",
+          "permanent_location" => "serials",
+          "current_library" => "MAIN",
+          "current_location" => "serials",
+          "call_number_type" => "0",
+          "call_number" => "HV696.F6F624",
+          "holding_id" => "22242235730003811",
+          "availability" => "<span class=\"check\"></span>Library Use Only" }] }
       end
 
       it "returns copies for each library by location" do
-        sorted_locations = sort_order_for_holdings(grouped_items)["MAIN"].map { |item| location_name_from_short_code(item)}
+        sorted_locations = sort_order_for_holdings(grouped_items)["MAIN"].map { |item| location_name_from_short_code(item) }
         expect(sorted_locations).to eq(["Journals", "Paley Reference", "Stacks"])
       end
     end
 
     context "Items are ordered by call number after location" do
       let(:grouped_items) do
-        {"MAIN"=>
-          [{"item_pid"=>"23242235660003811",
-          "item_policy"=>"12",
-          "description"=>"1992-94",
-          "permanent_library"=>"MAIN",
-          "permanent_location"=>"stacks",
-          "current_library"=>"MAIN",
-          "current_location"=>"stacks",
-          "call_number_type"=>"0",
-          "call_number"=>"MT655.P45x",
-          "holding_id"=>"22242235730003811",
-          "availability"=>"<span class=\"check\"></span>Library Use Only"},
-         {"item_pid"=>"23242235720003811",
-          "item_policy"=>"12",
-          "description"=>"1983-1986",
-          "permanent_library"=>"MAIN",
-          "permanent_location"=>"stacks",
-          "current_library"=>"MAIN",
-          "current_location"=>"stacks",
-          "call_number_type"=>"0",
-          "call_number"=>"HF5006 .I614",
-          "holding_id"=>"22242235730003811",
-          "availability"=>"<span class=\"check\"></span>Library Use Only"},
-         {"item_pid"=>"23242235710003811",
-          "item_policy"=>"12",
-          "description"=>"1987-89",
-          "permanent_library"=>"MAIN",
-          "permanent_location"=>"stacks",
-          "current_library"=>"MAIN",
-          "current_location"=>"stacks",
-          "call_number_type"=>"0",
-          "call_number"=>"AC1 .G72",
-          "holding_id"=>"22242235730003811",
-          "availability"=>"<span class=\"check\"></span>Library Use Only"}]}
+        { "MAIN" =>
+          [{ "item_pid" => "23242235660003811",
+          "item_policy" => "12",
+          "description" => "1992-94",
+          "permanent_library" => "MAIN",
+          "permanent_location" => "stacks",
+          "current_library" => "MAIN",
+          "current_location" => "stacks",
+          "call_number_type" => "0",
+          "call_number" => "MT655.P45x",
+          "holding_id" => "22242235730003811",
+          "availability" => "<span class=\"check\"></span>Library Use Only" },
+         { "item_pid" => "23242235720003811",
+          "item_policy" => "12",
+          "description" => "1983-1986",
+          "permanent_library" => "MAIN",
+          "permanent_location" => "stacks",
+          "current_library" => "MAIN",
+          "current_location" => "stacks",
+          "call_number_type" => "0",
+          "call_number" => "HF5006 .I614",
+          "holding_id" => "22242235730003811",
+          "availability" => "<span class=\"check\"></span>Library Use Only" },
+         { "item_pid" => "23242235710003811",
+          "item_policy" => "12",
+          "description" => "1987-89",
+          "permanent_library" => "MAIN",
+          "permanent_location" => "stacks",
+          "current_library" => "MAIN",
+          "current_location" => "stacks",
+          "call_number_type" => "0",
+          "call_number" => "AC1 .G72",
+          "holding_id" => "22242235730003811",
+          "availability" => "<span class=\"check\"></span>Library Use Only" }] }
       end
 
       it "returns copies for each library by call number" do
-        sorted_call_numbers = sort_order_for_holdings(grouped_items)["MAIN"].map { |item| alternative_call_number(item)}
+        sorted_call_numbers = sort_order_for_holdings(grouped_items)["MAIN"].map { |item| alternative_call_number(item) }
         expect(sorted_call_numbers).to eq(["AC1 .G72", "HF5006 .I614", "MT655.P45x"])
       end
     end
 
     context "Items are ordered by description after call number" do
       let(:grouped_items) do
-        {"MAIN"=>
-          [{"item_pid"=>"23242235660003811",
-          "item_policy"=>"12",
-          "description"=>"v.55, no.5 (Nov. 2017)",
-          "permanent_library"=>"MAIN",
-          "permanent_location"=>"stacks",
-          "current_library"=>"MAIN",
-          "current_location"=>"stacks",
-          "call_number_type"=>"0",
-          "call_number"=>"MT655.P45x",
-          "holding_id"=>"22242235730003811",
-          "availability"=>"<span class=\"check\"></span>Library Use Only"},
-         {"item_pid"=>"23242235720003811",
-          "item_policy"=>"12",
-          "description"=>"v.53 (2016)",
-          "permanent_library"=>"MAIN",
-          "permanent_location"=>"stacks",
-          "current_library"=>"MAIN",
-          "current_location"=>"stacks",
-          "call_number_type"=>"0",
-          "call_number"=>"MT655.P45x",
-          "holding_id"=>"22242235730003811",
-          "availability"=>"<span class=\"check\"></span>Library Use Only"},
-         {"item_pid"=>"23242235710003811",
-          "item_policy"=>"12",
-          "description"=>"v.42 (2004)",
-          "permanent_library"=>"MAIN",
-          "permanent_location"=>"stacks",
-          "current_library"=>"MAIN",
-          "current_location"=>"stacks",
-          "call_number_type"=>"0",
-          "call_number"=>"MT655.P45x",
-          "holding_id"=>"22242235730003811",
-          "availability"=>"<span class=\"check\"></span>Library Use Only"}]}
+        { "MAIN" =>
+          [{ "item_pid" => "23242235660003811",
+          "item_policy" => "12",
+          "description" => "v.55, no.5 (Nov. 2017)",
+          "permanent_library" => "MAIN",
+          "permanent_location" => "stacks",
+          "current_library" => "MAIN",
+          "current_location" => "stacks",
+          "call_number_type" => "0",
+          "call_number" => "MT655.P45x",
+          "holding_id" => "22242235730003811",
+          "availability" => "<span class=\"check\"></span>Library Use Only" },
+         { "item_pid" => "23242235720003811",
+          "item_policy" => "12",
+          "description" => "v.53 (2016)",
+          "permanent_library" => "MAIN",
+          "permanent_location" => "stacks",
+          "current_library" => "MAIN",
+          "current_location" => "stacks",
+          "call_number_type" => "0",
+          "call_number" => "MT655.P45x",
+          "holding_id" => "22242235730003811",
+          "availability" => "<span class=\"check\"></span>Library Use Only" },
+         { "item_pid" => "23242235710003811",
+          "item_policy" => "12",
+          "description" => "v.42 (2004)",
+          "permanent_library" => "MAIN",
+          "permanent_location" => "stacks",
+          "current_library" => "MAIN",
+          "current_location" => "stacks",
+          "call_number_type" => "0",
+          "call_number" => "MT655.P45x",
+          "holding_id" => "22242235730003811",
+          "availability" => "<span class=\"check\"></span>Library Use Only" }] }
       end
 
       it "returns copies for each library by description" do
-        sorted_descriptions = sort_order_for_holdings(grouped_items)["MAIN"].map { |item| description(item)}
+        sorted_descriptions = sort_order_for_holdings(grouped_items)["MAIN"].map { |item| description(item) }
         expect(sorted_descriptions).to eq(["Description: v.42 (2004)", "Description: v.53 (2016)", "Description: v.55, no.5 (Nov. 2017)"])
       end
     end

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -90,8 +90,6 @@ RSpec.describe AlmaDataHelper, type: :helper do
         expect(availability_status(item)).to eq "<span class=\"close-icon\"></span>At another institution"
       end
     end
-
-
   end
 
   describe "#unavailable_items(item)" do
@@ -227,6 +225,41 @@ RSpec.describe AlmaDataHelper, type: :helper do
     end
   end
 
+  describe "#missing_or_lost(item)" do
+    context "an item is missing" do
+      let(:item) { { "item_pid" => "23237957740003811",
+      "item_policy" => "5",
+      "permanent_library" => "AMBLER",
+      "permanent_location" => "media",
+      "current_library" => "AMBLER",
+      "current_location" => "media",
+      "call_number" => "DVD 13 A165",
+      "holding_id" => "22237957750003811",
+      "process_type" => "MISSING" }
+    }
+
+      it "correctly identifies missing items" do
+        expect(missing_or_lost?(item)).to be true
+      end
+    end
+
+    context "an item is not missing or lost" do
+      let(:item) { { "item_pid" => "23237957740003811",
+      "item_policy" => "5",
+      "permanent_library" => "AMBLER",
+      "permanent_location" => "media",
+      "current_library" => "AMBLER",
+      "current_location" => "media",
+      "call_number" => "DVD 13 A165",
+      "holding_id" => "22237957750003811" }
+    }
+
+      it "correctly identifies missing items" do
+        expect(missing_or_lost?(item)).to be false
+      end
+    end
+  end
+
   describe "#library(item)" do
     context "item is in temporary library" do
       let(:item) { { "current_library" => "RES_SHARE" } }
@@ -346,6 +379,27 @@ RSpec.describe AlmaDataHelper, type: :helper do
       let(:items_list) { Alma::BibItem.find("merge_document_and_api").grouped_by_library }
 
       it "does not merge the availability into the document field" do
+        expect(document_and_api_merged_results(document, items_list)).to eq({})
+      end
+    end
+
+    context "does not include missing or lost items" do
+      let(:document) { { "items_json_display" =>
+        [{ "item_pid" => "12345",
+        "item_policy" => "5",
+        "permanent_library" => "AMBLER",
+        "permanent_location" => "media",
+        "current_library" => "AMBLER",
+        "current_location" => "media",
+        "call_number" => "DVD 13 A165",
+        "process_type" => "MISSING",
+        "holding_id" => "22237957750003811" }]
+          }
+        }
+
+      let(:items_list) { Alma::BibItem.find("merge_document_and_api").grouped_by_library }
+
+      it "filters out missing or lost items" do
         expect(document_and_api_merged_results(document, items_list)).to eq({})
       end
     end

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "spec_helper"
 require "rails_helper"
 
 RSpec.describe AlmaDataHelper, type: :helper do
@@ -244,7 +245,6 @@ RSpec.describe AlmaDataHelper, type: :helper do
     end
   end
 
-
   describe "#location(item)" do
     context "item is in temporary location" do
       let(:item) { { "current_location" => "ILL" } }
@@ -315,10 +315,10 @@ RSpec.describe AlmaDataHelper, type: :helper do
           }
         }
 
-      let(:items_list) { Alma::BibItem.find("document_and_api_merged_results") }
+      let(:items_list) { Alma::BibItem.find("merge_document_and_api").grouped_by_library }
 
       it "merges the availability into the document field" do
-        expect(document_and_api_merged_results(document, items_list)).to eq([{ "item_pid" => "23237957740003811",
+        expect(document_and_api_merged_results(document, items_list)).to eq("AMBLER" => [{ "item_pid" => "23237957740003811",
                                                                             "item_policy" => "5",
                                                                             "permanent_library" => "AMBLER",
                                                                             "permanent_location" => "media",
@@ -326,155 +326,222 @@ RSpec.describe AlmaDataHelper, type: :helper do
                                                                             "current_location" => "media",
                                                                             "call_number" => "DVD 13 A165",
                                                                             "holding_id" => "22237957750003811",
-                                                                            "availability" => "<span class=\"check\"></span>Available" }])
+                                                                            availability: "<span class=\"check\"></span>Available" }])
+      end
+    end
+
+    context "item_pid from api does not match item_pid in document" do
+      let(:document) { { "items_json_display" =>
+        [{ "item_pid" => "12345",
+        "item_policy" => "5",
+        "permanent_library" => "AMBLER",
+        "permanent_location" => "media",
+        "current_library" => "AMBLER",
+        "current_location" => "media",
+        "call_number" => "DVD 13 A165",
+        "holding_id" => "22237957750003811" }]
+          }
+        }
+
+      let(:items_list) { Alma::BibItem.find("merge_document_and_api").grouped_by_library }
+
+      it "does not merge the availability into the document field" do
+        expect(document_and_api_merged_results(document, items_list)).to eq({})
       end
     end
   end
 
   describe "#sort_order_for_holdings(grouped_items)" do
     context "items are sorted by library name with Paley first" do
-      let(:grouped_items) do
-        {
-        "MAIN" => [Alma::BibItem.new({})],
-        "AMBLER" => [Alma::BibItem.new({})]
-      }
+      let(:grouped_items) do { "AMBLER" =>
+  [{ "item_pid" => "23239405700003811",
+    "item_policy" => "0",
+    "permanent_library" => "AMBLER",
+    "permanent_location" => "stacks",
+    "current_library" => "AMBLER",
+    "current_location" => "stacks",
+    "call_number_type" => "0",
+    "call_number" => "F159.P7 C66 2003",
+    "holding_id" => "22239405730003811",
+    "availability" => "<span class=\"check\"></span>Available" }],
+ "MAIN" =>
+  [{ "item_pid" => "23239405740003811",
+    "item_policy" => "0",
+    "permanent_library" => "MAIN",
+    "permanent_location" => "stacks",
+    "current_library" => "MAIN",
+    "current_location" => "stacks",
+    "call_number_type" => "0",
+    "call_number" => "F159.P7 C66 2003",
+    "holding_id" => "22239405750003811",
+    "availability" => "<span class=\"check\"></span>Available" }] }
       end
 
       it "returns Paley first, then Ambler" do
-        expect(sort_order_for_holdings(items).keys).to eq(["MAIN", "AMBLER"])
+        expect(sort_order_for_holdings(grouped_items).keys).to eq(["MAIN", "AMBLER"])
       end
     end
 
     context "items in Kardon sort by Remote Storage, not KARDON" do
-      let(:items) do
-        {
-          "KARDON" => [Alma::BibItem.new({})],
-          "MEDIA" =>  [Alma::BibItem.new({})]
-        }
+      let(:grouped_items) do {
+      "KARDON"=>
+        [{"item_pid"=>"23243718620003811",
+         "item_policy"=>"0",
+         "permanent_library"=>"KARDON",
+         "permanent_location"=>"p_remote",
+         "current_library"=>"KARDON",
+         "current_location"=>"p_remote",
+         "call_number_type"=>"0",
+         "call_number"=>"N6853.S49 A4 2001",
+         "holding_id"=>"22243718630003811",
+         "availability"=>"<span class=\"check\"></span>Available"}],
+      "MAIN"=>
+         [{"item_pid"=>"23243718640003811",
+         "item_policy"=>"0",
+         "permanent_library"=>"MAIN",
+         "permanent_location"=>"stacks",
+         "current_library"=>"MAIN",
+         "current_location"=>"stacks",
+         "call_number_type"=>"0",
+         "call_number"=>"N6853.S49 A4 2001",
+         "holding_id"=>"22243718650003811",
+         "availability"=>"<span class=\"check\"></span>Available"}]}
       end
 
       it "returns Media before Kardon" do
-        expect(sort_order_for_holdings(items).keys).to eq(["MEDIA", "KARDON"])
+        expect(sort_order_for_holdings(grouped_items).keys).to eq(["MAIN", "KARDON"])
       end
     end
 
     context "Items are ordered by location after library name" do
-      let(:items) do
-        { "MAIN" => [ Alma::BibItem.new(
-          "holding_data" =>
-             { "in_temp_location" => false
-          },
-          "item_data" => {
-            "library" => { "value" => "MAIN" },
-            "location" => { "value" => "stacks" }
-          }
-        ),  Alma::BibItem.new(
-          "holding_data" =>
-             { "in_temp_location" => false
-          },
-          "item_data" => {
-            "library" => { "value" => "MAIN" },
-            "location" => { "value" => "serials" }
-          }
-        ),  Alma::BibItem.new(
-          "holding_data" =>
-             { "in_temp_location" => false
-          },
-          "item_data" => {
-            "library" => { "value" => "MAIN" },
-            "location" => { "value" => "reference" }
-            }
-          )]
-        }
+      let(:grouped_items) do
+        {"MAIN"=>
+          [{"item_pid"=>"23242235660003811",
+          "item_policy"=>"12",
+          "description"=>"1992-94",
+          "permanent_library"=>"MAIN",
+          "permanent_location"=>"stacks",
+          "current_library"=>"MAIN",
+          "current_location"=>"stacks",
+          "call_number_type"=>"0",
+          "call_number"=>"HV696.F6F624",
+          "holding_id"=>"22242235730003811",
+          "availability"=>"<span class=\"check\"></span>Library Use Only"},
+         {"item_pid"=>"23242235720003811",
+          "item_policy"=>"12",
+          "description"=>"1983-1986",
+          "permanent_library"=>"MAIN",
+          "permanent_location"=>"reference",
+          "current_library"=>"MAIN",
+          "current_location"=>"reference",
+          "call_number_type"=>"0",
+          "call_number"=>"HV696.F6F624",
+          "holding_id"=>"22242235730003811",
+          "availability"=>"<span class=\"check\"></span>Library Use Only"},
+         {"item_pid"=>"23242235710003811",
+          "item_policy"=>"12",
+          "description"=>"1987-89",
+          "permanent_library"=>"MAIN",
+          "permanent_location"=>"serials",
+          "current_library"=>"MAIN",
+          "current_location"=>"serials",
+          "call_number_type"=>"0",
+          "call_number"=>"HV696.F6F624",
+          "holding_id"=>"22242235730003811",
+          "availability"=>"<span class=\"check\"></span>Library Use Only"}]}
       end
 
       it "returns copies for each library by location" do
-
-        sorted_locations = sort_order_for_holdings(items)["MAIN"].map(&:location)
-        expect(sorted_locations).to eq(["serials", "reference", "stacks"])
+        sorted_locations = sort_order_for_holdings(grouped_items)["MAIN"].map { |item| location_name_from_short_code(item)}
+        expect(sorted_locations).to eq(["Journals", "Paley Reference", "Stacks"])
       end
     end
 
     context "Items are ordered by call number after location" do
-      let(:items) do
-        { "MAIN" => [Alma::BibItem.new(
-          "holding_data" =>
-             { "in_temp_location" => false,
-               "call_number" => "MT655.P45x"
-          },
-          "item_data" => {
-            "library" => { "value" => "MAIN" },
-            "location" => { "value" => "stacks" }
-          }
-        ), Alma::BibItem.new(
-          "holding_data" =>
-             { "in_temp_location" => false,
-               "call_number" => "AC1 .G72"
-
-          },
-          "item_data" => {
-            "library" => { "value" => "MAIN" },
-            "location" => { "value" => "stacks" }
-          }
-        ), Alma::BibItem.new(
-          "holding_data" =>
-             { "in_temp_location" => false,
-               "call_number" => "HF5006 .I614"
-          },
-          "item_data" => {
-            "library" => { "value" => "MAIN" },
-            "location" => { "value" => "stacks" }
-            }
-          )]
-        }
+      let(:grouped_items) do
+        {"MAIN"=>
+          [{"item_pid"=>"23242235660003811",
+          "item_policy"=>"12",
+          "description"=>"1992-94",
+          "permanent_library"=>"MAIN",
+          "permanent_location"=>"stacks",
+          "current_library"=>"MAIN",
+          "current_location"=>"stacks",
+          "call_number_type"=>"0",
+          "call_number"=>"MT655.P45x",
+          "holding_id"=>"22242235730003811",
+          "availability"=>"<span class=\"check\"></span>Library Use Only"},
+         {"item_pid"=>"23242235720003811",
+          "item_policy"=>"12",
+          "description"=>"1983-1986",
+          "permanent_library"=>"MAIN",
+          "permanent_location"=>"stacks",
+          "current_library"=>"MAIN",
+          "current_location"=>"stacks",
+          "call_number_type"=>"0",
+          "call_number"=>"HF5006 .I614",
+          "holding_id"=>"22242235730003811",
+          "availability"=>"<span class=\"check\"></span>Library Use Only"},
+         {"item_pid"=>"23242235710003811",
+          "item_policy"=>"12",
+          "description"=>"1987-89",
+          "permanent_library"=>"MAIN",
+          "permanent_location"=>"stacks",
+          "current_library"=>"MAIN",
+          "current_location"=>"stacks",
+          "call_number_type"=>"0",
+          "call_number"=>"AC1 .G72",
+          "holding_id"=>"22242235730003811",
+          "availability"=>"<span class=\"check\"></span>Library Use Only"}]}
       end
 
       it "returns copies for each library by call number" do
-        sorted_call_numbers = sort_order_for_holdings(items)["MAIN"].map(&:call_number)
+        sorted_call_numbers = sort_order_for_holdings(grouped_items)["MAIN"].map { |item| alternative_call_number(item)}
         expect(sorted_call_numbers).to eq(["AC1 .G72", "HF5006 .I614", "MT655.P45x"])
       end
     end
 
     context "Items are ordered by description after call number" do
-      let(:items) do
-        { "MAIN" => [Alma::BibItem.new(
-          "holding_data" =>
-             { "in_temp_location" => false,
-               "call_number" => "MT655.P45x"
-          },
-          "item_data" => {
-            "library" => { "value" => "MAIN" },
-            "location" => { "value" => "stacks" },
-            "description" => "v.55, no.5 (Nov. 2017)"
-          }
-      ), Alma::BibItem.new(
-        "holding_data" =>
-           { "in_temp_location" => false,
-             "call_number" => "MT655.P45x"
-
-        },
-        "item_data" => {
-          "library" => { "value" => "MAIN" },
-          "location" => { "value" => "stacks" },
-          "description" => "v.42 (2004)"
-        }
-      ), Alma::BibItem.new(
-        "holding_data" =>
-           { "in_temp_location" => false,
-             "call_number" => "MT655.P45x"
-        },
-        "item_data" => {
-          "library" => { "value" => "MAIN" },
-          "location" => { "value" => "stacks" },
-          "description" => "v.53 (2016)"
-          }
-        )]
-      }
+      let(:grouped_items) do
+        {"MAIN"=>
+          [{"item_pid"=>"23242235660003811",
+          "item_policy"=>"12",
+          "description"=>"v.55, no.5 (Nov. 2017)",
+          "permanent_library"=>"MAIN",
+          "permanent_location"=>"stacks",
+          "current_library"=>"MAIN",
+          "current_location"=>"stacks",
+          "call_number_type"=>"0",
+          "call_number"=>"MT655.P45x",
+          "holding_id"=>"22242235730003811",
+          "availability"=>"<span class=\"check\"></span>Library Use Only"},
+         {"item_pid"=>"23242235720003811",
+          "item_policy"=>"12",
+          "description"=>"v.53 (2016)",
+          "permanent_library"=>"MAIN",
+          "permanent_location"=>"stacks",
+          "current_library"=>"MAIN",
+          "current_location"=>"stacks",
+          "call_number_type"=>"0",
+          "call_number"=>"MT655.P45x",
+          "holding_id"=>"22242235730003811",
+          "availability"=>"<span class=\"check\"></span>Library Use Only"},
+         {"item_pid"=>"23242235710003811",
+          "item_policy"=>"12",
+          "description"=>"v.42 (2004)",
+          "permanent_library"=>"MAIN",
+          "permanent_location"=>"stacks",
+          "current_library"=>"MAIN",
+          "current_location"=>"stacks",
+          "call_number_type"=>"0",
+          "call_number"=>"MT655.P45x",
+          "holding_id"=>"22242235730003811",
+          "availability"=>"<span class=\"check\"></span>Library Use Only"}]}
       end
 
       it "returns copies for each library by description" do
-        sorted_descriptions = sort_order_for_holdings(items)["MAIN"].map(&:description)
-        expect(sorted_descriptions).to eq(["v.42 (2004)", "v.53 (2016)", "v.55, no.5 (Nov. 2017)"])
+        sorted_descriptions = sort_order_for_holdings(grouped_items)["MAIN"].map { |item| description(item)}
+        expect(sorted_descriptions).to eq(["Description: v.42 (2004)", "Description: v.53 (2016)", "Description: v.55, no.5 (Nov. 2017)"])
       end
     end
   end

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -152,11 +152,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
 
   describe "#description(item)" do
     context "item includes description" do
-      let(:item) do
-        Alma::BibItem.new("item_data" =>
-           { "description" => "v. 1" }
-         )
-      end
+      let(:item) { { "description" => "v. 1" } }
 
       it "displays description" do
         expect(description(item)).to eq "Description: v. 1"
@@ -164,28 +160,17 @@ RSpec.describe AlmaDataHelper, type: :helper do
     end
 
     context "item does NOT include description" do
-      let(:item) do
-        Alma::BibItem.new("item_data" =>
-           { "description" => "" }
-         )
-      end
+      let(:item) { {} }
 
       it "displays nothing" do
-        expect(description(item)).to eq nil
+        expect(description(item)).to eq ""
       end
     end
   end
 
   describe "#physical_material_type(item)" do
     context "item includes physical_material_type" do
-      let(:item) do
-        Alma::BibItem.new("item_data" =>
-           { "physical_material_type" =>
-             { "value" => "RECORD",
-                "desc" => "Sound Recording" }
-           }
-         )
-      end
+      let(:item) { { "material_type" => "Sound Recording" } }
 
       it "displays physical_material_type" do
         expect(physical_material_type(item)).to eq "Sound Recording"
@@ -193,13 +178,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
     end
 
     context "item does NOT include PHYSICAL_TYPE_EXCLUSIONS" do
-      let(:item) do
-        Alma::BibItem.new("item_data" =>
-           { "physical_material_type" =>
-             { "value" => "BOOK" }
-           }
-         )
-      end
+      let(:item) { { "material_type" => "Book" } }
 
       it "displays nothing" do
         expect(physical_material_type(item)).to eq nil
@@ -207,7 +186,7 @@ RSpec.describe AlmaDataHelper, type: :helper do
     end
 
     context "item does not include a physical_material_type" do
-      let(:item) { Alma::BibItem.new("item_data" => {}) }
+      let(:item) { {} }
 
       it "displays nothing" do
         expect(physical_material_type(item)).to eq nil
@@ -231,65 +210,70 @@ RSpec.describe AlmaDataHelper, type: :helper do
 
   describe "#public_note(item)" do
     context "item includes public note" do
-      let(:item) do
-        Alma::BibItem.new("item_data" =>
-           { "public_note" => "example" }
-         )
-      end
+      let(:item) { { "public_note" => "Sample note" } }
 
       it "displays note" do
-        expect(public_note(item)).to eq "Note: example"
+        expect(public_note(item)).to eq "Note: Sample note"
       end
     end
 
     context "item does NOT include public note" do
-      let(:item) do
-        Alma::BibItem.new("item_data" =>
-         { "public_note" => "" }
-       )
-      end
+      let(:item) { {} }
 
       it "displays nothing" do
-        expect(public_note(item)).to eq nil
+        expect(public_note(item)).to eq ""
       end
     end
   end
 
-  describe "#location_status(item)" do
-    context "item is in temporary location" do
-      let(:item) do
-        Alma::BibItem.new("holding_data" =>
-         { "in_temp_location" => true,
-           "temp_library" => { "value" => "RES_SHARE" },
-           "temp_location" => { "value" => "IN_RS_REQ" },
-           "temp_call_number" => "Temp call number"
-          }
-       )
-      end
+  describe "#library(item)" do
+    context "item is in temporary library" do
+      let(:item) { { "current_library" => "RES_SHARE" } }
 
-      it "displays temporary location and call number" do
-        expect(location_status(item)).to eq "Lending Resource Sharing Requests"
+      it "displays temporary library" do
+        expect(library(item)).to eq "RES_SHARE"
+      end
+    end
+
+    context "item is NOT in temporary library" do
+      let(:item) { { "permanent_library" => "MAIN" } }
+
+      it "displays library" do
+        expect(library(item)).to eq "MAIN"
+      end
+    end
+  end
+
+
+  describe "#location(item)" do
+    context "item is in temporary location" do
+      let(:item) { { "current_location" => "ILL" } }
+
+      it "displays temporary location" do
+        expect(location_status(item)).to eq "ILL"
       end
     end
 
     context "item is NOT in temporary location" do
-      let(:item) do
-        Alma::BibItem.new("holding_data" =>
-         { "in_temp_location" => false,
-           "call_number" => "Perm call number"
-         },
-         "item_data" => {
-           "library" => { "value" => "MAIN" },
-           "location" => { "value" => "stacks" },
-         }
-       )
-      end
+      let(:item) { { "permanent_location" => "rarestacks" } }
 
       it "displays location and call number" do
-        expect(location_status(item)).to eq "Stacks"
+        expect(location_status(item)).to eq "rarestacks"
       end
     end
   end
+
+  describe "#location_name_from_short_code(item)" do
+    context "location codes are converted to names using translation map" do
+      let(:item) { { "permanent_location" => "rarestacks",
+                      "permanent_library" => "SCRC" } }
+
+      it "displays location name" do
+        expect(location_name_from_short_code(item)).to eq "Reading Room"
+      end
+    end
+  end
+
 
   #  describe "#group_and_order_items(item)" do
   #    context "does not display items that are lost" do
@@ -377,16 +361,21 @@ RSpec.describe AlmaDataHelper, type: :helper do
 
   describe "#alternative_call_number(item)" do
     context "item has an alternate call number" do
-      let(:item) do
-        Alma::BibItem.new("item_data" =>
-           { "alternative_call_number" => "alternate" }
-        )
-      end
+      let(:item) { { "alt_call_number" => "alternate call number" } }
 
       it "displays alternate call number" do
-        expect(alternative_call_number(item)).to eq "(Also found under alternate)"
+        expect(alternative_call_number(item)).to eq "alternate call number"
       end
     end
+
+    context "item does NOT have an alternate call number" do
+      let(:item) { { "call_number" => "regular call number" } }
+
+      it "does NOT display alternate call number" do
+        expect(alternative_call_number(item)).to eq "regular call number"
+      end
+    end
+
   end
 
   describe "#sort_order_for_holdings(items)" do

--- a/spec/helpers/alma_data_helper_spec.rb
+++ b/spec/helpers/alma_data_helper_spec.rb
@@ -274,82 +274,6 @@ RSpec.describe AlmaDataHelper, type: :helper do
     end
   end
 
-
-  #  describe "#group_and_order_items(item)" do
-  #    context "does not display items that are lost" do
-  #      let(:item) do
-  #          Alma::BibItem.new([{ "holding_data" =>
-  #           { "in_temp_location" => false,
-  #           },
-  #           "item_data" => {
-  #             "library" => { "value" => "MAIN" },
-  #             "process_type" => { "value" => "LOST_LOAN" }
-  #           }
-  #         }]
-  #      end
-  #
-  #      it "does not display lost item" do
-  #        expect(group_and_order_items(item)).to eq({})
-  #      end
-  #    end
-  #
-  #    context "does not display items that are missing" do
-  #      let(:item) do
-  #        [{ "holding_data" =>
-  #           { "in_temp_location" => false,
-  #           },
-  #           "item_data" => {
-  #             "library" => { "value" => "MAIN" },
-  #             "process_type" => { "value" => "MISSING" }
-  #           }
-  #         }]
-  #      end
-  #
-  #      it "does not display missing item" do
-  #        expect(group_and_order_items(item)).to eq({})
-  #      end
-  #    end
-  #
-  #
-  #    context "item is in a permanent library" do
-  #      let(:item) do
-  #        [{ "holding_data" =>
-  #           { "in_temp_location" => false,
-  #           },
-  #           "item_data" => {
-  #             "library" => { "value" => "MAIN" },
-  #             "location" => { "value" => "" },
-  #             "process_type" => { "value" => "" }
-  #           }
-  #         }]
-  #      end
-  #
-  #      it "displays library code" do
-  #        expect(group_and_order_items(item)).to eq "MAIN" => [{ "holding_data" => { "in_temp_location" => false }, "item_data" => { "library" => { "value" => "MAIN" }, "location" => { "value" => "" }, "process_type" => { "value" => "" }
-  # } }]
-  #      end
-  #    end
-  #
-  #    context "item is in a temporary library" do
-  #      let(:item) do
-  #        [{ "holding_data" =>
-  #           { "in_temp_location" => true,
-  #             "temp_library" => { "value" => "RES_SHARE" },
-  #             "temp_location" => { "value" => "IN_RS_REQ" }
-  #           },
-  #           "item_data" => {
-  #             "library" => { "value" => "MAIN" },
-  #             "process_type" => { "value" => "" }
-  #           }
-  #         }]
-  #      end
-  #
-  #      it "displays temporary library code" do
-  #        expect(group_and_order_items(item).keys).to have_text "RES_SHARE"
-  #      end
-  #    end
-  #  end
-
   describe "#library_name_from_short_code(short_code)" do
     context "library codes are converted to names using translation map" do
       let(:short_code) { "MAIN" }
@@ -375,12 +299,41 @@ RSpec.describe AlmaDataHelper, type: :helper do
         expect(alternative_call_number(item)).to eq "regular call number"
       end
     end
-
   end
 
-  describe "#sort_order_for_holdings(items)" do
+  describe "#document_and_api_merged_results(document, items_list)" do
+    context "item_pid from api matches item_pid in document" do
+      let(:document) { { "items_json_display" =>
+        [{ "item_pid" => "23237957740003811",
+        "item_policy" => "5",
+        "permanent_library" => "AMBLER",
+        "permanent_location" => "media",
+        "current_library" => "AMBLER",
+        "current_location" => "media",
+        "call_number" => "DVD 13 A165",
+        "holding_id" => "22237957750003811" }]
+          }
+        }
+
+      let(:items_list) { Alma::BibItem.find("document_and_api_merged_results") }
+
+      it "merges the availability into the document field" do
+        expect(document_and_api_merged_results(document, items_list)).to eq([{ "item_pid" => "23237957740003811",
+                                                                            "item_policy" => "5",
+                                                                            "permanent_library" => "AMBLER",
+                                                                            "permanent_location" => "media",
+                                                                            "current_library" => "AMBLER",
+                                                                            "current_location" => "media",
+                                                                            "call_number" => "DVD 13 A165",
+                                                                            "holding_id" => "22237957750003811",
+                                                                            "availability" => "<span class=\"check\"></span>Available" }])
+      end
+    end
+  end
+
+  describe "#sort_order_for_holdings(grouped_items)" do
     context "items are sorted by library name with Paley first" do
-      let(:items) do
+      let(:grouped_items) do
         {
         "MAIN" => [Alma::BibItem.new({})],
         "AMBLER" => [Alma::BibItem.new({})]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require "webmock/rspec"
 require "vcr"
 require "database_cleaner"
 require "capybara/rspec"
+require "pry"
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
@@ -172,6 +173,10 @@ RSpec.configure do |config|
                 body: File.open(SPEC_ROOT + "/fixtures/availability_response.xml").read,
                 headers: { "content-type" => ["application/xml;charset=UTF-8"] })
 
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/merge_document_and_api\/holdings\/.*\/items/).
+      to_return(status: 200,
+                headers: { "content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/alma_data/merge_document_and_api.json"))
   end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
This changes the logic to depend more on document fields and less on the alma api
- Creates a new items_json_display field to get all document information except for real-time avail.
- Refactors all the alma_data_helper methods to use the new field rather than the api
- Creates a new method to merge the real-time availability for each item with the information from the items_json_display field
- group_by library and reject missing_and_lost items methods performed on this new merged_data
- sort-by-holdings refactored to use merged_data
- adds/updates specs as needed
- keeping alma bib_items and methods in controller since we are still using them for requests