### PR TITLE
BL-975 Background scrolling

### DIFF
--- a/app/assets/stylesheets/tucob.scss.erb
+++ b/app/assets/stylesheets/tucob.scss.erb
@@ -3,6 +3,15 @@
 /* === GENERAL STYLES === */
 body {
   font-size: 0.875rem;
+
+  // This prevents the background from scrolling when a modal is open
+  .modal-open {
+    bottom: 0;
+    left: 0;
+    position: fixed;
+    right: 0;
+    top: 0;
+  }
 }
 
 #main-container {


### PR DESCRIPTION
- There is an issue on mobile phones where the user can scroll past the open modal into the background and it is difficult to get focus back into the modal.  This adds styling to prevent background scrolling when a modal is open.