### PR TITLE
Remove books redirect.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,15 +20,6 @@ Rails.application.routes.draw do
   mount BlacklightAdvancedSearch::Engine => "/"
   mount BentoSearch::Engine => "/bento"
 
-  get "books/:id", to: redirect { |_, req| req.url.sub("books", "catalog") }
-  get "books", to: redirect { |_, req|
-    redirect_path = req.url.sub("books", "catalog")
-
-    redirect_path += "&f[format][]=Book" unless req.params.dig("f", "format")&.include?("Book")
-    redirect_path
-  }
-
-
   # resource and resources
   resource :catalog, only: [:index], as: "catalog", path: "/catalog", controller: "catalog" do
     concerns :searchable


### PR DESCRIPTION
The books redirect is only required once we deploy new navbar changes
where Everything link becomes "Books & Media".