### PR TITLE
BL-926 Update description logic

### DIFF
--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -123,13 +123,14 @@ module CobAlma
           desc
         end
       end
-      descriptions.reject(&:empty?)
+      descriptions.uniq
     end
 
     def self.asrs_descriptions(items_list)
       items_list.all
-        .select { |item| item.library == "ASRS" && item.in_place? && item.description.present? }
+        .select { |item| item.library == "ASRS" && item.in_place? }
         .map(&:description)
+        .uniq
     end
 
     def self.booking_location(items_list)

--- a/app/views/almaws/_asrs_request_form.html.erb
+++ b/app/views/almaws/_asrs_request_form.html.erb
@@ -4,6 +4,7 @@
     <%= form.hidden_field :mms_id, value: params[:mms_id] %>
     <%= form.hidden_field :user_id, value: @user_id %>
     <%= form.hidden_field :asrs_request_level, value: @asrs_request_level %>
+
     <% available_asrs_items.each do |item| %>
       <%= form.hidden_field "available_asrs_items[][item_pid]", value: item["item_data"]["pid"] %>
       <%= form.hidden_field "available_asrs_items[][holding_id]", value: item["holding_data"]["holding_id"] %>
@@ -29,12 +30,17 @@
     <% end %>
 
     <% if @asrs_request_level == "item" %>
-      <div class="row">
-        <div class="col-sm-4 col-md-6 form-group">
-          <%= form.label(:asrs_description, t("requests.form.description_label")) %>
-          <%= select_tag(:asrs_description, options_for_select(@asrs_description), { data: { "action": "form#select" }, class: "request-form form-control", include_blank: true, required: false, "aria-required": true } ) %>
+      <% if @asrs_description.count > 1 %>
+        <div class="row">
+          <div class="col-sm-4 col-md-6 form-group">
+            <%= form.label(:asrs_description, t("requests.form.description_label")) %>
+            <p><%= t("requests.form.description_additional_text") %></p>
+            <%= select_tag(:asrs_description, options_for_select(@asrs_description), { data: { "action": "form#select" }, class: "request-form form-control", include_blank: true }) %>
+          </div>
         </div>
-      </div>
+      <% else %>
+        <%= form.hidden_field :asrs_description, value: @asrs_description %>
+      <% end %>
 
       <div class="row">
         <div class="col-sm-4 col-md-6 hold-form form-group">

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -20,13 +20,16 @@
       </div>
     <% end %>
 
-    <% if @description.present? %>
+    <% if @description.count > 1 %>
       <div class="form-group row">
         <div class="col-sm-4 col-md-6 form-group">
           <%= form.label(:booking_description, t("requests.form.description_label")) %>
-          <%= select_tag(:booking_description, options_for_select(@description), class: "request-form form-control", include_blank: true, required: true, "aria-required": true) %>
+          <p><%= t("requests.form.description_additional_text") %></p>
+          <%= select_tag(:booking_description, options_for_select(@description), class: "request-form form-control", include_blank: true) %>
         </div>
       </div>
+    <% else %>
+        <%= form.hidden_field :booking_description, value: @description %>
     <% end %>
 
     <div class="row hold-form">

--- a/app/views/almaws/_digitization_request_form.html.erb
+++ b/app/views/almaws/_digitization_request_form.html.erb
@@ -6,7 +6,6 @@
   <%= form.hidden_field :user_id, value: @user_id %>
   <%= form.hidden_field :request_level, value: @request_level %>
 
-
   <div class="container" data-controller="form">
     <div class="form-group row">
       <div class="col-sm-4 col-md-6">
@@ -22,13 +21,16 @@
       </div>
     </div>
 
-    <% if @request_level == "item" %>
+    <% if @request_level == "item" && @description.count > 1 %>
       <div class="form-group row">
         <div class="col-sm-4 col-md-6">
           <%= form.label(:digitization_description, t("requests.form.description_label")) %>
-          <%= select_tag(:digitization_description, options_for_select(@description), class: "request-form form-control", include_blank: true, required: true, "aria-required": true) %>
+          <p><%= t("requests.form.description_additional_text") %></p>
+          <%= select_tag(:digitization_description, options_for_select(@description), class: "request-form form-control", include_blank: true) %>
         </div>
       </div>
+    <% else %>
+      <%= form.hidden_field :digitization_description, value: @description %>
     <% end %>
 
     <div class="form-group row">

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -7,11 +7,16 @@
     <%= form.hidden_field :user_id, value: @user_id %>
     <%= form.hidden_field :request_level, value: @request_level %>
 
