### PR TITLE
BL-861 Remove link

### DIFF
--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -5,9 +5,5 @@
     <%= render_nav_link(:search_path, "Articles", "navbar_articles") %>
     <%= render_nav_link(:search_databases_path, "Databases", "navbar_databases") %>
     <%= render_nav_link(:search_journals_path, "Journals", "navbar_journals") %>
-
-    <%# Need to update the path and id when integration work is competed  %>
-    <%= render_nav_link(:search_catalog_path, "Website", "navbar_more") %>
-
   </div>
 </nav>


### PR DESCRIPTION
- Removes the website link from the top nav so that it isn't accidentally included in the bento updates
- It will be added back in as part of the website integration work