### PR TITLE
BL-964 Location changes

### DIFF
--- a/config/locations.yml
+++ b/config/locations.yml
@@ -101,14 +101,14 @@ default: &default
     UNASSIGNED: Location information not available
   MAIN:
     ILL: Inter-Library Loan
-    juvenile: Juvenile
+    juvenile: Remote Storage
     leisure: Leisure Reading
     m_reserve: Media Reserves
     reference: LRS Consultation - Ask at Desk
     reserve: Reserves
     serials: Journals
     servicedsk: Service Desk
-    stacks: Stacks
+    stacks: Remote Storage
     techserv: Technical Services
     govdocmicr: Government Doc Microforms
     govdoc: Government Documents

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -654,7 +654,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
 
       it "returns copies for each library by location" do
         sorted_locations = sort_order_for_holdings(grouped_items)["MAIN"].map { |item| location_name_from_short_code(item) }
-        expect(sorted_locations).to eq(["Journals", "LRS Consultation - Ask at Desk", "Stacks"])
+        expect(sorted_locations).to eq(["Journals", "LRS Consultation - Ask at Desk", "Remote Storage"])
       end
     end
 


### PR DESCRIPTION
- Updates the external names for Stacks and Juvenile to temporarily display as Remote Storage until the 4th floor opens