+    <% if @description.count == 1 %>
+      <%= form.hidden_field :hold_description, value: @description %>
+    <% end %>
+
+
     <% if @equipment.empty?  && @request_level == "bib" %>
       <div class="row">
         <div class="col-sm-4 col-md-6 hold-form form-group">
           <%= label("", :hold_pickup_location, t("requests.form.pickup_locations_label")) %>
-          <%= select("", :hold_pickup_location, @pickup_locations.collect { |lib| [ lib.values.first, lib.keys.first ] }, { include_blank: true, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
+          <%= select("", :hold_pickup_location, @pickup_locations.collect { |lib| [ lib.values.first, lib.keys.first ] }, { include_blank: true }, {class: "request-form form-control"}) %>
         </div>
       </div>
     <% end %>
@@ -26,12 +31,17 @@
     <% end %>
 
     <% if @request_level == "item" %>
-      <div class="row">
-        <div class="col-sm-4 col-md-6 form-group">
-          <%= form.label(:hold_description, t("requests.form.description_label")) %>
-          <%= select_tag(:hold_description, options_for_select(@description), { data: { "action": "form#select" }, class: "request-form form-control", include_blank: true, required: true, "aria-required": true } ) %>
+      <% if @description.count > 1 %>
+        <div class="row">
+          <div class="col-sm-4 col-md-6 form-group">
+            <%= form.label(:hold_description, t("requests.form.description_label")) %>
+            <p><%= t("requests.form.description_additional_text") %></p>
+            <%= select_tag(:hold_description, options_for_select(@description), { data: { "action": "form#select" }, class: "request-form form-control", include_blank: true, required: true, "aria-required": true } ) %>
+          </div>
         </div>
-      </div>
+      <% else %>
+        <%= form.hidden_field :digitization_description, value: @description %>
+      <% end %>
 
       <div class="row">
         <div class="col-sm-4 col-md-6 hold-form form-group">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,10 +106,11 @@ en:
     form:
       header: "Details of title you requested:"
       pickup_locations_label: "Pickup Location: *"
-      description_label: "Description: *"
+      description_label: "Description (optional): "
       not_needed_after: "Not Needed After (optional):"
       notes_label: "Notes (optional):"
       notes_additional_text: "For additional information about the description of the item or the request itself"
+      description_additional_text: "Select volume/issue or additional item details, if applicable"
       submit: "Request"
       title_label: "Chapter/Article Title: *"
       author_label: "Chapter/Article Author: *"

--- a/spec/fixtures/requests/asrs_empty_descriptions.json
+++ b/spec/fixtures/requests/asrs_empty_descriptions.json
@@ -214,7 +214,7 @@
                 "chronology_k": "",
                 "chronology_l": "",
                 "chronology_m": "",
-                "description": "sample",
+                "description": "",
                 "receiving_operator": "import",
                 "process_type": {
                     "value": "",

--- a/spec/fixtures/requests/asrs_repeated_descriptions.json
+++ b/spec/fixtures/requests/asrs_repeated_descriptions.json
@@ -1,0 +1,260 @@
+{
+    "item": [
+        {
+            "bib_data": {
+                "mms_id": "991030207479703811",
+                "title": "Fences /",
+                "author": "Rudin, Scott,",
+                "issn": null,
+                "isbn": null,
+                "complete_edition": "[English/Spanish/French subtitled version]",
+                "network_number": [
+                    "(OCLC)ocn982129182",
+                    "ocn982129182",
+                    "(OCoLC)972884896",
+                    "(PPT)b6415337x-01tuli_inst"
+                ],
+                "place_of_publication": "Los Angeles, CA :",
+                "date_of_publication": "[2017]",
+                "publisher_const": "Paramount",
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991030207479703811"
+            },
+            "holding_data": {
+                "holding_id": "22255855480003811",
+                "call_number_type": {
+                    "value": "8",
+                    "desc": "Other scheme"
+                },
+                "call_number": "DVD 17 A32",
+                "accession_number": "",
+                "copy_id": "1",
+                "in_temp_location": false,
+                "temp_library": {
+                    "value": null,
+                    "desc": null
+                },
+                "temp_location": {
+                    "value": null,
+                    "desc": null
+                },
+                "temp_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "temp_call_number": "",
+                "temp_policy": {
+                    "value": "",
+                    "desc": null
+                },
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991030207479703811/holdings/22255855480003811"
+            },
+            "item_data": {
+                "pid": "23255855460003811",
+                "barcode": "39074030840144",
+                "creation_date": "2017-06-20Z",
+                "modification_date": "2018-10-06Z",
+                "base_status": {
+                    "value": "1",
+                    "desc": "Item in place"
+                },
+                "physical_material_type": {
+                    "value": "DVD",
+                    "desc": "DVD"
+                },
+                "policy": {
+                    "value": "5",
+                    "desc": "Media"
+                },
+                "provenance": {
+                    "value": "",
+                    "desc": null
+                },
+                "po_line": "",
+                "is_magnetic": false,
+                "arrival_date": "2017-03-22Z",
+                "year_of_issue": "",
+                "enumeration_a": "",
+                "enumeration_b": "",
+                "enumeration_c": "",
+                "enumeration_d": "",
+                "enumeration_e": "",
+                "enumeration_f": "",
+                "enumeration_g": "",
+                "enumeration_h": "",
+                "chronology_i": "",
+                "chronology_j": "",
+                "chronology_k": "",
+                "chronology_l": "",
+                "chronology_m": "",
+                "description": "sample",
+                "receiving_operator": "import",
+                "process_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "library": {
+                    "value": "ASRS",
+                    "desc": "ASRS"
+                },
+                "location": {
+                    "value": "media",
+                    "desc": "Media"
+                },
+                "alternative_call_number": "",
+                "alternative_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "storage_location_id": "",
+                "pages": "",
+                "pieces": "$0.00",
+                "public_note": "",
+                "fulfillment_note": "MESSAGE(ITEM): Check container for DVD.",
+                "internal_note_1": "",
+                "internal_note_2": "",
+                "internal_note_3": "ITEM LOC: avid",
+                "statistics_note_1": "TOT RENEW: 0",
+                "statistics_note_2": "LYCIRC: 0",
+                "statistics_note_3": "",
+                "requested": null,
+                "edition": null,
+                "imprint": null,
+                "language": null,
+                "physical_condition": {
+                    "value": null,
+                    "desc": null
+                }
+            },
+            "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991030207479703811/holdings/22255855480003811/items/23255855460003811"
+        },
+        {
+            "bib_data": {
+                "mms_id": "991030207479703811",
+                "title": "Fences /",
+                "author": "Rudin, Scott,",
+                "issn": null,
+                "isbn": null,
+                "complete_edition": "[English/Spanish/French subtitled version]",
+                "network_number": [
+                    "(OCLC)ocn982129182",
+                    "ocn982129182",
+                    "(OCoLC)972884896",
+                    "(PPT)b6415337x-01tuli_inst"
+                ],
+                "place_of_publication": "Los Angeles, CA :",
+                "date_of_publication": "[2017]",
+                "publisher_const": "Paramount",
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991030207479703811"
+            },
+            "holding_data": {
+                "holding_id": "22255855450003811",
+                "call_number_type": {
+                    "value": "8",
+                    "desc": "Other scheme"
+                },
+                "call_number": "DVD 17 168",
+                "accession_number": "",
+                "copy_id": "1",
+                "in_temp_location": false,
+                "temp_library": {
+                    "value": "MEDIA",
+                    "desc": "Media Services"
+                },
+                "temp_location": {
+                    "value": "reserve",
+                    "desc": "Main Media Reserve"
+                },
+                "temp_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "temp_call_number": "",
+                "temp_policy": {
+                    "value": "",
+                    "desc": null
+                },
+                "due_back_date": "2017-12-22Z",
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991030207479703811/holdings/22255855450003811"
+            },
+            "item_data": {
+                "pid": "23255855440003811",
+                "barcode": "39074030837900",
+                "creation_date": "2017-06-20Z",
+                "modification_date": "2018-08-06Z",
+                "base_status": {
+                    "value": "1",
+                    "desc": "Item in place"
+                },
+                "physical_material_type": {
+                    "value": "DVD",
+                    "desc": "DVD"
+                },
+                "policy": {
+                    "value": "5",
+                    "desc": "Media"
+                },
+                "provenance": {
+                    "value": "",
+                    "desc": null
+                },
+                "po_line": "",
+                "is_magnetic": false,
+                "arrival_date": "2017-04-06Z",
+                "year_of_issue": "",
+                "enumeration_a": "",
+                "enumeration_b": "",
+                "enumeration_c": "",
+                "enumeration_d": "",
+                "enumeration_e": "",
+                "enumeration_f": "",
+                "enumeration_g": "",
+                "enumeration_h": "",
+                "chronology_i": "",
+                "chronology_j": "",
+                "chronology_k": "",
+                "chronology_l": "",
+                "chronology_m": "",
+                "description": "sample",
+                "receiving_operator": "import",
+                "process_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "library": {
+                    "value": "ASRS",
+                    "desc": "ASRS"
+                },
+                "location": {
+                    "value": "media",
+                    "desc": "Main Media"
+                },
+                "alternative_call_number": "",
+                "alternative_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "storage_location_id": "",
+                "pages": "",
+                "pieces": "$0.00",
+                "public_note": "",
+                "fulfillment_note": "MESSAGE(ITEM): Check container for DVD.",
+                "internal_note_1": "",
+                "internal_note_2": "",
+                "internal_note_3": "ITEM LOC: pmed",
+                "statistics_note_1": "TOT RENEW: 1",
+                "statistics_note_2": "LYCIRC: 0",
+                "statistics_note_3": "",
+                "requested": null,
+                "edition": null,
+                "imprint": null,
+                "language": null,
+                "physical_condition": {
+                    "value": null,
+                    "desc": null
+                }
+            },
+            "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991030207479703811/holdings/22255855450003811/items/23255855440003811"
+        }
+    ],
+    "total_record_count": 2
+}

--- a/spec/fixtures/requests/repeated_descriptions.json
+++ b/spec/fixtures/requests/repeated_descriptions.json
@@ -1,0 +1,260 @@
+{
+    "item": [
+        {
+            "bib_data": {
+                "mms_id": "991030207479703811",
+                "title": "Fences /",
+                "author": "Rudin, Scott,",
+                "issn": null,
+                "isbn": null,
+                "complete_edition": "[English/Spanish/French subtitled version]",
+                "network_number": [
+                    "(OCLC)ocn982129182",
+                    "ocn982129182",
+                    "(OCoLC)972884896",
+                    "(PPT)b6415337x-01tuli_inst"
+                ],
+                "place_of_publication": "Los Angeles, CA :",
+                "date_of_publication": "[2017]",
+                "publisher_const": "Paramount",
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991030207479703811"
+            },
+            "holding_data": {
+                "holding_id": "22255855480003811",
+                "call_number_type": {
+                    "value": "8",
+                    "desc": "Other scheme"
+                },
+                "call_number": "DVD 17 A32",
+                "accession_number": "",
+                "copy_id": "1",
+                "in_temp_location": false,
+                "temp_library": {
+                    "value": null,
+                    "desc": null
+                },
+                "temp_location": {
+                    "value": null,
+                    "desc": null
+                },
+                "temp_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "temp_call_number": "",
+                "temp_policy": {
+                    "value": "",
+                    "desc": null
+                },
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991030207479703811/holdings/22255855480003811"
+            },
+            "item_data": {
+                "pid": "23255855460003811",
+                "barcode": "39074030840144",
+                "creation_date": "2017-06-20Z",
+                "modification_date": "2018-10-06Z",
+                "base_status": {
+                    "value": "1",
+                    "desc": "Item in place"
+                },
+                "physical_material_type": {
+                    "value": "DVD",
+                    "desc": "DVD"
+                },
+                "policy": {
+                    "value": "5",
+                    "desc": "Media"
+                },
+                "provenance": {
+                    "value": "",
+                    "desc": null
+                },
+                "po_line": "",
+                "is_magnetic": false,
+                "arrival_date": "2017-03-22Z",
+                "year_of_issue": "",
+                "enumeration_a": "",
+                "enumeration_b": "",
+                "enumeration_c": "",
+                "enumeration_d": "",
+                "enumeration_e": "",
+                "enumeration_f": "",
+                "enumeration_g": "",
+                "enumeration_h": "",
+                "chronology_i": "",
+                "chronology_j": "",
+                "chronology_k": "",
+                "chronology_l": "",
+                "chronology_m": "",
+                "description": "sample",
+                "receiving_operator": "import",
+                "process_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "library": {
+                    "value": "AMBLER",
+                    "desc": "Ambler Campus Library"
+                },
+                "location": {
+                    "value": "media",
+                    "desc": "Ambler Media"
+                },
+                "alternative_call_number": "",
+                "alternative_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "storage_location_id": "",
+                "pages": "",
+                "pieces": "$0.00",
+                "public_note": "",
+                "fulfillment_note": "MESSAGE(ITEM): Check container for DVD.",
+                "internal_note_1": "",
+                "internal_note_2": "",
+                "internal_note_3": "ITEM LOC: avid",
+                "statistics_note_1": "TOT RENEW: 0",
+                "statistics_note_2": "LYCIRC: 0",
+                "statistics_note_3": "",
+                "requested": null,
+                "edition": null,
+                "imprint": null,
+                "language": null,
+                "physical_condition": {
+                    "value": null,
+                    "desc": null
+                }
+            },
+            "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991030207479703811/holdings/22255855480003811/items/23255855460003811"
+        },
+        {
+            "bib_data": {
+                "mms_id": "991030207479703811",
+                "title": "Fences /",
+                "author": "Rudin, Scott,",
+                "issn": null,
+                "isbn": null,
+                "complete_edition": "[English/Spanish/French subtitled version]",
+                "network_number": [
+                    "(OCLC)ocn982129182",
+                    "ocn982129182",
+                    "(OCoLC)972884896",
+                    "(PPT)b6415337x-01tuli_inst"
+                ],
+                "place_of_publication": "Los Angeles, CA :",
+                "date_of_publication": "[2017]",
+                "publisher_const": "Paramount",
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991030207479703811"
+            },
+            "holding_data": {
+                "holding_id": "22255855450003811",
+                "call_number_type": {
+                    "value": "8",
+                    "desc": "Other scheme"
+                },
+                "call_number": "DVD 17 168",
+                "accession_number": "",
+                "copy_id": "1",
+                "in_temp_location": false,
+                "temp_library": {
+                    "value": "MEDIA",
+                    "desc": "Media Services"
+                },
+                "temp_location": {
+                    "value": "reserve",
+                    "desc": "Main Media Reserve"
+                },
+                "temp_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "temp_call_number": "",
+                "temp_policy": {
+                    "value": "",
+                    "desc": null
+                },
+                "due_back_date": "2017-12-22Z",
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991030207479703811/holdings/22255855450003811"
+            },
+            "item_data": {
+                "pid": "23255855440003811",
+                "barcode": "39074030837900",
+                "creation_date": "2017-06-20Z",
+                "modification_date": "2018-08-06Z",
+                "base_status": {
+                    "value": "1",
+                    "desc": "Item in place"
+                },
+                "physical_material_type": {
+                    "value": "DVD",
+                    "desc": "DVD"
+                },
+                "policy": {
+                    "value": "5",
+                    "desc": "Media"
+                },
+                "provenance": {
+                    "value": "",
+                    "desc": null
+                },
+                "po_line": "",
+                "is_magnetic": false,
+                "arrival_date": "2017-04-06Z",
+                "year_of_issue": "",
+                "enumeration_a": "",
+                "enumeration_b": "",
+                "enumeration_c": "",
+                "enumeration_d": "",
+                "enumeration_e": "",
+                "enumeration_f": "",
+                "enumeration_g": "",
+                "enumeration_h": "",
+                "chronology_i": "",
+                "chronology_j": "",
+                "chronology_k": "",
+                "chronology_l": "",
+                "chronology_m": "",
+                "description": "sample",
+                "receiving_operator": "import",
+                "process_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "library": {
+                    "value": "MEDIA",
+                    "desc": "Media Services"
+                },
+                "location": {
+                    "value": "media",
+                    "desc": "Main Media"
+                },
+                "alternative_call_number": "",
+                "alternative_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "storage_location_id": "",
+                "pages": "",
+                "pieces": "$0.00",
+                "public_note": "",
+                "fulfillment_note": "MESSAGE(ITEM): Check container for DVD.",
+                "internal_note_1": "",
+                "internal_note_2": "",
+                "internal_note_3": "ITEM LOC: pmed",
+                "statistics_note_1": "TOT RENEW: 1",
+                "statistics_note_2": "LYCIRC: 0",
+                "statistics_note_3": "",
+                "requested": null,
+                "edition": null,
+                "imprint": null,
+                "language": null,
+                "physical_condition": {
+                    "value": null,
+                    "desc": null
+                }
+            },
+            "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991030207479703811/holdings/22255855450003811/items/23255855440003811"
+        }
+    ],
+    "total_record_count": 2
+}

