### PR TITLE
BL-964 MAIN stacks should be requestable at Charles

### DIFF
--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -7,7 +7,7 @@ module CobAlma
   module Requests
     def self.determine_campus(item)
       case item
-      when  "LAW", "PRESSER", "MAIN", "ASRS"
+      when  "LAW", "PRESSER", "ASRS" #MAIN was temporarily removed from this list until the 4th floor opens
         :MAIN
       when "AMBLER"
         :AMBLER
@@ -34,7 +34,7 @@ module CobAlma
     def self.remove_by_campus(campus)
       case campus
       when :MAIN
-        [ "LAW", "MEDIA", "PRESSER", "MAIN", "ASRS"]
+        [ "LAW", "MEDIA", "PRESSER", "ASRS"] #MAIN was temporarily removed from this list until the 4th floor opens
       when :AMBLER
         ["AMBLER"]
       when :HSL


### PR DESCRIPTION
- Until the fourth floor opens, MAIN stacks and Juvenile collections need to be available for pickup at Charles.  
- This removes Charles from the MAIN campus so that items can be picked up there
- It retains the logic for the rest of the campuses