### PR TITLE
[BL-838] Fix refworks paths for books and journals

### DIFF
--- a/app/helpers/blacklight_marc_helper.rb
+++ b/app/helpers/blacklight_marc_helper.rb
@@ -8,20 +8,14 @@ module BlacklightMarcHelper
 
   # Overrides the original method in Blacklight Marc so that we only use this link for catalog items
   def refworks_solr_document_path(opts = {})
-    if opts[:id] && controller_name == "catalog"
+    return if !opts[:id]
+
+    case controller_name
+    when "catalog"
       refworks_export_url(url: solr_document_url(opts[:id], format: :refworks_marc_txt))
-    end
-  end
-
-  # Replicates the refworks_solr_document_path method for books and journals
-  def refworks_solr_book_document_path(opts = {})
-    if opts[:id] && controller_name == "books"
+    when "books"
       refworks_export_url(url: solr_book_document_path(opts[:id], format: :refworks_marc_txt))
-    end
-  end
-
-  def refworks_solr_journal_document_path(opts = {})
-    if opts[:id] && controller_name == "journals"
+    when "journals"
       refworks_export_url(url: solr_journal_document_path(opts[:id], format: :refworks_marc_txt))
     end
   end


### PR DESCRIPTION
REF BL-838

Now that books and journals document models alias the solr document only
the `refworks_solr_document_path()` gets called.  This commit updates
this method to also return for books and journal controller.