--- a/spec/helpers/almaws_helper_spec.rb
+++ b/spec/helpers/almaws_helper_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe AlmawsHelper, type: :helper do
   let(:items_list) { Alma::BibItem.find("merge_document_and_api") }
 
   before do
+    helper.instance_variable_set(:@description, [])
     helper.instance_variable_set(:@equipment, [])
     helper.instance_variable_set(:@material_types, [])
     helper.instance_variable_set("@items", items_list)

--- a/spec/lib/cob_alma/requests_spec.rb
+++ b/spec/lib/cob_alma/requests_spec.rb
@@ -124,11 +124,19 @@ RSpec.describe CobAlma::Requests do
       end
     end
 
-    context "record has multiple descriptions" do
+    context "record has multiple descriptions that are different" do
       let(:items_list) { Alma::BibItem.find("multiple_descriptions") }
 
       it "returns multiple descriptions" do
         expect(described_class.descriptions(items_list)).to eq(["sample", "second"])
+      end
+    end
+
+    context "record has multiple descriptions that are the same" do
+      let(:items_list) { Alma::BibItem.find("repeated_descriptions") }
+
+      it "returns unique descriptions" do
+        expect(described_class.descriptions(items_list)).to eq(["sample"])
       end
     end
   end
@@ -163,6 +171,14 @@ RSpec.describe CobAlma::Requests do
 
       it "returns empty list" do
         expect(described_class.asrs_descriptions(items_list)).to eq([])
