### PR TITLE
BL-810 database links

### DIFF
--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -87,7 +87,7 @@ class DatabasesController < CatalogController
     # Show fields
     config.add_show_field "note_display", label: "Description", raw: true, helper_method: :join
     config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :check_for_full_http_link, if: false
-    config.add_show_field "subject_display", label: "Subject", helper_method: :subject_links, multi: true
+    config.add_show_field "subject_display", label: "Subject", helper_method: :database_subject_links, multi: true
     config.add_show_field "format", label: "Database Type", helper_method: :database_type_links, multi: true
     config.add_show_field "az_vendor_name_display", label: "Database Vendor"
     config.add_show_field "id", label: "Database Record ID"

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -265,9 +265,16 @@ module CatalogHelper
     end
   end
 
+  def database_subject_links(args)
+    args[:document][args[:field]].map do |subject|
+      link_to(subject.sub("— — ", "— "), "#{base_path}?f[az_subject_facet][]=#{CGI.escape subject}")
+    end
+  end
+
+
   def database_type_links(args)
     args[:document][args[:field]].map do |type|
-      link_to(type.sub("— — ", "— "), "#{base_path}?f[format][]=#{CGI.escape type}", class: "p-2")
+      link_to(type.sub("— — ", "— "), "#{base_path}?f[az_format][]=#{CGI.escape type}", class: "p-2")
     end
   end
 

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -475,17 +475,42 @@ RSpec.describe CatalogHelper, type: :helper do
           {
             document:
             {
-              format: ["eBooks"]
+              az_format: ["eBooks"]
             },
-            field: :format
+            field: :az_format
           }
         }
 
       it "includes link to database type" do
-        expect(database_type_links(args).first).to have_link("eBooks", href: "#{base_path}?f[format][]=eBooks")
+        expect(database_type_links(args).first).to have_link("eBooks", href: "#{base_path}?f[az_format][]=eBooks")
       end
     end
   end
+
+  describe "#database_subject_links(args)" do
+    let(:base_path) { "foo" }
+
+    before do
+      allow(helper).to receive(:base_path) { base_path }
+    end
+
+    context "links to database type facet" do
+      let(:args) {
+          {
+            document:
+            {
+              az_subject_facet: ["art"]
+            },
+            field: :az_subject_facet
+          }
+        }
+
+      it "includes link to database type" do
+        expect(database_subject_links(args).first).to have_link("art", href: "#{base_path}?f[az_subject_facet][]=art")
+      end
+    end
+  end
+
 
   # TODO: Remove if BL get upgraded, see details in helper method doc.
   describe "#presenter" do


### PR DESCRIPTION
- Adding the az prefix to database facet fields broke these two methods. This updates the methods to use the correct field names.