### PR TITLE
BL-932 Record page availaiblity

### DIFF
--- a/app/assets/stylesheets/partials/_availability.scss
+++ b/app/assets/stylesheets/partials/_availability.scss
@@ -36,17 +36,13 @@
   display: table-row;
 }
 
-.online-card {
-  padding: 0.625rem;
-}
-
 #record-page-online {
   text-align: left;
 }
 
-.online-card,
-.online-list .online-card {
+.online-card {
   border: 0.0625rem solid $dark-blue;
+  padding-left: 0;
 }
 
 .library-name {

--- a/app/assets/stylesheets/partials/_record_pages.scss
+++ b/app/assets/stylesheets/partials/_record_pages.scss
@@ -44,15 +44,12 @@
 }
 
 #stafflink {
-  padding: 1.5rem 0.25rem;
+  margin-left: 0 !important;
+  padding-top: 1.0rem;
 }
 
 .blacklight-url_more_links_display .online-card {
   padding: 0;
-}
-
-.online-card {
-  padding-left: 1rem;
 }
 
 .list_items {
@@ -65,4 +62,8 @@
   hr {
     border-bottom: 0.0625rem solid $red;
   }
+}
+
+dd.blacklight-format {
+  padding-left: 15px;
 }

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -171,7 +171,7 @@ module CatalogHelper
       label = content_tag :span, "Request Rapid Access", class: "avail-label"
       path = purchase_order_path(id: doc.id)
       link = link_to label, path, class: "btn btn-sm btn-danger", title: "Open a modal form to request a purchase for this item.", target: "_blank", id: "purchase_order_button-#{doc.id}", data: { "blacklight-modal": "trigger" }
-      content_tag :div, link, class: "requests-container"
+      content_tag :div, link, class: "requests-container mb-2 ml-0"
     end
   end
 
@@ -302,7 +302,7 @@ module CatalogHelper
   def electronic_access_links(field)
     text = field.fetch("title", "Link to Resource").sub(/ *[ ,.\/;:] *\Z/, "")
     url = field["url"]
-    content_tag(:div, link_to(text, url, title: "Target opens in new window", target: "_blank"), class: "electronic_links online-list-items online-card")
+    content_tag(:div, link_to(text, url, title: "Target opens in new window", target: "_blank"), class: "electronic_links online-list-items")
   end
 
   def electronic_resource_link_builder(field)
@@ -317,7 +317,7 @@ module CatalogHelper
     item_html = [item_html, electronic_notes]
       .select(&:present?).join(" ").html_safe
 
-    content_tag(:div, item_html , class: " electronic_links online-list-items online-card border-top-0")
+    content_tag(:div, item_html , class: " electronic_links online-list-items online-card border-top-0 p-2")
   end
 
   def render_electronic_notes(field)

--- a/app/views/catalog/_online_availability.html.erb
+++ b/app/views/catalog/_online_availability.html.erb
@@ -1,5 +1,5 @@
-<div class="card online-card rounded-0 border-0 offset-md-2 mb-3">
-  <div id="record-page-online" class="mb-0 p-1">
+<div class="card online-card rounded-0 border-0 mb-3">
+  <div id="record-page-online" class="mb-0">
     <h5 class="online-card-heading card-title mb-0 border-bottom border-dark-blue">Online</h5>
       <% online_resources.each do |value| %>
         <div class="record-page-online-list"><%= safe_join([value]) %></div>

--- a/app/views/catalog/_purchase_order_anonymous_button.html.erb
+++ b/app/views/catalog/_purchase_order_anonymous_button.html.erb
@@ -7,7 +7,7 @@
 
 <div id="online-document-<%= document.id %>" class="collapse online_resources">
   <div>
-    <div class="electronic_links online-list-items border border-dark-blue p-2"><%= t("purchase_order_allowed") %></div>
+    <div class="electronic_links online-list-items p-2"><%= t("purchase_order_allowed") %></div>
     <span class="border-bottom"></span>
   </div>
 </div>

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -1,7 +1,7 @@
 <% doc_presenter = show_presenter(document) %>
 <%# partial to display availability details in catalog show view -%>
 