+      end
+    end
+
+    context "record has multiple descriptions that are the same" do
+      let(:items_list) { Alma::BibItem.find("asrs_repeated_descriptions") }
+
+      it "returns unique descriptions" do
+        expect(described_class.asrs_descriptions(items_list)).to eq(["sample"])
       end
     end
   end

--- a/spec/lib/cob_alma/requests_spec.rb
+++ b/spec/lib/cob_alma/requests_spec.rb
@@ -111,16 +111,16 @@ RSpec.describe CobAlma::Requests do
     context "record has multiple empty descriptions" do
       let(:items_list) { Alma::BibItem.find("empty_descriptions") }
 
-      it "returns an empty array" do
-        expect(described_class.descriptions(items_list)).to eq([])
+      it "returns an array with empty string" do
+        expect(described_class.descriptions(items_list)).to eq([""])
       end
     end
 
     context "record has empty description and description" do
       let(:items_list) { Alma::BibItem.find("empty_and_description") }
 
-      it "returns single description" do
-        expect(described_class.descriptions(items_list)).to eq(["sample"])
+      it "returns single description and empty string" do
+        expect(described_class.descriptions(items_list)).to eq(["", "sample"])
       end
     end
 
@@ -143,10 +143,10 @@ RSpec.describe CobAlma::Requests do
 
   describe "#asrs_descriptions" do
     context "record has multiple empty descriptions" do
