### PR TITLE
BL-951 Add back logout option

### DIFF
--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -96,7 +96,8 @@
 }
 
 .navbar-form,
-#bookmarks_nav {
+#bookmarks_nav,
+.user-logout {
 	font-size: 1rem;
 	padding-left: 2rem;
 	width: 10rem;

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -23,7 +23,11 @@
   </div>
 <% end %>
 
-<div class="d-inline-flex justify-content-around search-right-links">
+<div class="d-inline-flex justify-content-around search-right-links align-items-center">
   <%= render "advanced_search_link" %>
   <%= render_bookmark_partial %>
+
+  <% if has_user_authentication_provider? %>
+    <%= render 'shared/nav_bar_login_links' unless login_disabled? %>
+  <% end %>
 </div>

--- a/app/views/shared/_nav_bar_login_links.html.erb
+++ b/app/views/shared/_nav_bar_login_links.html.erb
@@ -1,9 +1,5 @@
 <% if current_user %>
-    <li class="user-links">
+    <div class="user-logout">
       <%= link_to t('blacklight.header_links.logout'), destroy_user_session_path(type: session[:alma_auth_type]), :method => 'delete', id: "logout" %>
-    </li>
-<% else %>
-    <li class="user-links">
-      <%= link_to t('blacklight.header_links.login'), new_user_session_with_redirect_path(users_account_path), data: {"blacklight-modal": "trigger"}, id: "login" %>
-    </li>
+    </div>
 <% end %>


### PR DESCRIPTION
- With the recent design changes, the logout button was removed.  This adds the button back in next to bookmarks.
- The nav_bar_login template was updated to not display the login option since that link is being generated in the main menu navbar.