### PR TITLE
BL-949 Material types in request forms

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -44,7 +44,7 @@ class AlmawsController < CatalogController
     @item_level_locations = CobAlma::Requests.item_level_locations(@items)
     @equipment = CobAlma::Requests.equipment(@items)
     @booking_location = CobAlma::Requests.booking_location(@items)
-    @material_types = CobAlma::Requests.physical_material_type(@items).compact if CobAlma::Requests.physical_material_type(@items).count > 1
+    @material_types = CobAlma::Requests.physical_material_type(@items).compact
     @pickup_locations = params[:pickup_location].split(",").collect { |lib| { lib => helpers.library_name_from_short_code(lib) } }
     @asrs_pickup_locations = CobAlma::Requests.asrs_pickup_locations
     @user_id = current_user.uid

--- a/app/views/almaws/_asrs_request_form.html.erb
+++ b/app/views/almaws/_asrs_request_form.html.erb
@@ -51,13 +51,15 @@
 
     <% end %>
 
-    <% if @material_types.present? %>
+    <% if @material_types.present? && @material_types.count > 1 %>
       <div class="row">
         <div class="col-sm-4 col-md-6 hold-form form-group">
           <%= label("", :material_type, t("requests.form.material_type")) %>
           <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, "aria-required": true }, {class: "request-form form-control"}) %>
         </div>
       </div>
+    <% else %>
+      <%= form.hidden_field :material_type, value: @material_types %>
     <% end %>
 
     <div class="row hold-form">

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -11,13 +11,15 @@
       </div>
     </div>
 
-    <% if @material_types.present? %>
+    <% if @material_types.present? && @material_types.count > 1 %>
       <div class="row">
         <div class="col-sm-4 col-md-6 hold-form form-group">
           <%= label("", :material_type, t("requests.form.material_type")) %>
           <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
         </div>
       </div>
+    <% else %>
+      <%= form.hidden_field :material_type, value: @material_types %>
     <% end %>
 
     <% if @description.count > 1 %>

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -51,13 +51,15 @@
       </div>
     <% end %>
 
-    <% if @material_types.present? %>
+    <% if @material_types.present? && @material_types.count > 1 %>
       <div class="row">
         <div class="col-sm-4 col-md-6 hold-form form-group">
           <%= label("", :material_type, t("requests.form.material_type")) %>
           <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, "aria-required": true }, {class: "request-form form-control"}) %>
         </div>
       </div>
+    <% else %>
+      <%= form.hidden_field :material_type, value: @material_types %>
     <% end %>
 
     <div class="row hold-form">


### PR DESCRIPTION
- Refactor the way we handle material types so that they are sent to alma as a hidden parameter when only one option is present