### PR TITLE
Unsuppress asrs_test location 

### DIFF
--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -83,7 +83,7 @@ module AvailabilityHelper
 
   def unwanted_library_locations(item)
     location = item.fetch("current_location", "")
-    !!location.match(/techserv|UNASSIGNED|intref|ASRS_TEST/) || library(item) == "EMPTY"
+    !!location.match(/techserv|UNASSIGNED|intref/) || library(item) == "EMPTY"
   end
 
   def library(item)


### PR DESCRIPTION
In order to test that requests are working properly on Libqa, we need to unsuppress this location