### PR TITLE
[BL-809] Fix database title missing from results.

### DIFF
--- a/lib/traject/databases_az_indexer_config.rb
+++ b/lib/traject/databases_az_indexer_config.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$:.unshift "./lib" if !$:.include?["./lib"]
+$:.unshift "./lib" if !$:.include?("./lib")
 require "traject_plus"
 require "traject_plus/json_reader.rb"
 require "traject_plus/macros"

--- a/lib/traject/databases_az_indexer_config.rb
+++ b/lib/traject/databases_az_indexer_config.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
+$:.unshift "./lib" if !$:.include?["./lib"]
 require "traject_plus"
 require "traject_plus/json_reader.rb"
 require "traject_plus/macros"
 require "traject_plus/macros/json"
+require "traject/macros/custom"
 
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
+extend Traject::Macros::Custom
 
 solr_config = YAML.load_file("config/blacklight.yml")[(ENV["RAILS_ENV"] || "development")]
 
@@ -42,6 +45,7 @@ to_field "title_t", extract_json("$.name")
 to_field "title_sort", extract_json("$.name")
 to_field "alt_names_t", extract_json("$.alt_names")
 to_field "title_statement_display", extract_json("$.name")
+to_field "title_truncated_display", extract_json("$.name"), &truncate(300)
 to_field "az_vendor_id_display", extract_json("$.az_vendor_id")
 to_field "az_vendor_name_display", extract_json("$.az_vendor_name")
 

--- a/spec/features/databases_spec.rb
+++ b/spec/features/databases_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "yaml"
+
+RSpec.feature "Databases AZ" do
+  feature "Search all fields" do
+    scenario "Search Title" do
+      visit "/databases"
+      within("div.input-group") do
+        fill_in "q", with: "Mental Measurements Yearbook"
+        click_button
+      end
+
+      expect(page).to have_text "Mental Measurements Yearbook with Tests in Print"
+    end
+  end
+end


### PR DESCRIPTION
We recently removed automatically adding title_truncated_display to the
solrdocument instance.  Because databases inherits from the catalog
controller and also uses the solr document model, it was automatically
configured to use title_statement_display as the title field for
results.

There are two ways to fix this issue.
* Add a databases specific title field (like title_display)
* Or, make sure we add "title_truncated_display" to databases.

I when with the latter option because there is another related issue
that requires we truncate the database titles in the results page.