### PR TITLE
BL-761 EZ Borrow Link

### DIFF
--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -6,4 +6,15 @@ module RequestHelper
   def request_modal(mms_id, pickup_locations, request_level)
     link_to(t("requests.request_button"), "#", id: "request-btn-#{mms_id}", class: "btn btn-sm btn-primary request-button search-results-request-btn", data: { "blacklight-modal": "trigger", "action": "availability#modal", "target": "availability.href" })
   end
+
+  def ez_borrow_link_with_updated_query(url)
+    uri = URI.parse(url)
+    params = CGI.parse(uri.query)
+    new_params = params.select { |key, value| ["group", "LS", "dest", "PI", "RK", "rft.title"].include? key }
+
+    URI::HTTPS.build(
+      host: uri.host,
+      path: uri.path,
+      query: URI.encode_www_form(new_params)).to_s
+  end
 end

--- a/app/views/almaws/_resource_sharing_broker_allowed.html.erb
+++ b/app/views/almaws/_resource_sharing_broker_allowed.html.erb
@@ -9,6 +9,6 @@
 <div id="collapseFour-<%= @mms_id %>" class="collapse <%= 'show' if only_one_option_allowed(request_options)%>">
   <div class="card-body">
     <p><%= t("requests.resource_sharing_broker_text") %></p>
-      <%= link_to(t("requests.resource_sharing_broker_link"), request_options.ez_borrow_link, id: "ez-borrow-button", class: "btn btn-primary request-button search-results-request-btn text-white", target: "_blank") %>
+      <%= link_to(t("requests.resource_sharing_broker_link"), ez_borrow_link_with_updated_query(request_options.ez_borrow_link), id: "ez-borrow-button", class: "btn btn-primary request-button search-results-request-btn text-white", target: "_blank") %>
   </div>
 </div>

--- a/spec/helpers/almaws_helper_spec.rb
+++ b/spec/helpers/almaws_helper_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe AlmawsHelper, type: :helper do
       { request_option:
         [{
         "type" => { "value" => "RS_BROKER", "desc" => "Resource Sharing Broker" },
-        "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+        "request_url" => "https://e-zborrow.relais-host.com/user/login.html?group=patron&LS=TEMPLE&dest=discovery&PI=915602377&RK=915602377&rft.stitle=A+thin+bright+line+%2F&rft.pub=The+University+of+Wisconsin+Press%2C&rft.place=Madison%2C+Wisconsin+%3A&rft.isbn=0299309304&rft.btitle=A+thin+bright+line+%2F&rft.genre=book&rft.normalized_isbn=9780299309305&rft.oclcnum=946770187&rft.mms_id=991028550499703811&rft.object_type=BOOK&rft.publisher=The+University+of+Wisconsin+Press%2C&rft.au=Bledsoe%2C+Lucy+Jane%2C+author.&rft.pubdate=%5B2016%5D&rft.title=A+thin+bright+line+%2F"
         }]
       }.to_json
     }
@@ -137,7 +137,7 @@ RSpec.describe AlmawsHelper, type: :helper do
         { request_option:
           [{
           "type" => { "value" => "BOOKING", "desc" => "Booking" },
-          "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+          "request_url" => "https://e-zborrow.relais-host.com/user/login.html?group=patron&LS=TEMPLE&dest=discovery&PI=915602377&RK=915602377&rft.stitle=A+thin+bright+line+%2F&rft.pub=The+University+of+Wisconsin+Press%2C&rft.place=Madison%2C+Wisconsin+%3A&rft.isbn=0299309304&rft.btitle=A+thin+bright+line+%2F&rft.genre=book&rft.normalized_isbn=9780299309305&rft.oclcnum=946770187&rft.mms_id=991028550499703811&rft.object_type=BOOK&rft.publisher=The+University+of+Wisconsin+Press%2C&rft.au=Bledsoe%2C+Lucy+Jane%2C+author.&rft.pubdate=%5B2016%5D&rft.title=A+thin+bright+line+%2F"
           }]
         }.to_json
       }
@@ -153,7 +153,7 @@ RSpec.describe AlmawsHelper, type: :helper do
       { request_option:
         [{
         "type" => { "value" => "RS_BROKER", "desc" => "Resource Sharing Broker" },
-        "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+        "request_url" => "https://e-zborrow.relais-host.com/user/login.html?group=patron&LS=TEMPLE&dest=discovery&PI=915602377&RK=915602377&rft.stitle=A+thin+bright+line+%2F&rft.pub=The+University+of+Wisconsin+Press%2C&rft.place=Madison%2C+Wisconsin+%3A&rft.isbn=0299309304&rft.btitle=A+thin+bright+line+%2F&rft.genre=book&rft.normalized_isbn=9780299309305&rft.oclcnum=946770187&rft.mms_id=991028550499703811&rft.object_type=BOOK&rft.publisher=The+University+of+Wisconsin+Press%2C&rft.au=Bledsoe%2C+Lucy+Jane%2C+author.&rft.pubdate=%5B2016%5D&rft.title=A+thin+bright+line+%2F"
         }]
       }.to_json
     }

--- a/spec/helpers/request_helper_spec.rb
+++ b/spec/helpers/request_helper_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RequestHelper, type: :helper do
+  describe "#ez_borrow_link_with_updated_query(url)" do
+    let(:url) { "https://e-zborrow.relais-host.com/user/login.html?group=patron&LS=TEMPLE&dest=discovery&PI=12345&RK=12345&rft.stitle=A+thin+bright+line+%2F&rft.pub=The+University+of+Wisconsin+Press%2C&rft.place=Madison%2C+Wisconsin+%3A&rft.isbn=0299309304&rft.btitle=A+thin+bright+line+%2F&rft.genre=book&rft.normalized_isbn=9780299309305&rft.oclcnum=946770187&rft.mms_id=991028550499703811&rft.object_type=BOOK&rft.publisher=The+University+of+Wisconsin+Press%2C&rft.au=Bledsoe%2C+Lucy+Jane%2C+author.&rft.pubdate=%5B2016%5D&rft.title=A+thin+bright+line+%2F" }
+
+    it "has correct link to resource" do
+      expect(ez_borrow_link_with_updated_query(url)).to eq("https://e-zborrow.relais-host.com/user/login.html?group=patron&LS=TEMPLE&dest=discovery&PI=12345&RK=12345&rft.title=A+thin+bright+line+%2F")
+    end
+  end
+end


### PR DESCRIPTION
- Currently the ez borrow link is too strict and is not giving patrons the matches for the titles they would like to request
- Strips out unwanted query params in the url
- Adds specs for new method
- Updates old specs to have valid urls
- URI.encode_www_form had to be added in for authentication to work