### PR TITLE
Short circuit the load fixtures task if filpath passed.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - "traefik.docker.network=reverseproxy_default"
     networks:
       - "default"
-      - "reverseproxy_default"
     depends_on:
       - solr
     entrypoint:
@@ -44,8 +43,3 @@ services:
       - /opt/solr/conf
       - "-Xms256m"
       - "-Xmx512m"
-
-networks:
-  reverseproxy_default:
-    external:
-      name: reverseproxy_default

--- a/lib/tasks/tulsearch.rake
+++ b/lib/tasks/tulsearch.rake
@@ -13,11 +13,15 @@ namespace :fortytu do
       end
       `traject -c #{Rails.configuration.traject_indexer} -x commit`
 
+      # Short circuit if filpath is set because that's only safe for
+      # ingesting marc files.
+      next if args[:filepath]
+
       az_url = Blacklight::Configuration.new.connection_config[:az_url]
       `SOLR_AZ_URL=#{az_url} cob_az_index ingest --use-fixtures`
 
       web_content_url = Blacklight::Configuration.new.connection_config[:web_content_url]
-      fixtures = args.fetch(:filepath, "spec/fixtures/web_content_data/*.json")
+      fixtures = "spec/fixtures/web_content_data/*.json"
       Dir.glob(fixtures).sort.reverse.each do |file|
         `SOLR_URL=#{web_content_url} traject -c lib/traject/web_content_indexer_config.rb #{file}`
       end


### PR DESCRIPTION
AZ and web-content files should not be ingested when we pass a filepath
to the load_fixtures task, because in this case the ingested files will
not be json.

This commit fixes this issue.