### PR TITLE
Remove reference to SolrBookDocument.

### DIFF
--- a/app/search_engines/catalog_bookmark_search.rb
+++ b/app/search_engines/catalog_bookmark_search.rb
@@ -6,6 +6,6 @@ class CatalogBookmarkSearch < CatalogController
 
   def self.handle_bookmark_search?(document_model)
     blacklight_config.document_model == document_model ||
-      [ SolrBookDocument, SolrJournalDocument ].include?(document_model)
+      [ SolrJournalDocument ].include?(document_model)
   end
 end


### PR DESCRIPTION
This is causing a 500 error when viewing bookmarks.

REF BL-837