### PR TITLE
BL-889 Subjects in advanced search

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -580,6 +580,7 @@
    <copyField source="title_added_entry_t" dest="title_added_entry_unstem_search"/>
    <copyField source="title_series_t" dest="title_series_unstem_search"/>
    <copyField source="creator_t" dest="creator_unstem_search"/>
+   <copyField source="subject_display" dest="subject_unstem_search"/>
    <!-- <copyField source="author_addl_t" dest="author_addl_unstem_search"/> -->
    <copyField source="subject_t" dest="subject_unstem_search"/>
    <copyField source="subject_addl_t" dest="subject_addl_unstem_search"/>


### PR DESCRIPTION
- Currently, searching for a full subject line such as Clothing and dress -
Greece - History gives no results
- Adds a copyfield for subject_display to the list of unstemmed fields in the solr schema to make them searchable
- Requires re-index