### PR TITLE
BL-861 Adjust height for bento compartments

### DIFF
--- a/app/assets/stylesheets/partials/_bento.scss
+++ b/app/assets/stylesheets/partials/_bento.scss
@@ -32,7 +32,7 @@
 
 	a {
 		color: $bento-header;
-		margin-left: -5px;
+		margin-left: -0.3125rem;
 	}
 }
 
@@ -45,7 +45,7 @@
 
 	@media(min-width: 768px) {
 	 	flex-direction: column;
-	 	max-height: 800px;
+	 	max-height: 43.75rem;
 	}
 }
 


### PR DESCRIPTION
- Currently the max-height property is dropping databases below the other compartments in some searches. 
- I think this is due to the length of results.  Lowering the max-height seems to solve the issue.