### PR TITLE
[BL-876] Update primo gem.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GIT
 
 GIT
   remote: https://github.com/tulibraries/primo
-  revision: a346aebc34038517613c7542bd41febac0861af0
+  revision: 695440062044db24a1d01c4fd873c4767e28dff6
   specs:
     primo (0.1.0)
       httparty

--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -85,7 +85,7 @@ module Blacklight::PrimoCentral
       end
     end
 
-    # Query is a Primo::Pnxs::Query instance after this process.
+    # Query is a Primo::Search::Query instance after this process.
     def add_query_facets(primo_central_parameters)
       if primo_central_parameters[:query][:q][:value].is_a? Array
         op = :build
@@ -95,7 +95,7 @@ module Blacklight::PrimoCentral
         query = primo_central_parameters[:query][:q]
       end
 
-      pq = Primo::Pnxs::Query.send(op, query)
+      pq = Primo::Search::Query.send(op, query)
 
       primo_central_parameters[:query][:q] = pq
 


### PR DESCRIPTION
The Primo::PNXS API has been deprecated. This updates the primo gem we
use to the version that uses Primo::Search api instead.