-      let(:items_list) { Alma::BibItem.find("empty_descriptions") }
+      let(:items_list) { Alma::BibItem.find("asrs_empty_descriptions") }
 
       it "returns an empty array" do
-        expect(described_class.asrs_descriptions(items_list)).to eq([])
+        expect(described_class.asrs_descriptions(items_list)).to eq([""])
       end
     end
 
@@ -154,7 +154,7 @@ RSpec.describe CobAlma::Requests do
       let(:items_list) { Alma::BibItem.find("asrs_empty_and_description") }
 
       it "returns one description" do
-        expect(described_class.asrs_descriptions(items_list)).to eq(["sample"])
+        expect(described_class.asrs_descriptions(items_list)).to eq(["", "sample"])
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -180,6 +180,16 @@ RSpec.configure do |config|
                 headers: { "Content-Type" => "application/json" },
                 body: File.open(SPEC_ROOT + "/fixtures/requests/multiple_descriptions.json"))
 
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/repeated_descriptions\/holdings\/.*\/items/).
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/repeated_descriptions.json"))
+
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/asrs_repeated_descriptions\/holdings\/.*\/items/).
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/asrs_repeated_descriptions.json"))
+
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/multiple_descriptions\/holdings\/.*\/items/).
       with(query: hash_including(offset: "100")).
       to_return(status: 200,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -137,6 +137,11 @@ RSpec.configure do |config|
                 headers: { "Content-Type" => "application/json" },
                 body: File.open(SPEC_ROOT + "/fixtures/requests/empty_descriptions.json"))
 
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/asrs_empty_descriptions\/holdings\/.*\/items/).
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/asrs_empty_descriptions.json"))
+
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/empty_descriptions\/holdings\/.*\/items/).
       with(query: hash_including(offset: "100")).
       to_return(status: 200,


### PR DESCRIPTION
- Refactors so that the dropdown menu only displays if multiple descriptions are present
- Single descriptions are passed as a hidden field to ensure they are sent to alma
- Returns only unique descriptions
- Do not filter out empty descriptions so that the patron can select the empty option if one item doesn't have a description
- Field should be optional, not required