### PR TITLE
BL-900 Hide button

### DIFF
--- a/app/javascript/packs/controllers/explanation_controller.js
+++ b/app/javascript/packs/controllers/explanation_controller.js
@@ -27,7 +27,7 @@ export default class extends Controller {
     let reg = new RegExp("(?:(?:^|.*;\s*)" + namespace + "Once\s*\=\s*([^;]*).*$)|^.*$")
     if (document.cookie.replace(reg, "$1") !== "true") {
         $(this[namespace + "Target"]).remove();
-        document.cookie = namespace + "Once=true; expires=Fri, 31 Dec 9999 23:59:59 GMT;";
+        document.cookie = namespace + "Once=true; expires=Fri, 31 Dec 9999 23:59:59 GMT;";        
       }
     }
   }

--- a/app/javascript/packs/controllers/explanation_controller.js
+++ b/app/javascript/packs/controllers/explanation_controller.js
@@ -27,7 +27,7 @@ export default class extends Controller {
     let reg = new RegExp("(?:(?:^|.*;\s*)" + namespace + "Once\s*\=\s*([^;]*).*$)|^.*$")
     if (document.cookie.replace(reg, "$1") !== "true") {
         $(this[namespace + "Target"]).remove();
-        document.cookie = namespace + "Once=true; expires=Fri, 31 Dec 9999 23:59:59 GMT;";        
+        document.cookie = namespace + "Once=true; expires=Fri, 31 Dec 9999 23:59:59 GMT;";
       }
     }
   }

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,10 +1,9 @@
 <% if !cookies.fetch("#{controller_name}Once", false) %>
-<div class="row bg-background-grey rounded">
-  <div class="explantion-wrapper col-sm-12 col-lg-10 mt-4 pl-5 pr-5 mx-auto" data-target="<%= "explanation.#{controller_name}" %>" data-controller="explanation">
+<div class="row bg-background-grey rounded explanation-div" data-controller="explanation" data-target="<%= "explanation.#{controller_name}" %>">
+  <div class="explantion-wrapper col-sm-12 col-lg-10 mt-4 pl-5 pr-5 mx-auto" >
     <p class="explanation"><%= explanation_translations(controller_name) %></p>
   </div>
     <button class="btn btn-link explantion-btn col-sm-12 col-lg-2 pt-0" data-action="<%= "explanation##{controller_name}" %>">Hide</button>
-
 </div>
 <% end %>
 


### PR DESCRIPTION
- The hide button for the explanation text on search results pages is not currently working.
- Moves the data-target and controller up a level so that they include the button and text div