### PR TITLE
BL-810 Fix database link

### DIFF
--- a/app/views/databases/_home_text.html.erb
+++ b/app/views/databases/_home_text.html.erb
@@ -3,7 +3,7 @@
   <p>
     <%= t("databases.home_question_html") %>
     <%= t("bento.zero_results.databases_html", href: link_to(t("bento.zero_results.databases_href"), t("bento.zero_results.databases_link"), target: "_blank")) %>
-    <%= link_to(t("bento.zero_results.databases_two"), t("bento.zero_results.databases_link"), target: "_blank") %>
+    <%= link_to(t("bento.zero_results.databases_two"), t("bento.zero_results.databases_two_link"), target: "_blank") %>
   </p>
 
 </div>


### PR DESCRIPTION
- The link to browse databases alphabetically was set to the subject browse instead. This fixes it to use the correct translation.