### PR TITLE
BL-926 Description form updates

### DIFF
--- a/app/javascript/packs/controllers/form_controller.js
+++ b/app/javascript/packs/controllers/form_controller.js
@@ -36,7 +36,7 @@ export default class extends Controller {
     if(options) {
       $(this.pickupsTarget).html(options);
     } else {
-      $(this.pickupsTarget).empty();
+      $(this.pickupsTarget);
     }
   }
 }

--- a/app/views/almaws/_asrs_request_form.html.erb
+++ b/app/views/almaws/_asrs_request_form.html.erb
@@ -29,6 +29,17 @@
       </div>
     <% end %>
 
+    <% if @material_types.present? && @material_types.count > 1 %>
+      <div class="row">
+        <div class="col-sm-4 col-md-6 hold-form form-group">
+          <%= label("", :material_type, t("requests.form.material_type")) %>
+          <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, "aria-required": true }, {class: "request-form form-control"}) %>
+        </div>
+      </div>
+    <% else %>
+      <%= form.hidden_field :material_type, value: @material_types %>
+    <% end %>
+
     <% if @asrs_request_level == "item" %>
       <% if @asrs_description.count > 1 %>
         <div class="row">
@@ -49,17 +60,6 @@
         </div>
       </div>
 
-    <% end %>
-
-    <% if @material_types.present? && @material_types.count > 1 %>
-      <div class="row">
-        <div class="col-sm-4 col-md-6 hold-form form-group">
-          <%= label("", :material_type, t("requests.form.material_type")) %>
-          <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, "aria-required": true }, {class: "request-form form-control"}) %>
-        </div>
-      </div>
-    <% else %>
-      <%= form.hidden_field :material_type, value: @material_types %>
     <% end %>
 
     <div class="row hold-form">

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -7,11 +7,6 @@
     <%= form.hidden_field :user_id, value: @user_id %>
     <%= form.hidden_field :request_level, value: @request_level %>
 
-    <% if @description.count == 1 %>
-      <%= form.hidden_field :hold_description, value: @description %>
-    <% end %>
-
-
     <% if @equipment.empty?  && @request_level == "bib" %>
       <div class="row">
         <div class="col-sm-4 col-md-6 hold-form form-group">
@@ -30,6 +25,17 @@
       </div>
     <% end %>
 
+    <% if @material_types.present? && @material_types.count > 1 %>
+      <div class="row">
+        <div class="col-sm-4 col-md-6 hold-form form-group">
+          <%= label("", :material_type, t("requests.form.material_type")) %>
+          <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, "aria-required": true }, {class: "request-form form-control"}) %>
+        </div>
+      </div>
+    <% else %>
+      <%= form.hidden_field :material_type, value: @material_types %>
+    <% end %>
+
     <% if @request_level == "item" %>
       <% if @description.count > 1 %>
         <div class="row">
@@ -40,7 +46,7 @@
           </div>
         </div>
       <% else %>
-        <%= form.hidden_field :digitization_description, value: @description %>
+        <%= form.hidden_field :hold_description, value: @description %>
       <% end %>
 
       <div class="row">
@@ -49,17 +55,6 @@
           <%= select_tag(:hold_pickup_location, grouped_options_for_select(item_level_library_name(@item_level_locations)), { data: { "target": "form.pickups" },  class: "request-form form-control", include_blank: true, required: true, "aria-required": true }) %>
         </div>
       </div>
-    <% end %>
-
-    <% if @material_types.present? && @material_types.count > 1 %>
-      <div class="row">
-        <div class="col-sm-4 col-md-6 hold-form form-group">
-          <%= label("", :material_type, t("requests.form.material_type")) %>
-          <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, "aria-required": true }, {class: "request-form form-control"}) %>
-        </div>
-      </div>
-    <% else %>
-      <%= form.hidden_field :material_type, value: @material_types %>
     <% end %>
 
     <div class="row hold-form">


### PR DESCRIPTION
- The javascript method that returns pickup locations used to be set to empty when no description was selected. This updates the method to display the pickup locations.
- Moves material type above descirption on the ASRS and hold request forms
- Removes unnecessary hidden field code from hold request form
- Fixes a bug that was calling digitization_description instead of hold_descirption in the hold form