### PR TITLE
BL-810 Database resource types

### DIFF
--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -26,6 +26,7 @@ class DatabasesController < CatalogController
         title_t^10000
         subject_facet^1000
         format^200
+        format_t^200
         note_t^100
         availability_facet^50
         text^25
@@ -35,6 +36,7 @@ class DatabasesController < CatalogController
         title_t^10000
         subject_facet^1000
         format^200
+        format_t^200
         note_t^100
         availability_facet^50
         text^25
@@ -86,6 +88,7 @@ class DatabasesController < CatalogController
     config.add_show_field "format", label: "Database Type", helper_method: :database_type_links, multi: true
     config.add_show_field "az_vendor_name_display", label: "Database Vendor"
     config.add_show_field "id", label: "Database Record ID"
+    config.add_show_field "database_display", show: false
 
     # Search fields
     config.add_search_field "all_fields", label: "All Fields"
@@ -103,7 +106,7 @@ class DatabasesController < CatalogController
       field.solr_parameters = { "spellcheck.dictionary": "subject" }
       field.qt = "search"
       field.solr_local_parameters = {
-        qf: "$subjec_qf",
+        qf: "$subject_qf",
         pf: "$subject_pf"
       }
     end

--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -50,9 +50,11 @@ class DatabasesController < CatalogController
         title_t^10000
       ].join(" "),
       subject_qf: %w[
+        subject_t^1000000
         subject_facet^1000000
       ].join(" "),
       subject_pf: %w[
+        subject_t^1000000
         subject_facet^1000000
       ].join(" "),
       defType: "edismax",
@@ -67,7 +69,7 @@ class DatabasesController < CatalogController
       ps: "3",
       tie: "0.01",
       facet: "true",
-      # spellcheck: "false",
+      spellcheck: "false",
       sow: "false",
     }
 

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -267,7 +267,7 @@ module CatalogHelper
 
   def database_type_links(args)
     args[:document][args[:field]].map do |type|
-      link_to(type.sub("— — ", "— "), "#{base_path}?f[format][]=#{CGI.escape type}")
+      link_to(type.sub("— — ", "— "), "#{base_path}?f[format][]=#{CGI.escape type}", class: "p-2")
     end
   end
 

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -24,5 +24,4 @@
 <%- else %>
   <%= render_document_index %>
 <%- end %>
-
 <%= render "results_pagination" %>

--- a/lib/traject/databases_az_indexer_config.rb
+++ b/lib/traject/databases_az_indexer_config.rb
@@ -32,11 +32,21 @@ each_record do |record, context|
 end
 
 to_field "id", extract_json("$.id")
+
 to_field "format", ->(rec, acc) {
   types = rec.fetch("az_types", [])
-  types = types << { "name" => "Database" }
-  types.each { |type| acc << type["name"] }
+  types.each { |type| acc << type["name"] unless type["name"] == "Database" }
 }
+to_field "format_t", ->(rec, acc) {
+  types = rec.fetch("az_types", [])
+  types.each { |type| acc << type["name"] unless type["name"] == "Database" }
+}
+to_field "database_display", ->(rec, acc) {
+  types = rec.fetch("az_types", [])
+  types = types << { "name" => "Database" }
+  types.each { |type| acc << type["name"] if type["name"] == "Database" }
+}
+
 to_field "title_t", extract_json("$.name")
 to_field "title_sort", extract_json("$.name")
 to_field "alt_names_t", extract_json("$.alt_names")

--- a/lib/traject/databases_az_indexer_config.rb
+++ b/lib/traject/databases_az_indexer_config.rb
@@ -83,6 +83,10 @@ to_field "subject_facet", -> (rec, acc) {
   rec["subjects"]&.each { |subject| acc << subject["name"] }
 }
 
+to_field "subject_t", -> (rec, acc) {
+  rec["subjects"]&.each { |subject| acc << subject["name"] }
+}
+
 each_record do |record, context|
   if ENV["SOLR_DISABLE_UPDATE_DATE_CHECK"] == "yes"
     context.output_hash["record_update_date"] = [ Time.now.to_s ]


### PR DESCRIPTION
- Makes resource types searchable in all fields searches
- Create separate field for "database" type so that it doesn't display in the facets (currently not being used, but may be in the future)
- Align database type links of record pages