### PR TITLE
[BL-917] Rename az facet fields.

### DIFF
--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -74,9 +74,9 @@ class DatabasesController < CatalogController
     }
 
     # Facet fields
-    config.add_facet_field "subject_facet", label: "Subject", limit: true, show: true, collapse: false
-    config.add_facet_field "format", label: "Database Type", limit: -1, show: true, home: true, collapse: false
-    config.add_facet_field "availability_facet", label: "Access", home: true
+    config.add_facet_field "az_subject_facet", field: "subject_facet", label: "Subject", limit: true, show: true, collapse: false
+    config.add_facet_field "az_format", field: "format", label: "Database Type", limit: -1, show: true, home: true, collapse: false
+    config.add_facet_field "az_availability_facet", field: "availability_facet", label: "Access", home: true
 
     # Index fields
     config.add_index_field "format", label: "Database Type", raw: true, helper_method: :separate_formats


### PR DESCRIPTION
Rename the az facet fields to avoid collision with the catalog faceting.

The catalog is aware of the facet fields that it has configured but in
order to work it cannot share the same name as facets for other
searches.

This commit updates the az facet fields and takes advantage of a BL
feature that allows us to change the name that BL uses for this field
without needing to change what the field is named in the backend solr
core (i.e. solrcores can duplicate field names).