### PR TITLE
BL-959 Requests bug

### DIFF
--- a/app/views/almaws/_asrs_request_form.html.erb
+++ b/app/views/almaws/_asrs_request_form.html.erb
@@ -37,7 +37,7 @@
         </div>
       </div>
     <% else %>
-      <%= form.hidden_field :material_type, value: @material_types %>
+      <%= form.hidden_field :material_type, value: @material_types.collect { |mat| [ mat.values.first ] }  %>
     <% end %>
 
     <% if @asrs_request_level == "item" %>

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -19,7 +19,7 @@
         </div>
       </div>
     <% else %>
-      <%= form.hidden_field :material_type, value: @material_types %>
+      <%= form.hidden_field :material_type, value: @material_types.collect { |mat| [ mat.values.first ] }  %>
     <% end %>
 
     <% if @description.count > 1 %>

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -33,7 +33,7 @@
         </div>
       </div>
     <% else %>
-      <%= form.hidden_field :material_type, value: @material_types %>
+      <%= form.hidden_field :material_type, value: @material_types.collect { |mat| [ mat.values.first ] } %>
     <% end %>
 
     <% if @request_level == "item" %>


### PR DESCRIPTION
- Some requests were not going through to alma.  The problem is with the material types when being passed as a hidden field.  The data was in a form that alma was not able to recognize, so it rejected the request.  This updates the hidden field to return the value of the material type.