### PR TITLE
Rename fortytu namespace tul_cob.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ bin/ingest.rb http://example.com/catalog/foo.xml
 
 ### Ingest AZ Database data
 AZ Database fixture data is loaded automatically when you run
-`bundle exec rake fortytu:solr:load_fixtures`. If you want to ingest a single file or URL, use `bundle exec cob_az_index ingest $path_to_file_or_url`.
+`bundle exec rake tul_cob:solr:load_fixtures`. If you want to ingest a single file or URL, use `bundle exec cob_az_index ingest $path_to_file_or_url`.
 
 Note: If you make an update to cob_az_index, you will need to run `bundle update cob_az_index` locally.
 
 
 ### Ingest web content data
 Web content fixture data is loaded automatically when you run
-`bundle exec rake fortytu:solr:load_fixtures`. If you want to ingest a single file or URL, use `bundle exec cob_web_index ingest $path_to_file_or_url`.
+`bundle exec rake tul_cob:solr:load_fixtures`. If you want to ingest a single file or URL, use `bundle exec cob_web_index ingest $path_to_file_or_url`.
 
 Note: If you make an update to cob_web_index, you will need to run `bundle update cob_web_index` locally.
 
@@ -142,9 +142,9 @@ an optional date/time ranges in ISO8901 format and enclosed in brackets. You may
 date/times. You may not provide only a `to` date/time
 
 ```bash
-bundle exec rake fortytu:oai:harvest[from,to]
-bundle exec rake fortytu:oai:conform_all
-bundle exec rake fortytu:oai:ingest_all
+bundle exec rake tul_cob:oai:harvest[from,to]
+bundle exec rake tul_cob:oai:conform_all
+bundle exec rake tul_cob:oai:ingest_all
 ```
 
 ## Running the Tests

--- a/lib/oai/alma.rb
+++ b/lib/oai/alma.rb
@@ -11,7 +11,7 @@ module Oai
     # Params
     # +time_range+:: Optinoal hash containing +:from+ (start) and +:to+ (end) time in ISO8601.
     def self.harvest(time_range)
-      log_path = File.join(Rails.root, "log/fortytu.log")
+      log_path = File.join(Rails.root, "log/oai_alma.log")
       logger = Logger.new("| tee #{log_path}", 10, 1024000)
 
       from_time = time_range.fetch(:from) { "" }
@@ -50,7 +50,7 @@ module Oai
     end
 
     def self.conform(harvest_filename)
-      log_path = File.join(Rails.root, "log/fortytu.log")
+      log_path = File.join(Rails.root, "log/tul_cob.log")
       logger = Logger.new("| tee #{log_path}", 10, 1024000)
       begin
         oai = Nokogiri::XML(File.open(harvest_filename))

--- a/lib/tasks/oaiharvest.rake
+++ b/lib/tasks/oaiharvest.rake
@@ -6,7 +6,7 @@ require "tempfile"
 require "oai/alma"
 require "time"
 
-namespace :fortytu do
+namespace :tul_cob do
 
   desc "Posts fixtures to Solr"
   task :ingest, [:marc_file] => :environment do |t, args|
@@ -45,20 +45,20 @@ namespace :fortytu do
       if !args[:use_cache]
         # Delete the previous build's marc_xml_files.
         Dir.glob("tmp/alma/**/*.xml").each { |file| File.delete file }
-        Rake::Task["fortytu:oai:harvest"].invoke(from, to)
-        Rake::Task["fortytu:oai:conform_all"].invoke()
+        Rake::Task["tul_cob:oai:harvest"].invoke(from, to)
+        Rake::Task["tul_cob:oai:conform_all"].invoke()
       end
 
-      Rake::Task["fortytu:oai:ingest_all"].invoke()
-      Rake::Task["fortytu:purge"].invoke()
+      Rake::Task["tul_cob:oai:ingest_all"].invoke()
+      Rake::Task["tul_cob:purge"].invoke()
 
       # Check the build for errors.
-      if File.file? "log/fortytu.log.error"
+      if File.file? "log/tul_cob.log.error"
 
         # Print and archive the Error logs
         # TODO: DRY up log file determination
         main_logdir = File.join(Rails.root, "log/")
-        main_log = File.join(main_logdir, "fortytu.log")
+        main_log = File.join(main_logdir, "tul_cob.log")
         error_log = "#{main_log}.error"
 
         puts "Errors:"
@@ -86,7 +86,7 @@ namespace :fortytu do
 
     desc "Conforms all raw OAI MARC records to traject readable MARC records"
     task conform_all: :environment do
-      log_path = File.join(Rails.root, "log/fortytu.log")
+      log_path = File.join(Rails.root, "log/tul_cob.log")
       logger = Logger.new("| tee #{log_path}", 10, 4096000)
       begin
         oai_path = File.join(Rails.root, "tmp", "alma", "oai", "*.xml")
@@ -104,7 +104,7 @@ namespace :fortytu do
     desc "Ingest all readable MARC records"
     task ingest_all: :environment do
       main_logdir = File.join(Rails.root, "log/")
-      main_log = File.join(main_logdir, "fortytu.log")
+      main_log = File.join(main_logdir, "tul_cob.log")
       logger = Logger.new("| tee #{main_log}", 10, 1024000)
 
       ingest_logdir = File.join(main_logdir, "ingest/")

--- a/lib/tasks/server.rake
+++ b/lib/tasks/server.rake
@@ -16,7 +16,7 @@ task :rspec, [:spec_args] do |t, args|
     system "java -jar tmp/solr/server/start.jar -DSTOP.PORT=7983 -DSTOP.KEY=solrrocks -DSTOP.HOST=127.0.0.1 --stop"
     system "bundle exec solr_wrapper clean"
     run_solr("test", port: "8985") do
-      Rake::Task["fortytu:solr:load_fixtures"].invoke if ENV["DO_INGEST"]
+      Rake::Task["tul_cob:solr:load_fixtures"].invoke if ENV["DO_INGEST"]
       rspec_cmd = ["rspec", args[:spec_args]].compact.join(" ")
       passed = system(rspec_cmd)
     end
@@ -29,7 +29,7 @@ end
 desc "Run solr and blacklight for interactive development"
 task :server, [:rails_server_args] do |t, args|
   run_solr("dev", port: "8983") do
-    Rake::Task["fortytu:solr:load_fixtures"].invoke if ENV["DO_INGEST"]
+    Rake::Task["tul_cob:solr:load_fixtures"].invoke if ENV["DO_INGEST"]
     system "bundle exec rails s #{args[:rails_server_args]}"
   end
 end

--- a/lib/tasks/tulsearch.rake
+++ b/lib/tasks/tulsearch.rake
@@ -2,7 +2,7 @@
 
 require "rsolr"
 
-namespace :fortytu do
+namespace :tul_cob do
   namespace :solr do
 
     desc "Posts fixtures to Solr"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -323,7 +323,7 @@ if ENV["RELEVANCE"] && ENV["RELEVANCE"] != "test_only"
     config.before(:suite) do
       require "rake"
       Rails.application.load_tasks
-      Rake::Task["fortytu:solr:load_fixtures"].invoke("#{SPEC_ROOT}/relevance/fixtures/*.xml")
+      Rake::Task["tul_cob:solr:load_fixtures"].invoke("#{SPEC_ROOT}/relevance/fixtures/*.xml")
     end
   end
 end


### PR DESCRIPTION
fortytu would work better for a repository named fortytu.  Since this
repo is named tul_cob it makes more sense for its rake tasks to also be
namedspaced by tul_cob.