### PR TITLE
BL-959 ASRS request bug

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -46,7 +46,7 @@ class AlmawsController < CatalogController
     @booking_location = CobAlma::Requests.booking_location(@items)
     @material_types = CobAlma::Requests.physical_material_type(@items).compact
     @pickup_locations = params[:pickup_location].split(",").collect { |lib| { lib => helpers.library_name_from_short_code(lib) } }
-    @asrs_pickup_locations = CobAlma::Requests.asrs_pickup_locations
+    @asrs_pickup_locations = CobAlma::Requests.asrs_pickup_locations.collect { |lib| { lib => helpers.library_name_from_short_code(lib) } }
     @user_id = current_user.uid
     @request_level = params[:request_level]
     @asrs_request_level = get_request_level(@items, "asrs")

--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -28,7 +28,7 @@ module CobAlma
     end
 
     def self.asrs_pickup_locations
-      ["Charles Library (wait time: up to 1 hour)", "Ambler Campus Library (wait time: 2-3 days)", "Ginsburg Health Science Library (wait time: 2-3 days)", "Podiatry Library (wait time: 2-3 days)", "Harrisburg Campus Library (wait time: 2-3 days)"]
+      ["MAIN", "AMBLER", "GINSBURG", "PODIATRY", "HARRISBURG"]
     end
 
     def self.remove_by_campus(campus)

--- a/app/views/almaws/_asrs_request_form.html.erb
+++ b/app/views/almaws/_asrs_request_form.html.erb
@@ -15,7 +15,7 @@
       <div class="row">
         <div class="col-sm-4 col-md-6 hold-form form-group">
           <%= label("", :asrs_pickup_location, t("requests.form.pickup_locations_label")) %>
-          <%= select("", :asrs_pickup_location, @asrs_pickup_locations.collect { |lib| [ lib ] }, { selected: @asrs_pickup_locations.first, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
+          <%= select("", :asrs_pickup_location, @asrs_pickup_locations.collect { |lib| [ lib.values.first, lib.keys.first ] }, { selected: @asrs_pickup_locations.first, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
         </div>
       </div>
     <% end %>
@@ -56,7 +56,7 @@
       <div class="row">
         <div class="col-sm-4 col-md-6 hold-form form-group">
           <%= label("", :asrs_pickup_location, t("requests.form.pickup_locations_label")) %>
-          <%= select("", :asrs_pickup_location, @asrs_pickup_locations.collect { |lib| [ lib ] }, { selected: @asrs_pickup_locations.first, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
+          <%= select("", :asrs_pickup_location, @asrs_pickup_locations.collect { |lib| [ lib.values.first, lib.keys.first ] }, { selected: @asrs_pickup_locations.first, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
         </div>
       </div>
 

--- a/spec/lib/cob_alma/requests_spec.rb
+++ b/spec/lib/cob_alma/requests_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe CobAlma::Requests do
 
   describe "#asrs_pickup_locations" do
     it "displays MAIN as the pickup_location" do
-      expect(described_class.asrs_pickup_locations).to eq(["Charles Library (wait time: up to 1 hour)", "Ambler Campus Library (wait time: 2-3 days)", "Ginsburg Health Science Library (wait time: 2-3 days)", "Podiatry Library (wait time: 2-3 days)", "Harrisburg Campus Library (wait time: 2-3 days)"])
+      expect(described_class.asrs_pickup_locations).to eq(["MAIN", "AMBLER", "GINSBURG", "PODIATRY", "HARRISBURG"])
     end
   end
 


### PR DESCRIPTION
- Hard coding the wait times into the pickup locations list means that the request does not go through to alma since it doesn't know how to handle that text.  This removes the extra explanation and goes back to the original method.