-<div id="record-view-iframe" data-availability-id="<%= document.alma_availability_mms_ids.first %>" class="card availability-card d-flex mx-auto border-0 pl-md-3">
+<div id="record-view-iframe" data-availability-id="<%= document.alma_availability_mms_ids.first %>" class="card availability-card d-flex mx-auto border-0">
   <div class="availability-card-heading float-right">
     <div id="heading-request ml-auto">
       <%= presenter_field_value(doc_presenter, "po_link") %>
@@ -19,7 +19,7 @@
 
 <% if document.fetch("availability_facet", []).include?("At the Library") %>
   <div class="physical-holding-panel border-0" data-controller="show" data-show-url="<%= item_url(document.alma_availability_mms_ids.first, doc_id: document.id, redirect_to: request.url) %>">
-    <div class="border border-header-grey offset-md-2 mb-3">
+    <div class="border border-header-grey mb-3">
       <div data-target="show.panel">
         <%= render "physical_availability_card", document: document, document_counter: document.id %>
       </div>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -1,6 +1,6 @@
 <% doc_presenter = show_presenter(document) %>
 <%# default partial to display solr document fields in catalog show view %>
-<div class="record-page-wrapper">
+<div class="record-page-wrapper clearfix">
   <% unless controller_name == "databases" %>
     <div class="record-view thumbnail float-md-left col-md-2"
       <%= isbn_data_attribute(document) %> >
@@ -9,11 +9,13 @@
     </div>
   <% end %>
 
-  <div class="ml-3">
+  <div class="float-md-right col-md-9">
     <%= render "show_primary_fields", :document => @document %>
     <%= render "show_availability_section", :document => @document %>
     <%= render "show_secondary_fields", :document => @document %>
+  </div>
 
+  <div class="float-md-right col-md-9 ml-0">
     <%= render "staff_view_link" %>
   </div>
 </div>

--- a/app/views/catalog/_show_primary_fields.html.erb
+++ b/app/views/catalog/_show_primary_fields.html.erb
@@ -1,6 +1,6 @@
 <% doc_presenter = show_presenter(document) %>
 
-<dl class="row document-metadata mb-0 show-page-list">
+<dl class="row document-metadata mb-0 show-page-list mb-3">
   <% document_show_primary_fields(document).each do |field_name, field| %>
     <% if should_render_show_field? document, field %>
       <dt class="blacklight-<%= field_name.parameterize %>col-xs-12 col-sm-3 col-md-3"><%= render_document_show_field_label document, field: field_name %></dt>

--- a/app/views/catalog/_show_secondary_fields.html.erb
+++ b/app/views/catalog/_show_secondary_fields.html.erb
@@ -1,11 +1,11 @@
 <% doc_presenter = show_presenter(document) %>
 
-<div class="offset-md-2 no-gutters pl-1 secondary-fields-header">
+<div class="no-gutters pl-1 secondary-fields-header">
   <h5>Description</h5>
   <hr />
 </div>
 
-<dl class="row document-metadata mb-0 show-page-list offset-md-2 no-gutters pl-1">
+<dl class="row document-metadata mb-0 show-page-list no-gutters pl-1">
   <% document_show_secondary_fields(document).each do |field_name, field| %>
     <% if should_render_show_field? document, field %>
       <dt class="blacklight-<%= field_name.parameterize %>col-xs-12 col-sm-3 col-md-3"><%= render_document_show_field_label document, field: field_name %></dt>

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe CatalogHelper, type: :helper do
     context "document has purchase order and user is logged in" do
       it "should render the purchase order button" do
         expect(helper).to have_received(:content_tag).with(
-          :div, "render_login_link", class: "requests-container"
+          :div, "render_login_link", class: "requests-container mb-2 ml-0"
         )
       end
     end


### PR DESCRIPTION
- Aligns all types of availability content (purchase order, online, etc)
- Fixes content displaying incorrectly in safari browser
- Aligns staff link with the rest of the content
- Adjusts css classes for availability displays