### PR TITLE
[Bl-877] Update alma and timeout.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GIT
 
 GIT
   remote: https://github.com/tulibraries/alma_rb.git
-  revision: b38c64cde562b4784690e45df8a241389d363364
+  revision: c910d2d6dba7e2e130c0bbfcf24a074709b00041
   branch: master
   specs:
     alma (0.2.8)

--- a/config/initializers/alma.rb
+++ b/config/initializers/alma.rb
@@ -4,6 +4,7 @@ Alma.configure do |config|
   # You have to set te apikey
   config.apikey = Rails.configuration.alma[:apikey]
   config.enable_loggable = true
+  config.timeout = Rails.configuration.alma[:timeout] || 10
 end
 ENV["ALMA_API_KEY"] ||= Rails.configuration.alma[:apikey]
 ENV["ALMA_DELIVERY_DOMAIN"] ||= Rails.configuration.alma[:delivery_domain]

--- a/config/initializers/primo.rb
+++ b/config/initializers/primo.rb
@@ -6,4 +6,5 @@ Primo.configure do |config|
   config.vid     = "TULI"
   config.scope   = "pci_scope"
   config.enable_loggable = true
+  config.timeout = Rails.configuration.bento[:primo][:timeout] || 10
 end


### PR DESCRIPTION
* Updates alma to use new version that limits  offset to < 500.
* Updates timeout to 10 seconds for primo and alma api (because we
noticed that locally we were timing out when it was set to default of
5 seconds).