### PR TITLE
BL-956 Availability sort order

### DIFF
--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -153,6 +153,7 @@ module AvailabilityHelper
   def sort_order_for_holdings(grouped_items)
     sorted_library_hash = {}
     sorted_library_hash.merge!("MAIN" => grouped_items.delete("MAIN")) if grouped_items.has_key?("MAIN")
+    sorted_library_hash.merge!("ASRS" => grouped_items.delete("ASRS")) if grouped_items.has_key?("ASRS")
     items_hash = grouped_items.sort_by { |k, v| library_name_from_short_code(k) }.to_h
     sorted_library_hash = sorted_library_hash.merge!(items_hash)
     sorted_library_hash.each do |lib, items|

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -540,31 +540,46 @@ RSpec.describe AvailabilityHelper, type: :helper do
   describe "#sort_order_for_holdings(grouped_items)" do
     context "items are sorted by library name with Paley first" do
       let(:grouped_items) do { "AMBLER" =>
-  [{ "item_pid" => "23239405700003811",
-    "item_policy" => "0",
-    "permanent_library" => "AMBLER",
-    "permanent_location" => "stacks",
-    "current_library" => "AMBLER",
-    "current_location" => "stacks",
-    "call_number_type" => "0",
-    "call_number" => "F159.P7 C66 2003",
-    "holding_id" => "22239405730003811",
-    "availability" => "<span class=\"check\"></span>Available" }],
- "MAIN" =>
-  [{ "item_pid" => "23239405740003811",
-    "item_policy" => "0",
-    "permanent_library" => "MAIN",
-    "permanent_location" => "stacks",
-    "current_library" => "MAIN",
-    "current_location" => "stacks",
-    "call_number_type" => "0",
-    "call_number" => "F159.P7 C66 2003",
-    "holding_id" => "22239405750003811",
-    "availability" => "<span class=\"check\"></span>Available" }] }
+        [{ "item_pid" => "23239405700003811",
+          "item_policy" => "0",
+          "permanent_library" => "AMBLER",
+          "permanent_location" => "stacks",
+          "current_library" => "AMBLER",
+          "current_location" => "stacks",
+          "call_number_type" => "0",
+          "call_number" => "F159.P7 C66 2003",
+          "holding_id" => "22239405730003811",
+          "availability" => "<span class=\"check\"></span>Available" }],
+        "ASRS" =>
+            [{ "item_pid" => "23239405700003811",
+              "item_policy" => "0",
+              "permanent_library" => "ASRS",
+              "permanent_location" => "bookbot",
+              "current_library" => "ASRS",
+              "current_location" => "bookbot",
+              "call_number_type" => "0",
+              "call_number" => "F159.P7 C66 2003",
+              "holding_id" => "22239405730003811",
+              "availability" => "<span class=\"check\"></span>Available" }],
+       "MAIN" =>
+        [{ "item_pid" => "23239405740003811",
+          "item_policy" => "0",
+          "permanent_library" => "MAIN",
+          "permanent_location" => "stacks",
+          "current_library" => "MAIN",
+          "current_location" => "stacks",
+          "call_number_type" => "0",
+          "call_number" => "F159.P7 C66 2003",
+          "holding_id" => "22239405750003811",
+          "availability" => "<span class=\"check\"></span>Available" }] }
       end
 
       it "returns Paley first, then Ambler" do
-        expect(sort_order_for_holdings(grouped_items).keys).to eq(["MAIN", "AMBLER"])
+        expect(sort_order_for_holdings(grouped_items).keys).to eq(["MAIN", "ASRS", "AMBLER"])
+      end
+
+      it "returns ASRS second" do
+        expect(sort_order_for_holdings(grouped_items).keys).to eq(["MAIN", "ASRS", "AMBLER"])
       end
     end
 

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -538,7 +538,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
   end
 
   describe "#sort_order_for_holdings(grouped_items)" do
-    context "items are sorted by library name with Paley first" do
+    context "items are sorted by library name with Charles first" do
       let(:grouped_items) do { "AMBLER" =>
         [{ "item_pid" => "23239405700003811",
           "item_policy" => "0",
@@ -574,7 +574,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
           "availability" => "<span class=\"check\"></span>Available" }] }
       end
 
-      it "returns Paley first, then Ambler" do
+      it "returns Charles first, then Ambler" do
         expect(sort_order_for_holdings(grouped_items).keys).to eq(["MAIN", "ASRS", "AMBLER"])
       end
 


### PR DESCRIPTION
- Items in the ASRS should display directly after MAIN and before the other libraries