### PR TITLE
[BL-837] Fix bookmarked article render breaks.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -317,6 +317,7 @@ class CatalogController < ApplicationController
     config.add_index_field "url_finding_aid_display", label: "Finding Aid", helper_method: :check_for_full_http_link
     config.add_index_field "availability"
     config.add_index_field "purchase_order_availability", field: "purchase_order", if: false, helper_method: :render_purchase_order_availability, with_po_link: true
+    config.add_index_field "bound_with_ids", if: false
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -115,6 +115,14 @@ module CatalogHelper
     end
   end
 
+  def render_bound_with_ids(doc_presenter)
+    document = doc_presenter.document
+
+    if index_fields["bound_with_ids"] && document.alma_availability_mms_ids.present?
+      "<span class='row document-metadata blacklight-availability availability-ajax-load' data-availability-ids='#{document.alma_availability_mms_ids.join(',')}'></span>"
+    end
+  end
+
   ##
   # Overridden from module Blacklight::BlacklightHelperBehavior.
   #

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -115,11 +115,9 @@ module CatalogHelper
     end
   end
 
-  def render_bound_with_ids(doc_presenter)
-    document = doc_presenter.document
-
+  def render_bound_with_ids(document)
     if index_fields["bound_with_ids"] && document.alma_availability_mms_ids.present?
-      "<span class='row document-metadata blacklight-availability availability-ajax-load' data-availability-ids='#{document.alma_availability_mms_ids.join(',')}'></span>"
+      content_tag :span, nil, class: "row document-metadata blacklight-availability availability-ajax-load", "data-availability-ids": document.alma_availability_mms_ids.join(",")
     end
   end
 

--- a/app/views/catalog/_fields.html.erb
+++ b/app/views/catalog/_fields.html.erb
@@ -18,4 +18,4 @@
 <% end -%>
 </dl>
 
-<%= raw render_bound_with_ids(doc_presenter) %>
+<%= render_bound_with_ids(document) %>

--- a/app/views/catalog/_fields.html.erb
+++ b/app/views/catalog/_fields.html.erb
@@ -18,6 +18,4 @@
 <% end -%>
 </dl>
 
-<% if [ "catalog", "books", "journals", "bookmarks" ].include?(controller_name) %>
-  <span class="row document-metadata blacklight-availability availability-ajax-load" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" ></span>
-<% end %>
+<%= raw render_bound_with_ids(doc_presenter) %>

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -200,19 +200,16 @@ RSpec.describe CatalogHelper, type: :helper do
   describe "#render_bound_with_ids" do
     let(:doc) { SolrDocument.new(bound_with_ids: ["foo"]) }
     let(:config) { CatalogController.blacklight_config }
-    let(:context) { Blacklight::Configuration::Context.new(nil) }
-    let(:presenter) { helper.index_presenter(doc) }
 
     before do
       without_partial_double_verification do
         allow(helper).to receive(:blacklight_config) { config }
-        allow(helper).to receive(:blacklight_configuration_context) { context }
       end
     end
 
     context "with boud_with_ids defined" do
       it "renders the bound_with_ids" do
-        expect(helper.render_bound_with_ids(presenter)).not_to be_nil
+        expect(helper.render_bound_with_ids(doc)).not_to be_nil
       end
     end
 
@@ -220,7 +217,7 @@ RSpec.describe CatalogHelper, type: :helper do
       let(:doc) { SolrDocument.new(bound_with_ids: nil) }
 
       it "does not render the bound_with_ids" do
-        expect(helper.render_bound_with_ids(presenter)).to be_nil
+        expect(helper.render_bound_with_ids(doc)).to be_nil
       end
     end
 
@@ -228,7 +225,7 @@ RSpec.describe CatalogHelper, type: :helper do
       let(:config) { PrimoCentralController.blacklight_config }
 
       it "does not render the bound_with_ids" do
-        expect(helper.render_bound_with_ids(presenter)).to be_nil
+        expect(helper.render_bound_with_ids(doc)).to be_nil
       end
     end
   end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -197,6 +197,42 @@ RSpec.describe CatalogHelper, type: :helper do
     end
   end
 
+  describe "#render_bound_with_ids" do
+    let(:doc) { SolrDocument.new(bound_with_ids: ["foo"]) }
+    let(:config) { CatalogController.blacklight_config }
+    let(:context) { Blacklight::Configuration::Context.new(nil) }
+    let(:presenter) { helper.index_presenter(doc) }
+
+    before do
+      without_partial_double_verification do
+        allow(helper).to receive(:blacklight_config) { config }
+        allow(helper).to receive(:blacklight_configuration_context) { context }
+      end
+    end
+
+    context "with boud_with_ids defined" do
+      it "renders the bound_with_ids" do
+        expect(helper.render_bound_with_ids(presenter)).not_to be_nil
+      end
+    end
+
+    context "with no bound with ids available" do
+      let(:doc) { SolrDocument.new(bound_with_ids: nil) }
+
+      it "does not render the bound_with_ids" do
+        expect(helper.render_bound_with_ids(presenter)).to be_nil
+      end
+    end
+
+    context "without bound_with_ids configured" do
+      let(:config) { PrimoCentralController.blacklight_config }
+
+      it "does not render the bound_with_ids" do
+        expect(helper.render_bound_with_ids(presenter)).to be_nil
+      end
+    end
+  end
+
   describe "#render_email_form_field" do
     let(:current_user) { OpenStruct.new(email: nil) }
 


### PR DESCRIPTION
Updates bound_with_ids render to be a configuration at the controller
level to avoid field getting rendered when it has not been configured.