### PR TITLE
[BL-830] Do not track bookmarks.

### DIFF
--- a/app/controllers/concerns/bookmarks_config.rb
+++ b/app/controllers/concerns/bookmarks_config.rb
@@ -16,6 +16,9 @@ module BookmarksConfig
       config.add_show_tools_partial(:citation)
       # Need to add citation for side effect only.
       config.show.document_actions.delete(:citation)
+
+      # Tracking bookmarks causes routing error (BL-903)
+      config.track_search_session = false
     end
   end
 end


### PR DESCRIPTION
Fixes error:

```
 Unable to find track_bookmarks_path route helper. Did you add `concerns
 :searchable` routing mixin to your `config/routes.rb`?
 ```