### PR TITLE
[BL-918] hotfix refworks link broken for books/journals path.

### DIFF
--- a/app/helpers/blacklight_marc_helper.rb
+++ b/app/helpers/blacklight_marc_helper.rb
@@ -14,9 +14,9 @@ module BlacklightMarcHelper
     when "catalog"
       refworks_export_url(url: solr_document_url(opts[:id], format: :refworks_marc_txt))
     when "books"
-      refworks_export_url(url: solr_book_document_path(opts[:id], format: :refworks_marc_txt))
+      refworks_export_url(url: solr_book_document_url(opts[:id], format: :refworks_marc_txt))
     when "journals"
-      refworks_export_url(url: solr_journal_document_path(opts[:id], format: :refworks_marc_txt))
+      refworks_export_url(url: solr_journal_document_url(opts[:id], format: :refworks_marc_txt))
     end
   end
 


### PR DESCRIPTION
REF BL-918
REF WEB-2169

We're using the path instead of url method to create the callback url
for the refworks link.

This fixes that issue.