### PR TITLE
BL-919 Add pickup locations for asrs

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -46,7 +46,7 @@ class AlmawsController < CatalogController
     @booking_location = CobAlma::Requests.booking_location(@items)
     @material_types = CobAlma::Requests.physical_material_type(@items)
     @pickup_locations = params[:pickup_location].split(",").collect { |lib| { lib => helpers.temporary_pickup_location_for_move(lib) } }
-    @asrs_pickup_locations = CobAlma::Requests.asrs_pickup_locations.collect { |lib| lib }
+    @asrs_pickup_locations = CobAlma::Requests.asrs_pickup_locations
     @user_id = current_user.uid
     @request_level = params[:request_level]
     @asrs_request_level = get_request_level(@items, "asrs")

--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -46,7 +46,7 @@ class AlmawsController < CatalogController
     @booking_location = CobAlma::Requests.booking_location(@items)
     @material_types = CobAlma::Requests.physical_material_type(@items)
     @pickup_locations = params[:pickup_location].split(",").collect { |lib| { lib => helpers.temporary_pickup_location_for_move(lib) } }
-    @asrs_pickup_locations = CobAlma::Requests.asrs_pickup_locations.collect { |lib| { lib => helpers.temporary_pickup_location_for_move(lib) } }
+    @asrs_pickup_locations = CobAlma::Requests.asrs_pickup_locations.collect { |lib| lib }
     @user_id = current_user.uid
     @request_level = params[:request_level]
     @asrs_request_level = get_request_level(@items, "asrs")

--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -28,7 +28,7 @@ module CobAlma
     end
 
     def self.asrs_pickup_locations
-      ["MAIN"]
+      ["Ambler Campus Library", "Charles Library (Main campus)", "Ginsburg Health Science Library", "Podiatry Library", "Harrisburg Campus Library"]
     end
 
     def self.remove_by_campus(campus)

--- a/app/views/almaws/_asrs_request_form.html.erb
+++ b/app/views/almaws/_asrs_request_form.html.erb
@@ -14,7 +14,7 @@
       <div class="row">
         <div class="col-sm-4 col-md-6 hold-form form-group">
           <%= label("", :asrs_pickup_location, t("requests.form.pickup_locations_label")) %>
-          <%= select("", :asrs_pickup_location, @asrs_pickup_locations.collect { |lib| [ lib.values.first, lib.keys.first ] }, { include_blank: true, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
+          <%= select("", :asrs_pickup_location, @asrs_pickup_locations.collect { |lib| [ lib ] }, { include_blank: true, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
         </div>
       </div>
     <% end %>
@@ -39,7 +39,7 @@
       <div class="row">
         <div class="col-sm-4 col-md-6 hold-form form-group">
           <%= label("", :asrs_pickup_location, t("requests.form.pickup_locations_label")) %>
-          <%= select("", :asrs_pickup_location, @asrs_pickup_locations.collect { |lib| [ lib.values.first, lib.keys.first ] }, { include_blank: true, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
+          <%= select("", :asrs_pickup_location, @asrs_pickup_locations.collect { |lib| [ lib ] }, { include_blank: true, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
         </div>
       </div>
 

--- a/spec/lib/cob_alma/requests_spec.rb
+++ b/spec/lib/cob_alma/requests_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe CobAlma::Requests do
 
   describe "#asrs_pickup_locations" do
     it "displays MAIN as the pickup_location" do
-      expect(described_class.asrs_pickup_locations).to eq(["MAIN"])
+      expect(described_class.asrs_pickup_locations).to eq(["Ambler Campus Library", "Charles Library (Main campus)", "Ginsburg Health Science Library", "Podiatry Library", "Harrisburg Campus Library"])
     end
   end
 end


### PR DESCRIPTION
- ASRS pickup locations should include all libraries.  For now, it was requested that these values be hard-coded with (Main campus) included with the Charles Library label.