### PR TITLE
[BL-837] Fix bookmarks not showing up.

### DIFF
--- a/app/controllers/concerns/multi_source_bookmarks.rb
+++ b/app/controllers/concerns/multi_source_bookmarks.rb
@@ -36,15 +36,12 @@ module MultiSourceBookmarks
     # Replacing TN_ in ids to add backward compatibility.
     document_map = document_list
       .map { |d| [d.id.gsub(/^TN_/, ""), d] }.to_h
-    @document_list = @bookmarks.map { |b| document_map[b.document_id] }.compact
-
+    @documents = @bookmarks.map { |b| document_map[b.document_id] }.compact
     # Capture full document list in response for correct current_bookmarks count.
-    @documents = @document_list
-    @response["docs"] = @documents if @response
+    @response.instance_variable_set(:@documents, @documents) if @response
 
     # Just display all the bookmarks in one page
     @response["rows"] = @bookmarks.count if @response
-    @docs = @documents
     [@response, @documents]
   end
 

--- a/app/views/bookmarks/_show_tools.html.erb
+++ b/app/views/bookmarks/_show_tools.html.erb
@@ -11,7 +11,7 @@
 <% if show_doc_actions? %>
 <% @sendto = {} %>
       <ul id="tools-navbar">
-        <%= render_show_doc_actions @document_list do |config, inner| %>
+        <%= render_show_doc_actions @documents do |config, inner| %>
           <% @sendto[config.key] = inner %>
         <% end %>
 

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -5,7 +5,7 @@
 <div id="content" class="bookmarks-page col-md-11 bg-white rounded p-0 mx-auto">
   <% if current_or_guest_user.blank? %>
     <h2 class="section-heading"><%= t("blacklight.bookmarks.need_login") %></h2>
-  <% elsif @document_list.blank? %>
+  <% elsif @documents.blank? %>
     <h2 class="section-heading no-bookmarks-message"><%= t("blacklight.bookmarks.no_bookmarks") %></h2>
   <% else %>
     <span id="alma_availability_url" data-url="<%= alma_availability_url(format: :json) %>" ></span>


### PR DESCRIPTION
REF BL-837

blacklight-7 changes the way that response.documents works causing
failure when we try to override what response.documents returns.

This commit overrides the @documents instance variable of response so
that reponse.documents works as expected (i.e. uses our merged documents
not just documents coming from one searcher).