### PR TITLE
Increase alma api call timeouts.

### DIFF
--- a/config/initializers/alma.rb
+++ b/config/initializers/alma.rb
@@ -4,7 +4,7 @@ Alma.configure do |config|
   # You have to set te apikey
   config.apikey = Rails.configuration.alma[:apikey]
   config.enable_loggable = true
-  config.timeout = Rails.configuration.alma[:timeout] || 10
+  config.timeout = Rails.configuration.alma[:timeout] || 30
 end
 ENV["ALMA_API_KEY"] ||= Rails.configuration.alma[:apikey]
 ENV["ALMA_DELIVERY_DOMAIN"] ||= Rails.configuration.alma[:delivery_domain]


### PR DESCRIPTION
user_loans api is timing out when timeout is set to 0.

This is a temp quick fix.  We should update timeout to be overridable at
call time and use alma user_loans specific override.