### PR TITLE
[BL-399] Fix database show page broken after BL-7 upgrade. (#1047)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -216,4 +216,10 @@ module ApplicationHelper
       format = "Chicago Notes & Bibliography (15th)/Turabian (6th)"
     end
   end
+
+  def presenter_field_value(presenter, field)
+    if blacklight_config.show_fields[field]
+      presenter.field_value(blacklight_config.show_fields[field])
+    end
+  end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -98,7 +98,7 @@ module CatalogHelper
   end
 
   def render_online_availability(doc_presenter)
-    field = blacklight_config.index_fields["electronic_resource_display"]
+    field = blacklight_config.show_fields["electronic_resource_display"]
     online_resources = [doc_presenter.field_value(field)]
       .select { |r| !r.empty? }.compact
 

--- a/spec/features/indices_spec.rb
+++ b/spec/features/indices_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature "Indices" do
         expect(page).to have_text item["title"]
       end
 
-      within(".documentHeader") do
+      within first(".documentHeader") do
         click_link item["title"]
         expect(current_url).to eq item_url
       end


### PR DESCRIPTION
A change in the way BL-7 adds fields to show page is causing a nil error
to now break databases show pages.

This commit adds a helper method to guard against nil values in this
context and fixes the issue with the databases show page.