### PR TITLE
[BL-853] Do not render layout for almaws errors.

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,10 +2,15 @@
 
 class ErrorsController < ApplicationController
   def not_found
-    render(status: 404)
+    render(layout(status: 404))
   end
 
   def internal_server_error
-    render(status: 500)
+    render(layout(status: 500))
   end
+
+  private
+    def layout(options)
+      request.env["REQUEST_PATH"].match?(/^\/almaws/) ? options.merge(layout: false) : options
+    end
 end


### PR DESCRIPTION
REF BL-853

almaws controller items are all for ajax so errors should not render the
full layout.