### PR TITLE
Remove bookmarks from  database index view.

### DIFF
--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -119,7 +119,8 @@ class DatabasesController < CatalogController
     config.add_sort_field "title_sort asc", label: "title (A to Z)"
     config.add_sort_field "title_sort desc", label: "title (Z to A)"
 
-    # Remove show doc actions.
+    # Remove show and index doc actions.
+    config.index.document_actions = Blacklight::NestedOpenStructWithHashAccess.new({})
     config.show.document_actions = Blacklight::NestedOpenStructWithHashAccess.new({})
 
   end

--- a/spec/features/databases_spec.rb
+++ b/spec/features/databases_spec.rb
@@ -13,6 +13,9 @@ RSpec.feature "Databases AZ" do
       end
 
       expect(page).to have_text "Mental Measurements Yearbook with Tests in Print"
+
+      expect(page).not_to have_button("Bookmark")
+      expect(page).not_to have_button("Remove bookmark")
     end
   end
 end


### PR DESCRIPTION
* We don't want any document features (inc. bookmarks) enabled for databases yet.
This was likely missed or we were disabling it incorrectly.

* Adds spec to avoid regression.