### PR TITLE
BL-902 More move updates

### DIFF
--- a/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
+++ b/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
@@ -19,9 +19,10 @@ var BlacklightAlma = function (options) {
 
 
  availabilityButton = function(id, holding) {
+   var hiddenLibraries = ["Paley Library", "ASRS", "Charles Library"] // Temporary change during the move
    var availButton = $("button[data-availability-ids='" + id + "']");
    if (!$(availButton).hasClass("btn-success")) {
-     if(holding['availability'] == 'available') {
+     if(holding['availability'] == 'available' && hiddenLibraries.includes(holding['library']) == false) {
        $(availButton).html("<span class='avail-label available'>Available</span>");
        $(availButton).removeClass("btn-default");
        $(availButton).addClass("btn-success collapsed collapse-button available");
@@ -61,7 +62,8 @@ var BlacklightAlma = function (options) {
    var availability = holding['availability'];
 
    if (library != "EMPTY") {
-     if (availability == "available") {
+     var hiddenLibraries = ["Paley Library", "ASRS", "Charles Library"] // Temporary change during the move
+     if (availability == "available" && hiddenLibraries.includes(holding['library']) == false)  {
        availItem = {};
        Object.assign(availItem, {library, availability})
        return availItem;

--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -112,7 +112,14 @@ module CobAlma
     end
 
     def self.descriptions(items_list)
-      descriptions = items_list.all.map(&:description)
+      # Temporary refactor to filter out descriptions in ASRS and MAIN during the move
+      libraries = items_list.all.select { |item| item }
+        .select { |i| i if i.library != "ASRS" }
+        .select { |i| i if i.library != "MAIN" }
+        .compact
+
+      descriptions = libraries.map(&:description)
+
       if descriptions.any?
         descriptions.each do |desc|
           desc

--- a/config/libraries.yml
+++ b/config/libraries.yml
@@ -17,7 +17,7 @@ default: &default
   SCRC: "Special Collections Research Center"
   EMPTY: "Other"
   KIOSK: "Laptop Kiosks"
-  ASRS: "ASRS"
+  ASRS: "Charles Library"
 
 test:
   <<: *default

--- a/config/locations.yml
+++ b/config/locations.yml
@@ -172,7 +172,7 @@ default: &default
   KIOSK:
     kiosk: Laptop Kiosks
   ASRS:
-    ASRS: Stacks
+    ASRS: BookBot
     ASRS_TEST: ASRS_TEST
     UNASSIGNED: Location information not available
 

--- a/config/translation_maps/libraries_map.properties
+++ b/config/translation_maps/libraries_map.properties
@@ -16,4 +16,4 @@ ROME = Rome Campus Library
 SCRC = Special Collections Research Center
 EMPTY = Other
 KIOSK = Laptop Kiosks
-ASRS = ASRS
+ASRS = Charles Library


### PR DESCRIPTION
- Change ASRS mappings for library and location
- Remove "Available at" text for items at ASRS or MAIN
- Change availability button to reflect unavailable for items on ly at ASRS or MAIN
- Refactor descriptions so that they do not include descriptions at ASRS or MAIN
- Requires reindex for the mapping changes