### PR TITLE
Switch to jdk9 on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
 - 2.4.1
 env:
 - TZ=America/New_York
-jdk: oraclejdk8
+jdk: oraclejdk9
 
 before_script:
 - cp config/secrets.yml.example config/secrets.yml


### PR DESCRIPTION
Travis has lost support of jdk8 OOB; Trying to switch to jdk9 for now ..
if this doesn't work we may need to upgrade to solr 8 ahead of
  schedule.