### PR TITLE
[BL-885] Redirect books urls for record pages and search results.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,15 @@ Rails.application.routes.draw do
   mount BlacklightAdvancedSearch::Engine => "/"
   mount BentoSearch::Engine => "/bento"
 
+  get "books/:id", to: redirect { |_, req| req.url.sub("books", "catalog") }
+  get "books", to: redirect { |_, req|
+    redirect_path = req.url.sub("books", "catalog")
+
+    redirect_path += "&f[format][]=Book" unless req.params.dig("f", "format")&.include?("Book")
+    redirect_path
+  }
+
+
   # resource and resources
   resource :catalog, only: [:index], as: "catalog", path: "/catalog", controller: "catalog" do
     concerns :searchable

--- a/spec/routing/books_redirect_spec.rb
+++ b/spec/routing/books_redirect_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "books redirect", type: :request do
+
+  it "should redirect /books/:id to /catalog/:id" do
+    get "/books/foo"
+    expect(response).to redirect_to("http://www.example.com/catalog/foo")
+  end
+
+  it "should redirect params as well" do
+    get "/books/foo?format=json"
+    expect(response).to redirect_to("http://www.example.com/catalog/foo?format=json")
+  end
+
+  it "should only substitute first occurance of books" do
+    get "/books/foo?format=json&type=books"
+    expect(response).to redirect_to("http://www.example.com/catalog/foo?format=json&type=books")
+  end
+
+  it "should add books filter if a books search url" do
+    get "/books?q=hello"
+    expect(response).to redirect_to("http://www.example.com/catalog?q=hello&f[format][]=Book")
+  end
+
+  it "should only add books filter once to URL" do
+    get "/books?q=hello&f[format][]=Book"
+    expect(response).to redirect_to("http://www.example.com/catalog?q=hello&f[format][]=Book")
+  end
+
+end


### PR DESCRIPTION
## Description
 Related to changes made in
 https://tulibdev.atlassian.net/browse/BL-861.

 With the removal of the "Books" nav option, we need to redirect URLs
 from /books

 * For individual record pages, redirect from /books/ID to /catalog/ID
 * For search results, redirect from /books to /catalog, with resource
 type facet for books added