### PR TITLE
[BL-876] Add back article fields lost in api upgrade.

### DIFF
--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -77,7 +77,7 @@ class PrimoCentralController < CatalogController
     config.add_show_field :issn, label: "ISSN", refwork_tag: :SN
     config.add_show_field :lccn, label: "LCCN"
     config.add_show_field :doi, label: "DOI"
-    config.add_show_field :languageId, label: "Language", multi: true, helper_method: :doc_translate_language_code, refwork_tag: :LA
+    config.add_show_field :language, label: "Language", multi: true, helper_method: :doc_translate_language_code, refwork_tag: :LA
 
     # Sort fields
     config.add_sort_field :rank, label: "relevance"

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -226,10 +226,8 @@ module CatalogHelper
 
   def get_search_params(field, query)
     case field
-    when "title_uniform_display", "title_addl_display"
+    when "title_uniform_display", "title_addl_display", "relation"
       { search_field: "title", q: query }
-    when "relation"
-      { search_field: "title", q: query["relatedTitle"] }
     else
       { search_field: field, q: query }
     end

--- a/app/helpers/primo_central_helper.rb
+++ b/app/helpers/primo_central_helper.rb
@@ -18,7 +18,7 @@ module PrimoCentralHelper
   end
 
   def doc_translate_language_code(presenter)
-    codes = presenter[:document][:languageId] || []
+    codes = presenter[:document][:language] || []
     codes.map { |c| translate_code(c, "language") }
   end
 

--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -39,15 +39,26 @@ module Blacklight::PrimoCentral::Document
     doc["format"] = [format]
 
     doc["title"] ||= doc.dig("pnx", "display", "title")&.first&.truncate(300)
+    doc["contributor"] ||= doc.dig("pnx", "display", "contributor")&.first&.split(";")
+    doc["publisher"] ||= doc.dig("pnx", "display", "publisher") ||
+      doc.dig("pnx", "addata", "pub")
+    doc["relation"] ||= doc.dig("pnx", "display", "relation")
     doc["link"] = @url
     doc["link_label"] = link_label(doc)
     doc["isbn"] ||= doc.dig("pnx", "search", "isbn") || isbn
     doc["issn"] ||= doc.dig("pnx", "search", "issn") || issn
-    doc["lccn"] ||= lccn
+    doc["lccn"] ||= doc.dig("pnx", "addata", "lccn") || lccn
 
     doc["isPartOf"] ||= doc.dig("pnx", "display", "ispartof")&.first
     doc["creator"] ||= doc.dig("pnx", "search", "creatorcontrib") || []
+
     doc["date"] ||= doc.dig("pnx", "search", "creationdate") || []
+
+    doc["language"] = doc.dig("pnx", "search", "language") ||
+      doc.dig("pnx", "display", "language") ||
+      ([ doc["lang3"] ] if doc["lang3"])
+
+    doc["doi"] = doc.dig("pnx", "addata", "doi")
 
     solr_to_primo_keys.each do |solr_key, primo_key|
       doc[solr_key] = doc[primo_key] || FIELD_DEFAULT_VALUES[primo_key]

--- a/spec/models/primo_central_document_spec.rb
+++ b/spec/models/primo_central_document_spec.rb
@@ -26,6 +26,144 @@ RSpec.describe PrimoCentralDocument, type: :model do
     end
   end
 
