### PR TITLE
Bl 815 physical item availability

### DIFF
--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -28,7 +28,7 @@ div.site-message {
 	color: $black;
 	font-family: "Crimson Text", serif;
 	font-size: 2.0rem;
-	margin-left: 0.625rem;	//  text-decoration: none;
+	margin-left: 0.625rem;
 
 	@media(max-width: 485px) {
 	 font-size: 1.4rem;

--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -21,7 +21,7 @@ class AlmawsController < CatalogController
     bib_items = do_with_json_logger(log) { Alma::BibItem.find(@mms_id, limit: limit, offset: offset) }
     @response = Blacklight::Alma::Response.new(bib_items, params)
     @items = bib_items.filter_missing_and_lost.grouped_by_library
-    @document_and_api_data = helpers.document_and_api_merged_results(@document, @items)
+    @document_and_api_data = helpers.document_and_api_merged_results(@document, bib_items)
     @document_availability = helpers.document_availability_info(@document)
     @pickup_locations = CobAlma::Requests.valid_pickup_locations(@items).join(",")
     @request_level = has_desc?(bib_items) ? "item" : "bib"

--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -34,12 +34,12 @@ module AvailabilityHelper
 
   def document_and_api_merged_results(document, items_list)
     document_items = document.fetch("items_json_display", [])
-    alma_item_pids = items_list.collect { |k, v|
-          v.map { |item| item["item_data"]["pid"] }
-        }.flatten
+    alma_item_pids = items_list.all.collect { |item|
+      item["item_data"]["pid"]
+    }.flatten
 
-    alma_item_availability = items_list.collect { |k, v|
-      v.collect { |item| availability_status(item) }
+    alma_item_availability = items_list.all.collect { |item|
+      availability_status(item)
     }.flatten
 
     document_items.collect { |item|
@@ -68,7 +68,7 @@ module AvailabilityHelper
     type = item["material_type"]
 
     if !type.match(PHYSICAL_TYPE_EXCLUSIONS)
-      return item["material_type"]
+      return Rails.configuration.material_types[type]
     end
   end
 

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -35,9 +35,10 @@
           </div>
         </div>
       <% end %>
-      <%= render :partial => "paginate_compact", :object => @response %>
     </div>
   <% end %>
+
+  <%= render :partial => "paginate_compact", :object => @response %>
 
   <% else %>
     <div id: "error-message">We are unable to find availability information for this record. Please contact the library for more information.</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,7 @@ module Tulcob
     config.process_types = config_for(:process_types).with_indifferent_access
     config.libraries = DotProperties.load(Rails.root + "config/translation_maps/libraries_map.properties")
     config.locations = config_for(:locations).with_indifferent_access
+    config.material_types = config_for(:material_types).with_indifferent_access
     config.alma = config_for(:alma).with_indifferent_access
     config.electronic_collection_notes = Alma::ConfigUtils.load_notes(type: "collection")
     config.electronic_service_notes = Alma::ConfigUtils.load_notes(type: "service")

--- a/config/material_types.yml
+++ b/config/material_types.yml
@@ -1,0 +1,107 @@
+default: &default
+  BOOK: Book
+  ISSUE: Issue
+  DVD: DVD
+  CD: Compact Disc
+  CDROM: CD-ROM
+  DVDRM: DVD-ROM
+  SCORE: Music Score
+  VIDEOCASSETTE: Video cassette
+  AUDIOCASSETTE: Audio cassette
+  MANUSCRIPT: Manuscript
+  FILM: Microfilm
+  FICHE: Microfiche
+  DISK: Computer Disk
+  REALIA: Realia
+  KIT: Kit
+  PICTURE: Picture
+  MAP: Map
+  LRDSC: Laserdisc
+  RECORD: Sound Recording
+  ISSBD: Bound Issue
+  HEAD: Headphones
+  LPTOP: Laptop
+  IPAD: iPad
+  FSADT: Flat Screen Adaptor
+  CHARG: Laptop Charger
+  CALC: Calculator
+  FLIPV: Flip Video Camera
+  ARTORIG: Art Original
+  ARTREPRO: Art Reproduction
+  CHART: Chart
+  DIORAMA: Diorama
+  FILMSTRIP: Filmstrip
+  FLASHCARD: Flash Card
+  GAME: Game
+  GRAPHIC: Graphic
+  MICROSLIDE: Microscope Slide
+  MODEL: Model
+  SLIDE: Slide
+  TECHDRAWING: Techincal Drawing
+  TOY: Toy
+  TRANSPARENCY: Transparency
+  LETTER: Letter
+  PHOTOGRAPH: Photograph
+  THESIS: Thesis
+  MIXED: Mixed material
+  AUDIOBOOK: Audiobook
+  EQUIP: Equipment
+  PAMPHLET: Pamphlet
+  OVERSIZE: Oversize
+  EPHEMERA: Ephemera
+  CASE: Case
+  ROOM: Room
+  VIDEODISC: Video Disk
+  SPECIALTHESIS: Special Degree Thesis
+  PHDTHESIS: PhD Thesis
+  MASTERTHESIS: Master Thesis
+  BACHLORTHESIS: Bachelor Thesis
+  OVERSIZESCORE: Oversize Score
+  MICROFORM: Mocroform
+  VRECORD: Video Recording
+  PLAYAWAY: Playaway
+  ARTICLE: Article
+  ATLAS: Atlas
+  AUDIORECORDER: Audio Recorder
+  BLURAY: Blu-Ray
+  BLURAYDVD: Blu-Ray And DVD
+  CAMERA: Camera
+  CAMRECORDER: Camcorder
+  EREADER: Ereader
+  GOVRECORD: Government Document
+  KEYS: Keys
+  LOOSELEAF: Looseleaf
+  LP: LP
+  MICROCARD: Microcard
+  MOBILEDEVICE: Mobile Device
+  NEWSPAPER: Newspaper
+  PROJECTOR: Projector
+  TABLET: Tablet
+  VIDEOGAME: Video Game
+  MMFILM: 16 mm Film
+  BOX: Box
+  FILMREEL: Film Reel
+  OTHERVM: Other Visual Material
+  FLOPPY_DISK: Floppy Disk
+  ITEM_WITH_FLOPPY_DISK: Item with Floppy Disk
+  ITEM_WITH_CD: Item with CD
+  ITEM_WITH_AUDIO_CASSETTE: Item with Audio Cassette
+  DAT: DAT(Digital Audio Tape)
+  GLOBE: Globe
+  LAPTOPACCESSORY: Laptop Accessory
+  MICROOPAQUE: Microopaque
+  MOTIONPICTURE: Motion Picture
+  PHONODISC: Record(Phonodisc)
+  VRECORD_OTHER: Video Recording(Other)
+  RARE: Rare
+  MICROFICHE_MASTER: Microfiche Master
+  OTHER: Other
+
+test:
+  <<: *default
+
+development:
+  <<: *default
+
+production:
+  <<: *default

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
           }
         }
 
-      let(:items_list) { Alma::BibItem.find("merge_document_and_api")}
+      let(:items_list) { Alma::BibItem.find("merge_document_and_api") }
 
       it "merges the availability into the document field" do
         expect(document_and_api_merged_results(document, items_list)).to eq("AMBLER" => [{ "item_pid" => "23237957740003811",

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
 
   describe "#material_type(item)" do
     context "item includes physical_material_type" do
-      let(:item) { { "material_type" => "Sound Recording" } }
+      let(:item) { { "material_type" => "RECORD" } }
 
       it "displays physical_material_type" do
         expect(material_type(item)).to eq "Sound Recording"
@@ -286,7 +286,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
     end
 
     context "item does NOT include PHYSICAL_TYPE_EXCLUSIONS" do
-      let(:item) { { "material_type" => "Book" } }
+      let(:item) { { "material_type" => "BOOK" } }
 
       it "displays nothing" do
         expect(material_type(item)).to eq nil

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
           }
         }
 
-      let(:items_list) { Alma::BibItem.find("merge_document_and_api").grouped_by_library }
+      let(:items_list) { Alma::BibItem.find("merge_document_and_api")}
 
       it "merges the availability into the document field" do
         expect(document_and_api_merged_results(document, items_list)).to eq("AMBLER" => [{ "item_pid" => "23237957740003811",
@@ -229,7 +229,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
           }
         }
 
-      let(:items_list) { Alma::BibItem.find("merge_document_and_api").grouped_by_library }
+      let(:items_list) { Alma::BibItem.find("merge_document_and_api") }
 
       it "does not merge the availability into the document field" do
         expect(document_and_api_merged_results(document, items_list)).to eq({})
@@ -250,7 +250,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
           }
         }
 
-      let(:items_list) { Alma::BibItem.find("merge_document_and_api").grouped_by_library }
+      let(:items_list) { Alma::BibItem.find("merge_document_and_api") }
 
       it "filters out missing or lost items" do
         expect(document_and_api_merged_results(document, items_list)).to eq({})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -179,6 +179,13 @@ RSpec.configure do |config|
       to_return(status: 200,
                 headers: { "content-Type" => "application/json" },
                 body: File.open(SPEC_ROOT + "/fixtures/alma_data/merge_document_and_api.json"))
+
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/merge_document_and_api\/holdings\/.*\/items/).
+      with(query: hash_including(offset: "100")).
+      to_return(status: 200,
+                headers: { "content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/empty_hash.json"))
+
   end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
- update material type to be description, not value
- add pagination links to the top of the modal
- Get all availability info, was only getting the first 100 previously
- fix failing specs and rubocop offenses