### PR TITLE
[BL-855] Default unknown fields to any.

### DIFF
--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -167,7 +167,7 @@ module Blacklight::PrimoCentral
           description: :desc,
         }
           .with_indifferent_access
-          .fetch(field, field) || :any
+          .fetch(field, :any)
       end
 
       def is_advanced_search?

--- a/spec/models/primo_search_builder_spec.rb
+++ b/spec/models/primo_search_builder_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new(search_field: "foo") }
 
       it "should always transform unknown search_fields to any" do
-        expect(primo_central_parameters["query"]["q"]["field"]).to eq("any")
+        expect(primo_central_parameters["query"]["q"]["field"]).to eq(:any)
       end
     end
   end


### PR DESCRIPTION
When searching an unknown field it should revert to primo field any not
just pass the field along.