### PR TITLE
[BL-641] do not skip suppressed on non full reingest

### DIFF
--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -516,14 +516,14 @@ module Traject
       end
 
       def suppress_items
-        lambda do |rec, acc, context|
+        lambda do |rec, acc|
           asrs = rec.fields("ITM").select { |field| field["g"] == "asrs" }
           lost = rec.fields("ITM").select { |field| field["u"] == "LOST_LOAN" }
           missing = rec.fields("ITM").select { |field| field["u"] == "MISSING" }
           technical = rec.fields("ITM").select { |field| field["u"] == "TECHNICAL" }
-
+          #field = rec.fields("ITM").map { |field| field["u"] }.first
           if rec.fields("ITM").length == 1 && (!lost.empty? || !missing.empty? || !technical.empty? || !asrs.empty?)
-            context.skip!
+            acc.replace([true])
           end
         end
       end

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -516,15 +516,20 @@ module Traject
       end
 
       def suppress_items
-        lambda do |rec, acc|
+        lambda do |rec, acc, context|
           asrs = rec.fields("ITM").select { |field| field["g"] == "asrs" }
           lost = rec.fields("ITM").select { |field| field["u"] == "LOST_LOAN" }
           missing = rec.fields("ITM").select { |field| field["u"] == "MISSING" }
           technical = rec.fields("ITM").select { |field| field["u"] == "TECHNICAL" }
-          #field = rec.fields("ITM").map { |field| field["u"] }.first
+
           if rec.fields("ITM").length == 1 && (!lost.empty? || !missing.empty? || !technical.empty? || !asrs.empty?)
             acc.replace([true])
           end
+
+          if acc == [true] && ENV["TRAJECT_FULL_REINDEX"] == "yes"
+            context.skip!
+          end
+
         end
       end
 

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -882,6 +882,55 @@ RSpec.describe Traject::Macros::Custom do
     end
   end
 
+  describe "full reindex #suppress_items" do
+    let(:path) { "lost_missing_technical.xml" }
+
+
+    before do
+      stub_const("ENV", ENV.to_hash.merge("TRAJECT_FULL_REINDEX" => "yes"))
+      @writer = Traject::ArrayWriter.new
+      @indexer = Traject::Indexer.new(writer: @writer) do
+        to_field "suppress_items_b", suppress_items
+      end
+
+      subject.instance_eval do
+        settings do
+          provide "marc_source.type", "xml"
+        end
+      end
+    end
+
+    context "when a single item is lost" do
+      it "maps lost record" do
+        expect(@indexer.process_record(records[0]).skip?).to eq(true)
+      end
+    end
+
+    context "when a single item is missing" do
+      it "maps  record" do
+        expect(@indexer.process_record(records[1]).skip?).to eq(true)
+      end
+    end
+
+    context "when a single item is technical" do
+      it "maps technical record" do
+        expect(@indexer.process_record(records[2]).skip?).to eq(true)
+      end
+    end
+
+    context "when there are multiple items and one of the records is lost" do
+      it "does not map to the field" do
+        expect(@indexer.process_record(records[3]).skip?).to eq(false)
+      end
+    end
+
+    context "when there are multiple items and one of the records is in asrs" do
+      it "does not map to the field" do
+        expect(@indexer.process_record(records[4]).skip?).to eq(false)
+      end
+    end
+  end
+
   describe "#extract_oclc_number" do
     let(:path) { "oclc.xml" }
 

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -842,14 +842,9 @@ RSpec.describe Traject::Macros::Custom do
   describe "#suppress_items" do
     let(:path) { "lost_missing_technical.xml" }
 
-
     before do
-      @writer = Traject::ArrayWriter.new
-      @indexer = Traject::Indexer.new(writer: @writer) do
-        to_field "suppress_items_b", suppress_items
-      end
-
       subject.instance_eval do
+        to_field "suppress_items_b", suppress_items
         settings do
           provide "marc_source.type", "xml"
         end
@@ -858,31 +853,31 @@ RSpec.describe Traject::Macros::Custom do
 
     context "when a single item is lost" do
       it "maps lost record" do
-        expect(@indexer.process_record(records[0]).skip?).to eq(true)
+        expect(subject.map_record(records[0])).to eq("suppress_items_b" => [true])
       end
     end
 
     context "when a single item is missing" do
-      it "maps  record" do
-        expect(@indexer.process_record(records[1]).skip?).to eq(true)
+      it "maps missing record" do
+        expect(subject.map_record(records[1])).to eq("suppress_items_b" => [true])
       end
     end
 
     context "when a single item is technical" do
       it "maps technical record" do
-        expect(@indexer.process_record(records[2]).skip?).to eq(true)
+        expect(subject.map_record(records[2])).to eq("suppress_items_b" => [true])
       end
     end
 
     context "when there are multiple items and one of the records is lost" do
       it "does not map to the field" do
-        expect(@indexer.process_record(records[3]).skip?).to eq(false)
+        expect(subject.map_record(records[3])).to eq({})
       end
     end
 
     context "when there are multiple items and one of the records is in asrs" do
       it "does not map to the field" do
-        expect(@indexer.process_record(records[4]).skip?).to eq(false)
+        expect(subject.map_record(records[4])).to eq({})
       end
     end
   end


### PR DESCRIPTION
REF BL-641
REF BL-850

* Reverts skipping suppressed docs because docs are sometimes already in solr repo.
* Allows to skip suppressed docs by signaling that a full reindex is in progess.

# Depends on:
- [ ] [Documentation](https://github.com/tulibraries/tul_cob_wiki/pull/1) (BL-850)
