### PR TITLE
BL-965 Temporary storage items

### DIFF
--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -7,10 +7,14 @@ module AvailabilityHelper
 
   def availability_status(item)
     unavailable_libraries = ["SCRC"]
-    # Temporary change to display SCRC items as unavailable until it opens
+    unavailable_locations = ["storage"]
 
+    # Temporary change to display SCRC items as unavailable until it opens
     if unavailable_libraries.include?(item.library)
       content_tag(:span, "", class: "close-icon") + "Not available pending move"
+    # Temporary change for items that don't currently fit in the ASRS bins
+    elsif unavailable_locations.include?(item.location)
+      content_tag(:span, "", class: "close-icon") + "Temporarily unavailable"
     elsif item.in_place? && item.item_data["requested"] == false
       if item.non_circulating? || item.location == "reserve" ||
           item.circulation_policy == "Bound Journal" ||

--- a/config/locations.yml
+++ b/config/locations.yml
@@ -116,6 +116,7 @@ default: &default
     micro: Microform
     rarestacks: Remote
     UNASSIGNED: 'Problem: See Library Staff'
+    storage: "Main Storage"
   PODIATRY:
     intref: Internal Reference
     leisure: Leisure Reading


### PR DESCRIPTION
- Items that don't fit in the ASRS should display Main Storage as the location
- They should display Temporarily unavailable as the avail_status
- This will require a restart of the application, but not a reindex