### PR TITLE
BL-923 bento columns

### DIFF
--- a/app/assets/stylesheets/partials/_bento.scss
+++ b/app/assets/stylesheets/partials/_bento.scss
@@ -1,24 +1,15 @@
 @import "_vars.scss";
 
 /* BENTO STYLES */
-.bento_compartment {
-	margin: 0 auto;
-	width: 33.3%;
-
-	@media(min-width: 1600px) {
-		width: 25% !important;
+.card-columns {
+	@include media-breakpoint-only(sm) {
+		column-count: 1;
 	}
-
-	@media(max-width: 1599px) {
-		width: 28% !important;
+	@include media-breakpoint-only(lg) {
+		column-count: 3;
 	}
-
-	@media(max-width: 1100px) {
-		width: 30% !important;
-	}
-
-	@media(max-width: 768px) {
-		width: 100% !important;
+	@include media-breakpoint-only(xl) {
+		column-count: 3;
 	}
 }
 
@@ -39,14 +30,6 @@
 .bento_compartment h3 {
 	font-size: 1.25rem;
 	padding-left: 0.9375rem;
-}
-
-.masonry {
-
-	@media(min-width: 768px) {
-	 	flex-direction: column;
-	 	max-height: 50rem;
-	}
 }
 
 .bento_item_title {

--- a/app/views/search/_bento_results.html.erb
+++ b/app/views/search/_bento_results.html.erb
@@ -1,6 +1,6 @@
-<div class="<%= results_class %> masonry px-3">
+<div class="card-columns">
   <% renderable_results(results, options).each_pair do |engine_id, result| %>
-    <div class="mx-auto test <%= comp_class %> <%= engine_id %>">
+    <div class="card d-inline-block mx-auto bento_compartment <%= engine_id %>">
       <h2 class="rounded-top m-0"><%= bento_icons(engine_id) %><%= bento_titleize(engine_id) %> </h2>
       <%= render :layout => "layouts/bento_box_wrapper", :locals => {:results => result } do %>
         <%= bento_search result %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,5 +1,5 @@
 <% if @results %>
-  <div class="bento-container pt-2 pb-5">
+  <div class="container">
     <%= render_bento_results %>
   </div>
   <%= render :partial => "resource_types" %>

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -19,7 +19,7 @@ test: &test
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8985}/solr/blacklight-core-test" %>
   az_url: <%= ENV['SOLR_AZ_URL'] || "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8985}/solr/az-database" %>
-  web_content_url: <%= ENV['SOLR_WEB_CONTENT_URL'] || "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8985}/solr/web-content-test" %>
+  web_content_url: <%= ENV['SOLR_WEB_CONTENT_URL'] || "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8985}/solr/web-content" %>
 production:
   adapter: solr
   az_url: <%= ENV['SOLR_AZ_URL'] || "http://127.0.0.1:8983/solr/az-database" %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -197,7 +197,7 @@ RSpec.configure do |config|
                 headers: { "content-Type" => "application/json" },
                 body: File.open(SPEC_ROOT + "/fixtures/alma_data/merge_document_and_api.json"))
 
-    stub_request(:get, /.*127.0.0.1\:8983\/solr\/web-content-test\/select?/).
+    stub_request(:get, /.*127.0.0.1\:8983\/solr\/web-content\/select?/).
       to_return(status: 200,
                 headers: { "Content-Type" => "application/json" },
                 body: File.open(SPEC_ROOT + "/fixtures/web_content/solr_response_no_query.json"))


### PR DESCRIPTION
- With our current configuration, the bento columns are displaying a different number depending on the height of the various results
- Changes the layout to use bootstrap cards for the bento results since the masonry layout is built in with the card-columns class