### PR TITLE
BL-966 SCRC availability

### DIFF
--- a/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
+++ b/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
@@ -19,9 +19,10 @@ var BlacklightAlma = function (options) {
 
 
  availabilityButton = function(id, holding) {
+   var hiddenLibraries = ["Special Collections Research Center"] // Temporary change until SCRC opens
    var availButton = $("button[data-availability-ids='" + id + "']");
    if (!$(availButton).hasClass("btn-success")) {
-     if(holding['availability'] == 'available') {
+   if(holding['availability'] == 'available' && hiddenLibraries.includes(holding['library']) == false) {
        $(availButton).html("<span class='avail-label available'>Available</span>");
        $(availButton).removeClass("btn-default");
        $(availButton).addClass("btn-success collapsed collapse-button available");
@@ -61,7 +62,8 @@ var BlacklightAlma = function (options) {
    var availability = holding['availability'];
 
    if (library != "EMPTY") {
-     if (availability == "available")  {
+     var hiddenLibraries = ["Special Collections Research Center"] // Temporary change until SCRC opens
+     if (availability == "available" && hiddenLibraries.includes(holding['library']) == false) {
        availItem = {};
        Object.assign(availItem, {library, availability})
        return availItem;

--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -6,7 +6,12 @@ module AvailabilityHelper
   PHYSICAL_TYPE_EXCLUSIONS = /BOOK|ISSUE|SCORE|KIT|MAP|ISSBD|GOVRECORD|OTHER/i
 
   def availability_status(item)
-    if item.in_place? && item.item_data["requested"] == false
+    unavailable_libraries = ["SCRC"]
+    # Temporary change to display SCRC items as unavailable until it opens
+
+    if unavailable_libraries.include?(item.library)
+      content_tag(:span, "", class: "close-icon") + "Not available pending move"
+    elsif item.in_place? && item.item_data["requested"] == false
       if item.non_circulating? || item.location == "reserve" ||
           item.circulation_policy == "Bound Journal" ||
           item.circulation_policy == "Music Restricted"


### PR DESCRIPTION
- SCRC items need to display as unavailable until the research room opens
- This hides the available at display in the search results, makes the button display unavailable for SCRC items, and updates the availaibility message for SCRC items