### PR TITLE
BL-877 Availability error message

### DIFF
--- a/app/assets/stylesheets/partials/_availability.scss
+++ b/app/assets/stylesheets/partials/_availability.scss
@@ -7,6 +7,10 @@
   }
 }
 
+#availability-alert {
+  padding: 0.5rem;
+}
+
 /* === RECORD PAGE AVAILABILITY === */
 #availability-heading {
   color: $red;

--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -69,6 +69,11 @@ module AvailabilityHelper
       .group_by { |item| library(item) }
   end
 
+  def availability_alert(document)
+    empty_availability = document["items_json_display"].map { |item|
+      item["availability"].blank?
+    }.any?
+  end
 
   def description(item)
     item["description"] ? "Description: #{item['description']}" : ""

--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -70,7 +70,7 @@ module AvailabilityHelper
   end
 
   def availability_alert(document)
-    empty_availability = document["items_json_display"].map { |item|
+    document["items_json_display"].map { |item|
       item["availability"].blank?
     }.any?
   end

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -3,7 +3,7 @@
 <%# This template has access to @items returned by the alma api, so it has slightly different information that the other template %>
 <%# Any changes related to the alma api should only be made here %>
 
-<% if availability_alert(@document) == true %>
+<% if availability_alert(@document) %>
   <div id="availability-alert" class="alert alert-info mb-0" role="alert">
       <p>  <%= t("blacklight.errors.availability_alert_html", href: link_to(t("blacklight.errors.not_found_href"), t("blacklight.errors.not_found_link"))) %></p>
   </div>

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -3,6 +3,12 @@
 <%# This template has access to @items returned by the alma api, so it has slightly different information that the other template %>
 <%# Any changes related to the alma api should only be made here %>
 
+<% if availability_alert(@document) == true %>
+  <div id="availability-alert" class="alert alert-info mb-0" role="alert">
+      <p>  <%= t("blacklight.errors.availability_alert_html", href: link_to(t("blacklight.errors.not_found_href"), t("blacklight.errors.not_found_link"))) %></p>
+  </div>
+<% end %>
+
 <div id="request-url-data-<%= @mms_id %>" class="hidden" data-requests-url="<%= request_options_path(@mms_id, @pickup_locations, @request_level) %>"></div>
 <% unless @document_availability.all?(&:empty?) %>
   <% sort_order_for_holdings(@document_availability).each do |key, items| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
       not_found_html: "The address may have been mistyped, or the page or record that was here may have been moved, suppressed, or withdrawn. For help, please %{href} or start over with a new search."
       not_found_href: "Ask a Librarian"
       not_found_link: "https://library.temple.edu/asktulibraries"
+      availability_alert_html: "Some availability information can not be loaded. Please contact your library's Circulation Desk for more information or %{href}."
 
     range_limit:
       submit_limit: "Apply"

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -899,4 +899,44 @@ RSpec.describe AvailabilityHelper, type: :helper do
       end
     end
   end
+
+  describe "#availability_alert(document)" do
+    context "document availability contains nil values" do
+      let(:document) { { "items_json_display" =>
+        [{ "item_pid" => "23237957740003811",
+        "item_policy" => "5",
+        "permanent_library" => "AMBLER",
+        "permanent_location" => "media",
+        "current_library" => "AMBLER",
+        "current_location" => "media",
+        "call_number" => "DVD 13 A165",
+        "availability" => nil,
+        "holding_id" => "22237957750003811" }]
+          }
+        }
+
+      it "returns true"  do
+        expect(availability_alert(document)).to eq true
+      end
+    end
+
+    context "document availability contains nil values" do
+      let(:document) { { "items_json_display" =>
+        [{ "item_pid" => "23237957740003811",
+        "item_policy" => "5",
+        "permanent_library" => "AMBLER",
+        "permanent_location" => "media",
+        "current_library" => "AMBLER",
+        "current_location" => "media",
+        "call_number" => "DVD 13 A165",
+        "availability" => "<span class=\"check\"></span>Library Use Only",
+        "holding_id" => "22237957750003811" }]
+          }
+        }
+
+      it "returns true"  do
+        expect(availability_alert(document)).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Currently some availability statuses are empty, which may cause confusion for the patron.
- Adds an alert message to the top of the availability panel when an availability status is left empty.