### PR TITLE
[BL-908] fix purchase_order_action fail on fetch. (#1224)

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -675,7 +675,7 @@ class CatalogController < ApplicationController
   end
 
   def purchase_order_action
-    (_, document) = fetch(params["id"])
+    (_, document) = search_service.fetch(params["id"])
 
     email = current_user&.email || params[:to]
     name = current_user&.name


### PR DESCRIPTION
After BL-7 upgrade we need to fetch documents via search_service.