### PR TITLE
BL-890 Add material type to hold requests

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -88,6 +88,7 @@ class AlmawsController < CatalogController
     description: params[:hold_description],
     pickup_location_library: params[:hold_pickup_location],
     pickup_location_type: "LIBRARY",
+    material_type: { value: params[:material_type] },
     request_type: "HOLD",
     last_interest_date: date,
     comment: params[:hold_comment]
@@ -113,6 +114,7 @@ class AlmawsController < CatalogController
     description: params[:asrs_description],
     pickup_location_library: params[:asrs_pickup_location],
     pickup_location_type: "LIBRARY",
+    material_type: { value: params[:material_type] },
     request_type: "HOLD",
     last_interest_date: date,
     comment: params[:asrs_comment]
@@ -159,7 +161,7 @@ class AlmawsController < CatalogController
     user_id: current_user.uid,
     pickup_location_library: params[:booking_pickup_location],
     pickup_location_type: "LIBRARY",
-    material_type: params[:material_type],
+    material_type: { value: params[:material_type] },
     request_type: "BOOKING",
     booking_start_date: start_date,
     booking_end_date: end_date,

--- a/app/views/almaws/_asrs_request_form.html.erb
+++ b/app/views/almaws/_asrs_request_form.html.erb
@@ -45,6 +45,13 @@
 
     <% end %>
 
+    <div class="row">
+      <div class="col-sm-4 col-md-6 hold-form form-group">
+        <%= label("", :material_type, t("requests.form.material_type")) %>
+        <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
+      </div>
+    </div>
+
     <div class="row hold-form">
       <div class="col-sm-5 col-md-6 form-group">
         <%= form.label(:asrs_last_interest_date, t("requests.form.not_needed_after")) %>

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -10,6 +10,7 @@
         <%= select("", :booking_pickup_location, @booking_location.collect { |lib| [ lib.last, lib.first ] }, {include_blank: true, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
       </div>
     </div>
+
     <div class="row">
       <div class="col-sm-4 col-md-6 hold-form form-group">
         <%= label("", :material_type, t("requests.form.material_type")) %>

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -25,7 +25,6 @@
       </div>
     <% end %>
 
-
     <% if @request_level == "item" %>
       <div class="row">
         <div class="col-sm-4 col-md-6 form-group">
@@ -40,8 +39,14 @@
           <%= select_tag(:hold_pickup_location, grouped_options_for_select(item_level_library_name(@item_level_locations)), { data: { "target": "form.pickups" },  class: "request-form form-control", include_blank: true, required: true, "aria-required": true }) %>
         </div>
       </div>
-
     <% end %>
+
+    <div class="row">
+      <div class="col-sm-4 col-md-6 hold-form form-group">
+        <%= label("", :material_type, t("requests.form.material_type")) %>
+        <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
+      </div>
+    </div>
 
     <div class="row hold-form">
       <div class="col-sm-5 col-md-6 form-group">

--- a/spec/controllers/almaws_controller_spec.rb
+++ b/spec/controllers/almaws_controller_spec.rb
@@ -93,8 +93,13 @@ RSpec.describe AlmawsController, type: :controller do
         expect { response }.not_to raise_error
       end
 
-      it "doesn't raise an exception for correctly formattted date for last_interest_date" do
+      it "doesn't raise an exception for correctly formatted date for last_interest_date" do
         post(:send_hold_request, params: { last_interest_date: "2018-08-15", mms_id: ""  })
+        expect { response }.not_to raise_error
+      end
+
+      it "doesn't raise an exception for correctly formatted material type" do
+        post(:send_hold_request, params: { material_type: { value: "BOOK", mms_id: ""  } })
         expect { response }.not_to raise_error
       end
     end
@@ -133,8 +138,13 @@ RSpec.describe AlmawsController, type: :controller do
         expect { response }.not_to raise_error
       end
 
-      it "doesn't raise an exception for correctly formattted date for last_interest_date" do
+      it "doesn't raise an exception for correctly formatted date for last_interest_date" do
         post(:send_hold_request, params: { last_interest_date: "2018-08-15", mms_id: ""  })
+        expect { response }.not_to raise_error
+      end
+
+      it "doesn't raise an exception for correctly formatted material type" do
+        post(:send_hold_request, params: { material_type: { value: "BOOK", mms_id: ""  } })
         expect { response }.not_to raise_error
       end
     end
@@ -168,7 +178,7 @@ RSpec.describe AlmawsController, type: :controller do
         expect { response }.not_to raise_error
       end
 
-      it "doesn't raise an exception for correctly formattted date for last_interest_date" do
+      it "doesn't raise an exception for correctly formatted date for last_interest_date" do
         post(:send_digitization_request, params: { last_interest_date: "2018-08-15", mms_id: ""  })
         expect { response }.not_to raise_error
       end
@@ -214,7 +224,7 @@ RSpec.describe AlmawsController, type: :controller do
         expect { response }.not_to raise_error
       end
 
-      it "doesn't raise an exception for correctly formattted date for booking dates" do
+      it "doesn't raise an exception for correctly formatted date for booking dates" do
         post(:send_booking_request, params: { booking_start_date: "2018-08-16", booking_end_date: "2018-08-20", mms_id: ""  })
         expect { response }.not_to raise_error
       end

--- a/spec/helpers/almaws_helper_spec.rb
+++ b/spec/helpers/almaws_helper_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe AlmawsHelper, type: :helper do
 
   before do
     helper.instance_variable_set(:@equipment, [])
+    helper.instance_variable_set(:@material_types, [])
     helper.instance_variable_set("@items", items_list)
     stub_request(:any, /request-options/).
       and_return(headers: { "Content-Type" => "application/json" },
@@ -77,6 +78,10 @@ RSpec.describe AlmawsHelper, type: :helper do
              "location" => {
                "value" => "stacks",
                "desc" => "Stacks"
+             },
+             "physical_material_type" => {
+               "value" => "BOOK",
+               "desc" => "book"
              },
          }
         )
@@ -321,6 +326,10 @@ RSpec.describe AlmawsHelper, type: :helper do
              "location" => {
                    "value" => "ASRS",
                    "desc" => "Automated Storage System"
+             },
+             "physical_material_type" => {
+               "value" => "BOOK",
+               "desc" => "book"
              },
           }
         )


### PR DESCRIPTION
- We previously only passed material types for booking requests, but a user requested this functionality for hold requests as well.