### PR TITLE
[BL-912] Do not flash article notice outside of articles.

### DIFF
--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -106,13 +106,13 @@ class PrimoCentralController < CatalogController
 
   def index
     # Temporary override to add notice for BL-912
-    flash[:notice] = "The bookmark feature for articles is temporarily disabled due to system errors"
+    flash.now[:notice] = "The bookmark feature for articles is temporarily disabled due to system errors"
     super
   end
 
   def show
     # Temporary override to add notice for BL-912
-    flash[:notice] = "The bookmark feature for articles is temporarily disabled due to system errors"
+    flash.now[:notice] = "The bookmark feature for articles is temporarily disabled due to system errors"
     super
   end
 end


### PR DESCRIPTION
Using flash now keeps flash from being alive when we go to another
action.