### PR TITLE
[BL-875] Add extract_update_date method to traject config.

### DIFF
--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -252,20 +252,5 @@ to_field "purchase_order", extract_purchase_order
 
 # Administrative data enrichment fields
 # a=create date, b=update date, c=Suppress from publishing, d=Originating system, e=Originating system ID, f=Originating system version
-to_field "record_creation_date", extract_marc("ADMa")
-to_field "record_update_date", extract_update_date
-
-# You have to make sure this is at the END of your traject pipeline
-each_record do |record, context|
-  if context.output_hash["record_creation_date"].nil? || context.output_hash["record_creation_date"] == []
-    context.output_hash["record_creation_date"] = ["2001-01-01 01:01:01"]
-  end
-
-  if context.output_hash["record_update_date"].nil? || context.output_hash["record_update_date"] == []
-    context.output_hash["record_update_date"] = ["2002-02-02 02:02:02"]
-  end
-
-  if ENV["SOLR_DISABLE_UPDATE_DATE_CHECK"] == "yes"
-    context.output_hash["record_update_date"] = [ Time.now.to_s ]
-  end
-end
+to_field "record_creation_date", extract_marc("ADMa"), default("2001-01-01 01:01:01")
+to_field "record_update_date", extract_update_date, default("2002-02-02 02:02:02")

--- a/lib/traject/indexer_config.rb
+++ b/lib/traject/indexer_config.rb
@@ -3,6 +3,7 @@
 $:.unshift "./config"
 $:.unshift "./lib"
 require "yaml"
+
 solr_config = YAML.load_file("config/blacklight.yml")[(ENV["RAILS_ENV"] || "development")]
 solr_url = ERB.new(solr_config["url"]).result
 # A sample traject configuration, save as say `traject_config.rb`, then
@@ -252,13 +253,14 @@ to_field "purchase_order", extract_purchase_order
 # Administrative data enrichment fields
 # a=create date, b=update date, c=Suppress from publishing, d=Originating system, e=Originating system ID, f=Originating system version
 to_field "record_creation_date", extract_marc("ADMa")
-to_field "record_update_date", extract_marc("ADMb")
+to_field "record_update_date", extract_update_date
 
 # You have to make sure this is at the END of your traject pipeline
 each_record do |record, context|
   if context.output_hash["record_creation_date"].nil? || context.output_hash["record_creation_date"] == []
     context.output_hash["record_creation_date"] = ["2001-01-01 01:01:01"]
   end
+
   if context.output_hash["record_update_date"].nil? || context.output_hash["record_update_date"] == []
     context.output_hash["record_update_date"] = ["2002-02-02 02:02:02"]
   end

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -650,11 +650,11 @@ module Traject
             rec.fields("PRT").map { |f| [ f["created"], f["updated"] ] },
             rec.fields("HLD").map { |f| [ f["created"], f["updated"] ] },
             rec.fields("ITM").map { |f| f["q"] } ]
-            .flatten.compact.uniq.map { |t| Time.parse(t) }
+            .flatten.compact.uniq.map { |t| Time.parse(t).utc }
             .sort.last.to_s
 
           if ENV["SOLR_DISABLE_UPDATE_DATE_CHECK"] == "yes"
-            latest_date = Time.now.to_s
+            latest_date = Time.now.utc.to_s
           end
 
           acc << latest_date unless latest_date.empty?

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -653,7 +653,11 @@ module Traject
             .flatten.compact.uniq.map { |t| Time.parse(t) }
             .sort.last.to_s
 
-          acc << latest_date
+          if ENV["SOLR_DISABLE_UPDATE_DATE_CHECK"] == "yes"
+            latest_date = Time.now.to_s
+          end
+
+          acc << latest_date unless latest_date.empty?
         end
       end
     end

