### PR TITLE
[BL-316] Disable spelling suggestions.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -202,7 +202,7 @@ class CatalogController < ApplicationController
         subject_addl_t^10
       ].join(" "),
       facet: "true",
-      spellcheck: "true",
+      spellcheck: "false",
       "spellcheck.extendedResults": "true",
       "spellcheck.collate": "true",
       "spellcheck.collateParam.q.op": "AND",


### PR DESCRIPTION
Blacklight/Solr spelling suggestions have too many issues to be useful.