### PR TITLE
BL-990 Request Options bug

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -37,7 +37,7 @@ class AlmawsController < CatalogController
     @mms_id = params[:mms_id]
     _, @document = begin search_service.fetch(@mms_id) rescue [ nil, SolrDocument.new({}) ] end
     log = { type: "alma_bib_item", mms_id: @mms_id }
-    @items = do_with_json_logger(log) { Alma::BibItem.find(@mms_id, limit: 100) }
+    @items = do_with_json_logger(log) { Alma::BibItem.find(@mms_id, limit: 100) }.filter_missing_and_lost
     @books = CobAlma::Requests.physical_material_type(@items).collect { |item| item["value"] if item["value"].include?("BOOK") }.compact
     @author = @items.map { |item| item["bib_data"]["author"].to_s }.first
     @description = CobAlma::Requests.descriptions(@items)


### PR DESCRIPTION
- We are not currently filtering out missing and lost items from the request options method in the controller.  This sometimes results in patrons not seeing the correct request options.  This adds the filter_missing_and_lost method to items