### PR TITLE
Allow access to raw json format.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -39,6 +39,7 @@ class CatalogController < ApplicationController
     config.advanced_search[:form_solr_parameters]["facet.field"] ||= %w(format library_facet language_facet availability_facet)
     config.advanced_search[:fields_row_count] = 3
 
+    config.raw_endpoint.enabled = true
     config.track_search_session = true
 
     ## Class for sending and receiving requests from a search index


### PR DESCRIPTION
After the BL-7 upgrade accessing raw json format is only available via
a new route catalog/:id/raw.json  that must be enabled in order to work.

Enabling the raw format makes our lives easier as developers because we
can more easily review fields that we are actively indexing.

BL-7 removed this feature for security purposes because other
institutions are potentially indexing sensitive information with their
documents.  But we do not index any sensitive information.