### PR TITLE
Bl 936 remove breadcrumbs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,7 +98,6 @@ gem "browser"
 gem "blacklight-ris", git: "https://github.com/upenn-libraries/blacklight-ris.git"
 gem "bootstrap-select-rails"
 gem "httparty"
-gem "breadcrumbs_on_rails"
 
 gem "traject", "~> 3.1"
 gem "traject_plus"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,6 @@ GEM
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
     bootstrap-select-rails (1.13.8)
-    breadcrumbs_on_rails (3.0.1)
     browser (2.6.1)
     builder (3.2.3)
     byebug (11.0.1)
@@ -571,7 +570,6 @@ DEPENDENCIES
   bootsnap
   bootstrap (~> 4.3)
   bootstrap-select-rails
-  breadcrumbs_on_rails
   browser
   byebug
   capybara (= 3.28.0)

--- a/app/assets/javascripts/listeners.js
+++ b/app/assets/javascripts/listeners.js
@@ -40,10 +40,6 @@ $(document).ready(function(){
 		{id: "navbar_articles", category: "navigation"},
 		{id: "navbar_journals", category: "navigation"},
 		{id: "navbar_more", category: "navigation"},
-		{id: "breadcrumbs_book", category: "navigation"},
-		{id: "breadcrumbs_record", category: "navigation"},
-		{id: "breadcrumbs_article", category: "navigation"},
-		{id: "breadcrumbs_journal", category: "navigation"},
 		{id: "request_options", category: "search-results"},
 		{id: "request-btn-0", category: "search-results"}
 	];

--- a/app/assets/stylesheets/tucob.scss.erb
+++ b/app/assets/stylesheets/tucob.scss.erb
@@ -9,20 +9,9 @@ body {
   padding-bottom: 5.125rem !important;
 }
 
-.breadcrumb {
-  background-color: transparent;
-  font-size: 0.875rem;
-}
-
 .form-control:focus {
   border-color: gray;
   box-shadow: inset 0 0.0625rem 0.0625rem rgba(96, 96, 96, 0.075), 0 0 0.5rem rgba(96, 96, 96, 0.6);
-}
-
-.breadcrumb > li + li:before {
-    color: $med-grey;
-    content: "/";
-    padding: 0 0.3125rem;
 }
 
 #documents {

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -14,12 +14,6 @@ class CatalogController < ApplicationController
   before_action :authenticate_purchase_order!, only: [ :purchase_order, :purchase_order_action ]
   before_action :set_thread_request
 
-  add_breadcrumb "More", :back_to_catalog_path, only: [ :show ], if: :catalog?
-  add_breadcrumb "More", :back_to_catalog_path, if: :advanced_controller?
-  add_breadcrumb "Record", :solr_document_path, only: [ :show ], if: :catalog?
-  add_breadcrumb I18n.t(:catalog_advanced_search), :advanced_search_path,
-    only: [ :index ], if: :advanced_controller?
-
   helper_method :browse_creator
   helper_method :display_duration
 

--- a/app/controllers/databases_advanced_controller.rb
+++ b/app/controllers/databases_advanced_controller.rb
@@ -8,10 +8,6 @@ class DatabasesAdvancedController < AdvancedController
     config.add_facet_field "az_format", field: "format", label: "Database Type"
   end
 
-  add_breadcrumb "Databases", :back_to_databases_path, options: { id: "breadcrumbs_databases" }
-  add_breadcrumb I18n.t(:databases_advanced_search), :databases_advanced_search_path,
-    only: [ :index ]
-
   protected
     def search_action_url(options = {})
       databases_advanced_search_path(options.merge(action: "index"))

--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -5,9 +5,6 @@ class DatabasesController < CatalogController
 
   helper_method :join
 
-  add_breadcrumb "Databases", :back_to_databases_path, options: { id: "breadcrumbs_database" }, only: [ :show ]
-  add_breadcrumb "Record", :solr_database_document_path, only: [ :show ]
-
   configure_blacklight do |config|
     config.advanced_search[:fields_row_count] = 2
     config.advanced_search[:form_solr_parameters]["facet.field"] = %w(subject_facet format)

--- a/app/controllers/journals_advanced_controller.rb
+++ b/app/controllers/journals_advanced_controller.rb
@@ -3,10 +3,6 @@
 class JournalsAdvancedController < AdvancedController
   copy_blacklight_config_from(JournalsController)
 
-  add_breadcrumb "Journals", :back_to_journals_path, options: { id: "breadcrumbs_journal" }
-  add_breadcrumb I18n.t(:journals_advanced_search), :journals_advanced_search_path,
-    only: [ :index ]
-
   protected
     def search_action_url(options = {})
       journals_advanced_search_path(options.merge(action: "index"))

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class JournalsController < CatalogController
-  add_breadcrumb "Journals", :back_to_journals_path, options: { id: "breadcrumbs_journal" }, only: [ :show ]
-  add_breadcrumb "Record", :solr_journal_document_path, only: [ :show ]
-
   configure_blacklight do |config|
     config.show.route = { controller: "journals" }
     config.search_builder_class = JournalsSearchBuilder

--- a/app/controllers/primo_advanced_controller.rb
+++ b/app/controllers/primo_advanced_controller.rb
@@ -2,8 +2,4 @@
 
 class PrimoAdvancedController < PrimoCentralController
   copy_blacklight_config_from(PrimoCentralController)
-
-  add_breadcrumb "Articles", :back_to_articles_path, options: { id: "breadcrumbs_article" }
-  add_breadcrumb I18n.t(:articles_advanced_search), :articles_advanced_search_path,
-    only: [ :index ]
 end

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -5,9 +5,6 @@ class PrimoCentralController < CatalogController
   include CatalogConfigReinit
   include Blacklight::Document::Export
 
-  add_breadcrumb "Articles", :back_to_articles_path, options: { id: "breadcrumbs_article" }, only: [ :show ]
-  add_breadcrumb "Record", :primo_central_document_path, only: [ :show ]
-
   helper_method :browse_creator
   helper_method :tags_strip
   helper_method :solr_range_queries_to_a

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -1,26 +1,17 @@
 <% @page_title = "#{ advanced_search_form_title } - #{application_name}" %>
 
-<div class="breadcrumb-wrapper">
-  <ol class="breadcrumb">
-    <%= render_breadcrumbs :tag => :li, :separator => "" %>
-  </ol>
-</div>
-
 <div class="advanced-search-form col-sm-12 bg-white rounded p-4">
+  <h2 class="advanced page-header mb-3">
+    <%= advanced_search_form_title %>
+  </h2>
 
-    <h2 class="advanced page-header mb-3">
-        <%= advanced_search_form_title %>
-    </h2>
-
-    <div class="row">
-
-        <div class="col-md-8">
-            <%= render 'advanced_search_form' %>
-        </div>
-        <div class="col-md-4">
-            <%= render "advanced_search_help" %>
-        </div>
-
+  <div class="row">
+    <div class="col-md-8">
+      <%= render 'advanced_search_form' %>
     </div>
-
+    
+    <div class="col-md-4">
+      <%= render "advanced_search_help" %>
+    </div>
+  </div>
 </div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -4,12 +4,6 @@
 <% @search_context ||= current_search_session %>
 
 <div id="record-page-container">
-  <div class="breadcrumb-wrapper">
-    <ol class="breadcrumb">
-      <%= render_breadcrumbs :tag => :li, :separator => "" %>
-    </ol>
-  </div>
-
   <div id="record-page-content" class="col-12">
     <%= render_document_main_content_partial %>
   </div>

--- a/app/views/primo_advanced/index.html.erb
+++ b/app/views/primo_advanced/index.html.erb
@@ -1,28 +1,18 @@
 <div id="stimulus-warning" class="alert alert-danger"></div>
 
-<div class="breadcrumb-wrapper">
-  <ol class="breadcrumb">
-    <%= render_breadcrumbs :tag => :li, :separator => "" %>
-  </ol>
-</div>
-
 <% @page_title = "Articles Advanced Search - #{application_name}" %>
 
 <div class="advanced-search-form primo-advanced-form col-sm-12 bg-white rounded p-4">
+  <h2 class="advanced page-header">
+    <%= t("blacklight_advanced_search.articles_title") %>
+  </h2>
 
-    <h2 class="advanced page-header">
-        <%= t("blacklight_advanced_search.articles_title") %>
-    </h2>
-
-    <div class="row">
-
-        <div class="col-md-8" data-controller="primo">
-            <%= render "advanced_search_form" %>
-        </div>
-        <div class="col-md-4">
-            <%= render "advanced_search_help" %>
-        </div>
-
+  <div class="row">
+    <div class="col-md-8" data-controller="primo">
+      <%= render "advanced_search_form" %>
     </div>
-
+    <div class="col-md-4">
+      <%= render "advanced_search_help" %>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
- We were currently displaying breadcrumbs for individual record pages and advanced search pages.  The decision was made to get rid of them, so this removes breadcrumb-related code.