+  context "with pnx description " do
+    let(:doc) { { "pnx" => { "search" => { "description" => [ "foo" ] } } } }
+
+    it "maps the description" do
+      expect(subject["description"]).to eq("foo")
+    end
+  end
+
+  context "with pnx subject" do
+    let(:doc) { { "pnx" => { "search" => { "subject" => [ "foo", "bar"] } } } }
+
+    it "maps the subject" do
+      expect(subject["subject"]).to eq([ "foo", "bar" ])
+    end
+  end
+
+  context "with pnx type" do
+    let(:doc) { { "pnx" => { "display" => { "type" => [ "foo" ] } } } }
+
+    it "maps the type and format" do
+      expect(subject["type"]).to eq([ "foo" ])
+      expect(subject["format"]).to eq([ "foo" ])
+    end
+  end
+
+  context "with pnx title" do
+    let(:doc) { { "pnx" => { "display" => { "title" => [ "foo" ] } } } }
+
+    it "maps the title" do
+      expect(subject["title"]).to eq("foo")
+    end
+  end
+
+  context "with pnx contributor" do
+    let(:doc) { { "pnx" => { "display" => { "contributor" => [ "foo;bar" ] } } } }
+
+    it "maps the contributor" do
+      expect(subject["contributor"]).to eq(["foo", "bar"])
+    end
+  end
+
+  context "with pnx dislpay publisher" do
+    let(:doc) { { "pnx" => { "display" => { "publisher" => [ "foo" ] } } } }
+    it "maps the publisher" do
+      expect(subject["publisher"]).to eq(["foo"])
+    end
+  end
+
+  context "with pnx addata pub" do
+    let(:doc) { { "pnx" => { "addata" => { "pub" => [ "foo" ] } } } }
+    it "maps the publisher" do
+      expect(subject["publisher"]).to eq(["foo"])
+    end
+  end
+
+  context "with pnx display relation" do
+    let(:doc) { { "pnx" => { "display" => { "relation" => [ "foo" ] } } } }
+    it "maps the relation" do
+      expect(subject["relation"]).to eq(["foo"])
+    end
+  end
+
+  context "with pnx search isbn" do
+    let(:doc) { { "pnx" => { "search" => { "isbn" => [ "foo" ] } } } }
+    it "maps isbn" do
+      expect(subject["isbn"]).to eq(["foo"])
+    end
+  end
+
+  context "with pnx addata lccn" do
+    let(:doc) { { "pnx" => { "addata" => { "lccn" => [ "foo" ] } } } }
+    it "maps lccn" do
+      expect(subject["lccn"]).to eq(["foo"])
+    end
+  end
+
+  context "with pnx search issn" do
+    let(:doc) { { "pnx" => { "search" => { "issn" => [ "foo" ] } } } }
+    it "maps issn" do
+      expect(subject["issn"]).to eq(["foo"])
+    end
+  end
+
+  context "with pnx display ispartof" do
+    let(:doc) { { "pnx" => { "display" => { "ispartof" => [ "foo" ] } } } }
+    it "maps isPartOf" do
+      expect(subject["isPartOf"]).to eq("foo")
+    end
+  end
+
+  context "with pnx search creatorcontrib" do
+    let(:doc) { { "pnx" => { "search" => { "creatorcontrib" => [ "foo" ] } } } }
+
+    it "maps creator" do
+      expect(subject["creator"]).to eq(["foo"])
+    end
+  end
+
+  context "with pnx search creationdate" do
+    let(:doc) { { "pnx" => { "search" => { "creationdate" => [ "foo" ] } } } }
+
+    it "maps date" do
+      expect(subject["date"]).to eq(["foo"])
+    end
+  end
+
+  context "with pnx addata doi" do
+    let(:doc) { { "pnx" => { "addata" => { "doi" => [ "foo" ] } } } }
+
+    it "maps doi" do
+      expect(subject["doi"]).to eq(["foo"])
+    end
+  end
+
+  context "with pnx search language " do
+    let(:doc) { { "pnx" => { "search" => { "language" => [ "foo" ] } } } }
+
+    it "maps language" do
+      expect(subject["language"]).to eq(["foo"])
+    end
+  end
+
+  context "with pnx display language " do
+    let(:doc) { { "pnx" => { "display" => { "language" => [ "foo" ] } } } }
+
+    it "maps language" do
+      expect(subject["language"]).to eq(["foo"])
+    end
+  end
+
+  context "with lang3" do
+    let(:doc) { { "lang3" => "foo" } }
+
+    it "maps language" do
+      expect(subject["language"]).to eq(["foo"])
+    end
+  end
+
   describe "#export_as_refworks" do
     context "simple document" do
       it "exports a refworks tagged formatted string" do


### PR DESCRIPTION
* Adds back fields lost when upgrading to new primo pnx API.
* Adds some extra unit tests for the mappings.