### PR TITLE
adding verbose flag to prod deploy for tracking down assets error

### DIFF
--- a/.circleci/deploy-prod.sh
+++ b/.circleci/deploy-prod.sh
@@ -11,5 +11,5 @@ cp .circleci/.vault ~/.vault # setup vault password retrieval from travis envvar
 chmod +x ~/.vault  # setup vault password retrieval from travis envvar
 
 # deploy to qa using ansible-playbook
-pipenv run ansible-playbook -i inventory/prod/hosts playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' --private-key=~/.ssh/.conan_the_deployer --limit=app
+pipenv run ansible-playbook -i inventory/prod/hosts playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' --private-key=~/.ssh/.conan_the_deployer --limit=app -vv
 echo "BE AWARE THAT SOLR CONFIG CHANGES WERE NOT DEPLOYED AS PART OF THIS BUILD"


### PR DESCRIPTION
Depends on running next prod deploy in circle. Will give ansible logs along with already logged output.