### PR TITLE
BL-974 Mobile facets bug

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -47,27 +47,39 @@ $(window).on('turbolinks:load', function() {
 		$('#nav-tools').insertAfter('#page-links');
 		$('#bookmarks-tools').addClass('row');
 		$('#facet-filter-icon').addClass('hidden');
-		$('#facet-panel-collapse').addClass('show');
 	}
 });
 
-$(window).on('resize', function() {
-	if ($(window).width() < 768) {
-		$('#nav-tools').insertAfter('#document');
-		$('#bookmarks-tools').insertAfter('#documents');
-		$('#bookmarks-tools').removeClass('row');
-		$('.clear-bookmarks').insertAfter('#back_to_search');
-		$('#facet-filter-icon').removeClass('hidden');
-		$('#facet-panel-collapse').removeClass('show');
-	}
-	else {
-		$('#nav-tools').insertAfter('#page-links');
-		$('#bookmarks-tools').addClass('row');
-		$('#facet-filter-icon').addClass('hidden');
-		$('#facet-panel-collapse').addClass('show');
-	}
-});
+$(document).ready(function() {
 
+	// This is necessary because iOS is triggering the resize event when an element is clicked.
+	// More information about this solution can be found here: https://stackoverflow.com/a/24212316/256854
+
+  var origWindowWidth = $(window).width();
+  $(window).on('resize', function() {
+    var windowWidth = $(window).width();
+
+    // ShortCircuit if this is not a real resize.
+    if (windowWidth == origWindowWidth) {
+      return;
+    }
+
+    if (windowWidth < 768) {
+      $('#nav-tools').insertAfter('#document');
+      $('#bookmarks-tools').insertAfter('#documents');
+      $('#bookmarks-tools').removeClass('row');
+      $('.clear-bookmarks').insertAfter('#back_to_search');
+      $('#facet-filter-icon').removeClass('hidden');
+      $('#facet-panel-collapse').removeClass('show');
+    }
+    else {
+      $('#nav-tools').insertAfter('#page-links');
+      $('#bookmarks-tools').addClass('row');
+      $('#facet-filter-icon').addClass('hidden');
+      $('#facet-panel-collapse').addClass('show');
+    }
+	});
+});
 
 $(document).on('turbolinks:load', function() {
    $(window).trigger('load.bs.select.data-api');

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -24,7 +24,7 @@
 
    <%= render "constraints" %>
 
-   <div id="facet-panel-collapse" class="facets-collapse collapse">
+   <div id="facet-panel-collapse" class="facets-collapse collapse show">
      <%= has_search_parameters? ? render_facet_partials : render_home_facets %>
    </div>
    <%= render_solr_search_tweaks %>


### PR DESCRIPTION
- There is currently a bug in production that is causing the facet collapse to work in strange ways. Sometimes it doesn't allow you to select a facet, sometimes the facets disappear and you need to click on the filter icon again.
- This is difficult to debug because we don't see any of these behaviors using the web dev tools in chrome or safari.
- This is an attempt to show the collapse menu on document load rather than turbolinks load to see if that solves the problem.