--- a/lib/traject/macros/custom.rb
+++ b/lib/traject/macros/custom.rb
@@ -649,7 +649,7 @@ module Traject
             rec.fields("ADM").map { |f| [ f["a"], f["b"] ] },
             rec.fields("PRT").map { |f| [ f["created"], f["updated"] ] },
             rec.fields("HLD").map { |f| [ f["created"], f["updated"] ] },
-            rec.fields("ITM").map { |f| f["q"] } ]
+            rec.fields("ITM").map { |f| [ f["q"], f["updated"] ] } ]
             .flatten.compact.uniq.map { |t| Time.parse(t).utc }
             .sort.last.to_s
 

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -1341,6 +1341,28 @@ RSpec.describe Traject::Macros::Custom do
       end
     end
 
+    context "Latest is ITM updated" do
+      let(:record_text) { "
+        <record>
+          <datafield ind1=' ' ind2=' ' tag='ADM'>
+            <subfield code='a'>2018-02-02 02:02:02 UTC</subfield>
+            <subfield code='b'>2002-02-02 02:02:02 UTC</subfield>
+          </datafield>
+          <datafield ind1='1' ind2=' ' tag='ITM'>
+            <subfield code='q'>2019-02-02 02:02:02 UTC</subfield>
+          </datafield>
+          <datafield ind1='1' ind2=' ' tag='ITM'>
+            <subfield code='q'>2013-02-02 02:02:02 UTC</subfield>
+            <subfield code='updated'>2019-02-02 02:02:02 UTC</subfield>
+          </datafield>
+        </record>
+                     " }
+
+      it "finds the latest date" do
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 UTC" ])
+      end
+    end
+
     context "Latest is HLDupdated" do
       let(:record_text) { "
         <record>

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -1297,7 +1297,7 @@ RSpec.describe Traject::Macros::Custom do
 
     before do
       subject.instance_eval do
-        to_field "record_update_date", extract_update_date, default("2002-02-02 02:02:02 +0000")
+        to_field "record_update_date", extract_update_date, default("2002-02-02 02:02:02 UTC")
         settings do
           provide "marc_source.type", "xml"
         end
@@ -1308,17 +1308,17 @@ RSpec.describe Traject::Macros::Custom do
       let(:record_text) { "
         <record>
           <datafield ind1=' ' ind2=' ' tag='ADM'>
-            <subfield code='a'>2019-02-02 02:02:02 +0000</subfield>
-            <subfield code='b'>2002-02-02 02:02:02 +0000</subfield>
+            <subfield code='a'>2019-02-02 02:02:02 UTC</subfield>
+            <subfield code='b'>2002-02-02 02:02:02 UTC</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='ITM'>
-            <subfield code='q'>2002-02-02 02:02:02 +0000</subfield>
+            <subfield code='q'>2002-02-02 02:02:02 UTC</subfield>
           </datafield>
         </record>
                      " }
 
       it "finds latest date" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 UTC" ])
       end
     end
 
@@ -1326,17 +1326,17 @@ RSpec.describe Traject::Macros::Custom do
       let(:record_text) { "
         <record>
           <datafield ind1=' ' ind2=' ' tag='ADM'>
-            <subfield code='a'>2018-02-02 02:02:02 +0000</subfield>
-            <subfield code='b'>2002-02-02 02:02:02 +0000</subfield>
+            <subfield code='a'>2018-02-02 02:02:02 UTC</subfield>
+            <subfield code='b'>2002-02-02 02:02:02 UTC</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='ITM'>
-            <subfield code='q'>2019-02-02 02:02:02 +0000</subfield>
+            <subfield code='q'>2019-02-02 02:02:02 UTC</subfield>
           </datafield>
         </record>
                      " }
 
       it "finds the latest date" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 UTC" ])
       end
     end
 
@@ -1344,25 +1344,25 @@ RSpec.describe Traject::Macros::Custom do
       let(:record_text) { "
         <record>
           <datafield ind1=' ' ind2=' ' tag='ADM'>
-            <subfield code='a'>2018-02-02 02:02:02 +0000</subfield>
-            <subfield code='b'>2002-02-02 02:02:02 +0000</subfield>
+            <subfield code='a'>2018-02-02 02:02:02 UTC</subfield>
+            <subfield code='b'>2002-02-02 02:02:02 UTC</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='ITM'>
-            <subfield code='q'>2017-02-02 02:02:02 +0000</subfield>
+            <subfield code='q'>2017-02-02 02:02:02 UTC</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='HLD'>
-            <subfield code='updated'>2019-02-02 02:02:02 +0000</subfield>
-            <subfield code='created'>2013-02-02 02:02:02 +0000</subfield>
+            <subfield code='updated'>2019-02-02 02:02:02 UTC</subfield>
+            <subfield code='created'>2013-02-02 02:02:02 UTC</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='HLD'>
-            <subfield code='updated'>2013-02-02 02:02:02 +0000</subfield>
-            <subfield code='created'>2014-02-02 02:02:02 +0000</subfield>
+            <subfield code='updated'>2013-02-02 02:02:02 UTC</subfield>
+            <subfield code='created'>2014-02-02 02:02:02 UTC</subfield>
           </datafield>
         </record>
                      " }
 
       it "finds the latest date" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 UTC" ])
       end
     end
 
@@ -1370,28 +1370,28 @@ RSpec.describe Traject::Macros::Custom do
       let(:record_text) { "
         <record>
           <datafield ind1=' ' ind2=' ' tag='ADM'>
-            <subfield code='a'>2018-02-02 02:02:02 +0000</subfield>
-            <subfield code='b'>2002-02-02 02:02:02 +0000</subfield>
+            <subfield code='a'>2018-02-02 02:02:02 UTC</subfield>
+            <subfield code='b'>2002-02-02 02:02:02 UTC</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='ITM'>
-            <subfield code='q'>2017-02-02 02:02:02 +0000</subfield>
+            <subfield code='q'>2017-02-02 02:02:02 UTC</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='HLD'>
-            <subfield code='updated'>2014-02-02 02:02:02 +0000</subfield>
-            <subfield code='created'>2013-02-02 02:02:02 +0000</subfield>
+            <subfield code='updated'>2014-02-02 02:02:02 UTC</subfield>
+            <subfield code='created'>2013-02-02 02:02:02 UTC</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='HLD'>
-            <subfield code='updated'>2013-02-02 02:02:02 +0000</subfield>
-            <subfield code='created'>2014-02-02 02:02:02 +0000</subfield>
+            <subfield code='updated'>2013-02-02 02:02:02 UTC</subfield>
+            <subfield code='created'>2014-02-02 02:02:02 UTC</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='PRT'>
-            <subfield code='created'>2019-02-02 02:02:02 +0000</subfield>
+            <subfield code='created'>2019-02-02 02:02:02 UTC</subfield>
           </datafield>
         </record>
                      " }
 
       it "finds the latest date" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 UTC" ])
       end
     end
 
@@ -1402,7 +1402,7 @@ RSpec.describe Traject::Macros::Custom do
                      " }
       it "uses time now as result" do
         stub_const("ENV", ENV.to_hash.merge("SOLR_DISABLE_UPDATE_DATE_CHECK" => "yes"))
-        expect(subject.map_record(record)).to eq("record_update_date" => [ Time.now.to_s ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ Time.now.utc.to_s ])
       end
     end
 
@@ -1412,11 +1412,8 @@ RSpec.describe Traject::Macros::Custom do
         </record>
                      " }
       it "uses default set" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ "2002-02-02 02:02:02 +0000" ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2002-02-02 02:02:02 UTC" ])
       end
     end
-
-
-
   end
 end

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -1298,7 +1298,7 @@ RSpec.describe Traject::Macros::Custom do
 
     before do
       subject.instance_eval do
-        to_field "record_update_date", extract_update_date
+        to_field "record_update_date", extract_update_date, default("2002-02-02 02:02:02 +0000")
         settings do
           provide "marc_source.type", "xml"
         end
@@ -1395,6 +1395,29 @@ RSpec.describe Traject::Macros::Custom do
         expect(subject.map_record(record)).to eq("record_update_date" => [ date ])
       end
     end
+
+    context "SOLR_DISABLE_UPDATE_DATE_CHECK ENV is set" do
+      let(:record_text) { "
+        <record>
+        </record>
+                     " }
+      it "uses time now as result" do
+        stub_const("ENV", ENV.to_hash.merge("SOLR_DISABLE_UPDATE_DATE_CHECK" => "yes"))
+        expect(subject.map_record(record)).to eq("record_update_date" => [ Time.now.to_s ])
+      end
+    end
+
+    context "Use default date" do
+      let(:record_text) { "
+        <record>
+        </record>
+                     " }
+      it "uses default set" do
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2002-02-02 02:02:02 +0000" ])
+      end
+    end
+
+
 
   end
 end

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -1291,4 +1291,109 @@ RSpec.describe Traject::Macros::Custom do
     end
 
   end
+
+  describe "#extract_update_date" do
+    let (:record) { MARC::XMLReader.new(StringIO.new(record_text)).first }
+
+    before do
+      subject.instance_eval do
+        to_field "record_update_date", extract_update_date
+        settings do
+          provide "marc_source.type", "xml"
+        end
+      end
+    end
+
+    context "Latest is ADMa" do
+      let(:record_text) { "
+        <record>
+          <datafield ind1=' ' ind2=' ' tag='ADM'>
+            <subfield code='a'>2019-02-02 02:02:02</subfield>
+            <subfield code='b'>2002-02-02 02:02:02</subfield>
+          </datafield>
+          <datafield ind1='1' ind2=' ' tag='ITM'>
+            <subfield code='q'>2002-02-02 02:02:02</subfield>
+          </datafield>
+        </record>
+                     " }
+
+      it "finds latest date" do
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
+      end
+    end
+
+    context "Latest is ITMq" do
+      let(:record_text) { "
+        <record>
+          <datafield ind1=' ' ind2=' ' tag='ADM'>
+            <subfield code='a'>2018-02-02 02:02:02</subfield>
+            <subfield code='b'>2002-02-02 02:02:02</subfield>
+          </datafield>
+          <datafield ind1='1' ind2=' ' tag='ITM'>
+            <subfield code='q'>2019-02-02 02:02:02</subfield>
+          </datafield>
+        </record>
+                     " }
+
+      it "finds the latest date" do
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
+      end
+    end
+
+    context "Latest is HLDupdated" do
+      let(:record_text) { "
+        <record>
+          <datafield ind1=' ' ind2=' ' tag='ADM'>
+            <subfield code='a'>2018-02-02 02:02:02</subfield>
+            <subfield code='b'>2002-02-02 02:02:02</subfield>
+          </datafield>
+          <datafield ind1='1' ind2=' ' tag='ITM'>
+            <subfield code='q'>2017-02-02 02:02:02</subfield>
+          </datafield>
+          <datafield ind1='1' ind2=' ' tag='HLD'>
+            <subfield code='updated'>2019-02-02 02:02:02</subfield>
+            <subfield code='created'>2013-02-02 02:02:02</subfield>
+          </datafield>
+          <datafield ind1='1' ind2=' ' tag='HLD'>
+            <subfield code='updated'>2013-02-02 02:02:02</subfield>
+            <subfield code='created'>2014-02-02 02:02:02</subfield>
+          </datafield>
+        </record>
+                     " }
+
+      it "finds the latest date" do
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
+      end
+    end
+
+    context "Latest is PRTcreated" do
+      let(:record_text) { "
+        <record>
+          <datafield ind1=' ' ind2=' ' tag='ADM'>
+            <subfield code='a'>2018-02-02 02:02:02</subfield>
+            <subfield code='b'>2002-02-02 02:02:02</subfield>
+          </datafield>
+          <datafield ind1='1' ind2=' ' tag='ITM'>
+            <subfield code='q'>2017-02-02 02:02:02</subfield>
+          </datafield>
+          <datafield ind1='1' ind2=' ' tag='HLD'>
+            <subfield code='updated'>2014-02-02 02:02:02</subfield>
+            <subfield code='created'>2013-02-02 02:02:02</subfield>
+          </datafield>
+          <datafield ind1='1' ind2=' ' tag='HLD'>
+            <subfield code='updated'>2013-02-02 02:02:02</subfield>
+            <subfield code='created'>2014-02-02 02:02:02</subfield>
+          </datafield>
+          <datafield ind1='1' ind2=' ' tag='PRT'>
+            <subfield code='created'>2019-02-02 02:02:02</subfield>
+          </datafield>
+        </record>
+                     " }
+
+      it "finds the latest date" do
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
+      end
+    end
+
+  end
 end

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -1294,7 +1294,6 @@ RSpec.describe Traject::Macros::Custom do
 
   describe "#extract_update_date" do
     let (:record) { MARC::XMLReader.new(StringIO.new(record_text)).first }
-    let (:date) { Time.parse("2019-02-02 02:02:02").to_s }
 
     before do
       subject.instance_eval do
@@ -1309,17 +1308,17 @@ RSpec.describe Traject::Macros::Custom do
       let(:record_text) { "
         <record>
           <datafield ind1=' ' ind2=' ' tag='ADM'>
-            <subfield code='a'>2019-02-02 02:02:02</subfield>
-            <subfield code='b'>2002-02-02 02:02:02</subfield>
+            <subfield code='a'>2019-02-02 02:02:02 +0000</subfield>
+            <subfield code='b'>2002-02-02 02:02:02 +0000</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='ITM'>
-            <subfield code='q'>2002-02-02 02:02:02</subfield>
+            <subfield code='q'>2002-02-02 02:02:02 +0000</subfield>
           </datafield>
         </record>
                      " }
 
       it "finds latest date" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ date ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
       end
     end
 
@@ -1327,17 +1326,17 @@ RSpec.describe Traject::Macros::Custom do
       let(:record_text) { "
         <record>
           <datafield ind1=' ' ind2=' ' tag='ADM'>
-            <subfield code='a'>2018-02-02 02:02:02</subfield>
-            <subfield code='b'>2002-02-02 02:02:02</subfield>
+            <subfield code='a'>2018-02-02 02:02:02 +0000</subfield>
+            <subfield code='b'>2002-02-02 02:02:02 +0000</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='ITM'>
-            <subfield code='q'>2019-02-02 02:02:02</subfield>
+            <subfield code='q'>2019-02-02 02:02:02 +0000</subfield>
           </datafield>
         </record>
                      " }
 
       it "finds the latest date" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ date ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
       end
     end
 
@@ -1345,25 +1344,25 @@ RSpec.describe Traject::Macros::Custom do
       let(:record_text) { "
         <record>
           <datafield ind1=' ' ind2=' ' tag='ADM'>
-            <subfield code='a'>2018-02-02 02:02:02</subfield>
-            <subfield code='b'>2002-02-02 02:02:02</subfield>
+            <subfield code='a'>2018-02-02 02:02:02 +0000</subfield>
+            <subfield code='b'>2002-02-02 02:02:02 +0000</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='ITM'>
-            <subfield code='q'>2017-02-02 02:02:02</subfield>
+            <subfield code='q'>2017-02-02 02:02:02 +0000</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='HLD'>
-            <subfield code='updated'>2019-02-02 02:02:02</subfield>
-            <subfield code='created'>2013-02-02 02:02:02</subfield>
+            <subfield code='updated'>2019-02-02 02:02:02 +0000</subfield>
+            <subfield code='created'>2013-02-02 02:02:02 +0000</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='HLD'>
-            <subfield code='updated'>2013-02-02 02:02:02</subfield>
-            <subfield code='created'>2014-02-02 02:02:02</subfield>
+            <subfield code='updated'>2013-02-02 02:02:02 +0000</subfield>
+            <subfield code='created'>2014-02-02 02:02:02 +0000</subfield>
           </datafield>
         </record>
                      " }
 
       it "finds the latest date" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ date ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
       end
     end
 
@@ -1371,28 +1370,28 @@ RSpec.describe Traject::Macros::Custom do
       let(:record_text) { "
         <record>
           <datafield ind1=' ' ind2=' ' tag='ADM'>
-            <subfield code='a'>2018-02-02 02:02:02</subfield>
-            <subfield code='b'>2002-02-02 02:02:02</subfield>
+            <subfield code='a'>2018-02-02 02:02:02 +0000</subfield>
+            <subfield code='b'>2002-02-02 02:02:02 +0000</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='ITM'>
-            <subfield code='q'>2017-02-02 02:02:02</subfield>
+            <subfield code='q'>2017-02-02 02:02:02 +0000</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='HLD'>
-            <subfield code='updated'>2014-02-02 02:02:02</subfield>
-            <subfield code='created'>2013-02-02 02:02:02</subfield>
+            <subfield code='updated'>2014-02-02 02:02:02 +0000</subfield>
+            <subfield code='created'>2013-02-02 02:02:02 +0000</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='HLD'>
-            <subfield code='updated'>2013-02-02 02:02:02</subfield>
-            <subfield code='created'>2014-02-02 02:02:02</subfield>
+            <subfield code='updated'>2013-02-02 02:02:02 +0000</subfield>
+            <subfield code='created'>2014-02-02 02:02:02 +0000</subfield>
           </datafield>
           <datafield ind1='1' ind2=' ' tag='PRT'>
-            <subfield code='created'>2019-02-02 02:02:02</subfield>
+            <subfield code='created'>2019-02-02 02:02:02 +0000</subfield>
           </datafield>
         </record>
                      " }
 
       it "finds the latest date" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ date ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
       end
     end
 

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -1296,6 +1296,7 @@ RSpec.describe Traject::Macros::Custom do
     let (:record) { MARC::XMLReader.new(StringIO.new(record_text)).first }
 
     before do
+      stub_const("ENV", ENV.to_hash.merge("SOLR_DISABLE_UPDATE_DATE_CHECK" => "false"))
       subject.instance_eval do
         to_field "record_update_date", extract_update_date, default("2002-02-02 02:02:02 UTC")
         settings do

--- a/spec/lib/traject/traject_indexer_spec.rb
+++ b/spec/lib/traject/traject_indexer_spec.rb
@@ -1294,6 +1294,7 @@ RSpec.describe Traject::Macros::Custom do
 
   describe "#extract_update_date" do
     let (:record) { MARC::XMLReader.new(StringIO.new(record_text)).first }
+    let (:date) { Time.parse("2019-02-02 02:02:02").to_s }
 
     before do
       subject.instance_eval do
@@ -1318,7 +1319,7 @@ RSpec.describe Traject::Macros::Custom do
                      " }
 
       it "finds latest date" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ date ])
       end
     end
 
@@ -1336,7 +1337,7 @@ RSpec.describe Traject::Macros::Custom do
                      " }
 
       it "finds the latest date" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ date ])
       end
     end
 
@@ -1362,7 +1363,7 @@ RSpec.describe Traject::Macros::Custom do
                      " }
 
       it "finds the latest date" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ date ])
       end
     end
 
@@ -1391,7 +1392,7 @@ RSpec.describe Traject::Macros::Custom do
                      " }
 
       it "finds the latest date" do
-        expect(subject.map_record(record)).to eq("record_update_date" => [ "2019-02-02 02:02:02 +0000" ])
+        expect(subject.map_record(record)).to eq("record_update_date" => [ date ])
       end
     end
 


### PR DESCRIPTION
REF BL-875
REF #1113 
The `extract_update_date` method finds the latest date by looking at all
dates in ADM, ITM, HLD and PRT record fields.