### PR TITLE
[BL-908] Fix purchase_order_action breaks after BL-7 upgrade

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -680,7 +680,7 @@ class CatalogController < ApplicationController
   end
 
   def purchase_order_action
-    (_, document) = fetch(params["id"])
+    (_, document) = search_service.fetch(params["id"])
 
     email = current_user&.email || params[:to]
     name = current_user&.name


### PR DESCRIPTION
In BL-7 searching documents happens indirectly via `search_service` not directly
in catalog controller.