### PR TITLE
Bl 972 accessibility review Part 1

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -52,6 +52,10 @@ $(window).on('turbolinks:load', function() {
 
 $(document).ready(function() {
 
+	$('.decorative').each(function() {
+    $(this).attr('alt', "");
+  });
+
 	// This is necessary because iOS is triggering the resize event when an element is clicked.
 	// More information about this solution can be found here: https://stackoverflow.com/a/24212316/256854
 

--- a/app/assets/stylesheets/partials/_mobilemenu.scss
+++ b/app/assets/stylesheets/partials/_mobilemenu.scss
@@ -112,6 +112,7 @@
 }
 
 .bar1, .bar2, .bar3 {
+	display: block;
   width: 1.5625rem;
   height: 0.125rem;
   background-color: $white;

--- a/app/assets/stylesheets/tucob.scss.erb
+++ b/app/assets/stylesheets/tucob.scss.erb
@@ -14,6 +14,29 @@ body {
   }
 }
 
+a.skip-main {
+    left: -999px;
+    position: absolute;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    z-index: -999;
+}
+a.skip-main:focus {
+    left: auto;
+    top: auto;
+    width: 30%;
+    height: auto;
+    overflow: auto;
+    margin: 0 35%;
+    padding: 5px;
+    font-size: 20px;
+    outline: 3px solid red;
+    text-align: center;
+    z-index: 999;
+}
+
 #main-container {
   padding-bottom: 5.125rem !important;
 }

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -118,7 +118,7 @@ module CatalogHelper
   def render_alma_availability(document)
     # We are checking index_fields["bound_with_ids"] because that is a field that is unique to catalog records
     # We do not want this to render if the item is from Primo, etc.
-    if index_fields["bound_with_ids"] &&  document.alma_availability_mms_ids.present?
+    if index_fields["bound_with_ids"] && document.alma_availability_mms_ids.present?
       content_tag :dl, nil, class: "row document-metadata blacklight-availability availability-ajax-load", "data-availability-ids": document.alma_availability_mms_ids.join(",")
     end
   end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -115,9 +115,11 @@ module CatalogHelper
     end
   end
 
-  def render_bound_with_ids(document)
-    if index_fields["bound_with_ids"] && document.alma_availability_mms_ids.present?
-      content_tag :span, nil, class: "row document-metadata blacklight-availability availability-ajax-load", "data-availability-ids": document.alma_availability_mms_ids.join(",")
+  def render_alma_availability(document)
+    # We are checking index_fields["bound_with_ids"] because that is a field that is unique to catalog records
+    # We do not want this to render if the item is from Primo, etc.
+    if index_fields["bound_with_ids"] &&  document.alma_availability_mms_ids.present?
+      content_tag :dl, nil, class: "row document-metadata blacklight-availability availability-ajax-load", "data-availability-ids": document.alma_availability_mms_ids.join(",")
     end
   end
 

--- a/app/views/application/_mobile_nav.html.erb
+++ b/app/views/application/_mobile_nav.html.erb
@@ -2,9 +2,9 @@
   <div id="menu-button" onclick="toggle('main')">
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mobile-menu" aria-controls="mobile-menu" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon" id="main-toggler-icon">
-      <div class="bar1"></div>
-      <div class="bar2"></div>
-      <div class="bar3"></div>
+      <span class="bar1"></span>
+      <span class="bar2"></span>
+      <span class="bar3"></span>
     </span>
     <span class="navbar-brand" id="main-navbar-brand">Main Menu</span>
   </button>
@@ -34,19 +34,19 @@
       </div>
       <div class="row">
         <div class="col">
-          <%= image_tag "person.png", class: "person-icon" %>
+          <%= image_tag "person.png", class: "person-icon decorative" %>
           <%= link_to "My Account", users_account_path %>
         </div>
       </div>
       <div class="row">
         <div class="col">
-          <%= image_tag "chat.png", class: "chat-icon" %>
+          <%= image_tag "chat.png", class: "chat-icon decorative" %>
           <%= link_to "Chat", "https://v2.libanswers.com/chati.php?hash=62e4dcbf0881db4f1514b077fbfd45b7&referer=http%3A%2F%2Flocalhost%3A3000%2Fhsl&referer_title=Temple%20University%20Libraries" %>
         </div>
       </div>
       <div class="row">
         <div class="col">
-          <%= image_tag "hours.png", class: "hours-icon" %>
+          <%= image_tag "hours.png", class: "hours-icon decorative" %>
           <%= link_to "Hours", "https://library.temple.edu/hours" %>
         </div>
       </div>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -1,5 +1,5 @@
-<nav class="path-links border-bottom border-light-grey bg-white" role="navigation">
-  <div class="d-md-flex justify-content-center text-center">
+<nav class="path-links border-bottom border-light-grey bg-white" aria-labelledby="secondary-menu">
+  <div id="secondary-menu" class="d-md-flex justify-content-center text-center">
     <%= render_nav_link(:everything_path, "Everything", "navbar_everything") %>
     <%= render_nav_link(:search_catalog_path, "Books & Media", "navbar_more") %>
     <%= render_nav_link(:search_path, "Articles", "navbar_articles") %>

--- a/app/views/catalog/_bookmark_control.html.erb
+++ b/app/views/catalog/_bookmark_control.html.erb
@@ -17,8 +17,8 @@
          absent: t("blacklight.search.bookmarks.absent"),
          inprogress: t("blacklight.search.bookmarks.inprogress")
       }) do %>
-        <%= hidden_field_tag("bookmarks[][document_id]", document.id)%>
-        <%= hidden_field_tag("bookmarks[][document_type]", document.class)%>
+        <%= hidden_field_tag("bookmarks[][document_id]", document.id, id: "bookmark_id_#{document.id.to_s.parameterize}]" )%>
+        <%= hidden_field_tag("bookmarks[][document_type]", document.class, id: "bookmark_class_#{document.id.to_s.parameterize}]")%>
           <%= submit_tag(t("blacklight.bookmarks.add.button"),
             :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "bookmark_add btn btn-sm btn-outline-secondary") %>
         <% end %>
@@ -34,8 +34,8 @@
            absent: t("blacklight.search.bookmarks.absent"),
            inprogress: t("blacklight.search.bookmarks.inprogress")
         }) do %>
-        <%= hidden_field_tag("bookmarks[][document_id]", document.id)%>
-        <%= hidden_field_tag("bookmarks[][document_type]", document.class)%>
+        <%= hidden_field_tag("bookmarks[][document_id]", document.id, id: "bookmark_id_#{document.id.to_s.parameterize}]")%>
+        <%= hidden_field_tag("bookmarks[][document_type]", document.class, id: "bookmark_class_#{document.id.to_s.parameterize}]")%>
           <%= submit_tag(t("blacklight.bookmarks.remove.button"),
             :id => "bookmark_toggle_#{document.id.to_s.parameterize}", :class => "bookmark_remove btn btn-sm btn-outline-secondary") %>
         <% end %>

--- a/app/views/catalog/_fields.html.erb
+++ b/app/views/catalog/_fields.html.erb
@@ -18,4 +18,4 @@
 <% end -%>
 </dl>
 
-<%= render_bound_with_ids(document) %>
+<%= render_alma_availability(document) %>

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -7,7 +7,7 @@
     <div data-controller="availability" data-availability-url="<%= item_url(document.alma_availability_mms_ids.first, doc_id: document.id, redirect_to: request.url) %>">
         <div class="controls">
         <button data-action="availability#item" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" class="btn btn-sm btn-default availability-toggle-details" data-toggle="collapse" data-target="#physical-document-<%=  document.id %>, availability.button" id="available_button-<%=  document.id %>" aria-expanded="false" aria-controls="physical-document-<%= document.id %>">
-          <i class="fa fa-spinner" role="spinbutton"></i>
+          <i class="fa fa-spinner" aria-busy="true" aria-live="polite"></i>
           <span>Loading...</span>
         </button>
 

--- a/app/views/catalog/_online_availability_button.html.erb
+++ b/app/views/catalog/_online_availability_button.html.erb
@@ -12,9 +12,9 @@
 <% elsif has_one_electronic_resource?(document) %>
   <div class="availability">
     <% if controller_name == "databases" %>
-      <a href="<%= single_link_builder(document["electronic_resource_display"].first) %>" class="collapse-button btn btn-sm databases-btn" title="This link opens the resource in a new tab", target="_blank" id:"single_link_online"><span class="avail-label">Go to Database<span></a>
+      <a href="<%= single_link_builder(document["electronic_resource_display"].first) %>" class="collapse-button btn btn-sm databases-btn" title="This link opens the resource in a new tab" target="_blank" id:"single_link_online"><span class="avail-label">Go to Database</span></a>
     <% else %>
-      <a href="<%= single_link_builder(document["electronic_resource_display"].first) %>" class="collapse-button btn btn-sm online-btn" title="This link opens the resource in a new tab", target="_blank" id:"single_link_online"><span class="avail-label">Online<span></a>
+      <a href="<%= single_link_builder(document["electronic_resource_display"].first) %>" class="collapse-button btn btn-sm online-btn" title="This link opens the resource in a new tab" target="_blank" id:"single_link_online"><span class="avail-label">Online</span></a>
     <% end %>
   </div>
 <% end %>

--- a/app/views/catalog/_online_availability_button.html.erb
+++ b/app/views/catalog/_online_availability_button.html.erb
@@ -1,6 +1,6 @@
 <% if has_many_electronic_resources?(document) %>
   <div class="row button-break"></div>
-  <button class="btn btn-sm online-btn collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document.id %>" id="many_links_online">
+  <button class="btn btn-sm online-btn collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document.id %>" id="online-<%=  document.id %>">
     <span class="avail-label" aria-expanded="false">Online</span>
   </button>
   <div id="online-document-<%= document.id %>" class="collapse online_resources online-list">

--- a/app/views/catalog/_physical_availability_card.html.erb
+++ b/app/views/catalog/_physical_availability_card.html.erb
@@ -31,7 +31,7 @@
           <!-- </div> -->
           <div class="d-sm-flex flex-sm-column align-self-center pl-md-4 pl-sm-0 avail-spinner-container">
             <div class="spinner">
-              <span class="fa fa-spinner" role="spinbutton"></span>
+              <span class="fa fa-spinner" aria-busy="true" aria-live="polite"></span>
               <span>Loading Availability</span>
             </div>
           </div>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -15,7 +15,6 @@
 
 <%= render "search_header" %>
 <span id="alma_availability_url" data-url="<%= alma_availability_url(format: :json) %>" ></span>
-<h2 class="sr-only"><%= t("blacklight.search.search_results") %></h2>
 
 <%- if empty_response?(@response) %>
   <%= render "zero_results" %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,7 +1,7 @@
 <div class="row pl-sm-5 pt-md-3 pb-5">
 
   <% if show_sidebar? %>
-    <div id="sidebar" class="col-md-4 col-lg-3">
+    <div id="sidebar" class="col-md-4 col-lg-3" role="complementary">
       <% if controller_name == "databases" %>
         <div class="mb-3 text-center">
           <%= link_to(t("databases.link_text"), t("databases.link_href"), class: "database-browse-link") %>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -40,7 +40,7 @@
 
       <%= render partial: "shared/modal" %>
 
-      <div id="main-container" class="col-sm-10 col-md-12 mx-auto p-0 m-0">
+      <div id="main-container" class="col-sm-10 col-md-12 mx-auto p-0 m-0" role="main">
         <div class="pb-5">
           <%= yield %>
         </div>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -31,6 +31,11 @@
     <%= analytics_init({anonymize: true}) if GoogleAnalytics.valid_tracker? %>
   </head>
   <body class="bg-white <%= render_body_class %>">
+
+    <div id="skip-link">
+      <%= link_to "Skip to main content", "#main-container", :class => "skip-main", :tabindex => "1" %>
+    </div>
+
     <div id="page-wrapper">
       <%= render :partial => "shared/header_navbar" %>
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<div id="footer">
+<div id="footer" role="contentinfo">
   <div id="site-footer">
     <div class="row">
       <div class="col">
@@ -12,24 +12,24 @@
            </div>
 
           <div class="region region-postscript-second">
-            <nav role="navigation">
+            <div>
               <ul>
                 <li><a href="https://directory.temple.edu/">Cherry and White Directory</a></li>
                 <li><a href="https://library.temple.edu/libraries/2">Maps and Directions</a></li>
                 <li><a href="https://library.temple.edu/contact-us">Contact</a></li>
               </ul>
-            </nav>
+            </div>
           </div>
 
           <div class="region region-postscript-third">
-            <nav role="navigation">
+            <div>
               <ul>
                 <li style="display:inline;margin-right:14px;"><%= link_to image_tag('fb.png', class: 'social-icon', alt: 'Facebook Icon', :style => 'width:32px;height:32px;'), 'https://www.facebook.com/templelibraries/' %></li>
                 <li style="display:inline;margin-right:14px;"><%= link_to image_tag('twitter.png', class: 'social-icon', alt: 'Twitter Icon', :style => 'width:36px;height:36px;margin-top:2px;'), 'https://twitter.com/TempleLibraries' %></li>
                 <li style="display:inline"><%= link_to image_tag('instagram.png', class: 'social-icon', alt: 'Instagram Icon', :style => 'width:34px;height:34px;'), 'http://instagram.com/tulibraries' %></li>
               </ul>
               <br /><br />
-            </nav>
+            </div>
           </div>
         </div>
 

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,11 +1,11 @@
-<nav id="logo-navbar" class="navbar navbar-header bg-white" role="navigation">
+<nav id="logo-navbar" class="navbar navbar-header bg-white" role="banner">
   <%= link_to library_link, class: "header-name d-flex align-items-end" do %>
     <%= image_tag("temple-logo-t-box.svg", class: "header-logo d-inline-flex", alt: "temple-logo") %>
     <span class="logo-text">University Libraries</span>
   <% end %>
 </nav>
 
-<nav id="website-navbar" class="navbar navbar-header bg-red p-0">
+<nav id="website-navbar" class="navbar navbar-header bg-red p-0" aria-labelledby="main-menu">
   <div class="row d-none d-sm-none d-md-none d-lg-none d-xl-block" id="main-menu">
     <ul class="list-unstyled pr-5 m-0">
       <li class="first"><%= link_to "About", "https://library.temple.edu/about" %></li>
@@ -22,12 +22,12 @@
     </ul>
   </div>
 
-  <div class="row d-block d-sm-block d-md-block d-lg-block d-xl-none" id="mobile-nav">
+  <div class="row d-block d-sm-block d-md-block d-lg-block d-xl-none" id="mobile-nav" aria-labelledby="mobile-main-menu">
     <%= render "mobile_nav" %>
   </div>
 </nav>
 
-<nav id="search-navbar" class="navbar navbar-default bg-website-grey border-bottom border-red pt-3" role="navigation">
+<nav id="search-navbar" class="navbar navbar-default bg-website-grey border-bottom border-red pt-3">
   <div class="d-lg-inline-flex align-items-center mx-auto">
     <h1 class="text-center pr-md-4 d-none d-md-block">
       <%= link_to("Library Search", everything_path, id: "catalog-header") %>

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe CatalogHelper, type: :helper do
     end
   end
 
-  describe "#render_bound_with_ids" do
+  describe "#render_alma_availability(document)" do
     let(:doc) { SolrDocument.new(bound_with_ids: ["foo"]) }
     let(:config) { CatalogController.blacklight_config }
 
@@ -210,9 +210,9 @@ RSpec.describe CatalogHelper, type: :helper do
       end
     end
 
-    context "with boud_with_ids defined" do
+    context "with bound_with_ids defined" do
       it "renders the bound_with_ids" do
-        expect(helper.render_bound_with_ids(doc)).not_to be_nil
+        expect(helper.render_alma_availability(doc)).not_to be_nil
       end
     end
 
@@ -220,7 +220,7 @@ RSpec.describe CatalogHelper, type: :helper do
       let(:doc) { SolrDocument.new(bound_with_ids: nil) }
 
       it "does not render the bound_with_ids" do
-        expect(helper.render_bound_with_ids(doc)).to be_nil
+        expect(helper.render_alma_availability(doc)).to be_nil
       end
     end
 
@@ -228,7 +228,7 @@ RSpec.describe CatalogHelper, type: :helper do
       let(:config) { PrimoCentralController.blacklight_config }
 
       it "does not render the bound_with_ids" do
-        expect(helper.render_bound_with_ids(doc)).to be_nil
+        expect(helper.render_alma_availability(doc)).to be_nil
       end
     end
   end


### PR DESCRIPTION
This one is getting big, so I am going to break it into parts.  This part focused on the catalog search results availability.  There are also some changes to the headers and navigation elements.

- The alma availability is currently rendered dt and dd tags that are not within a dl.  This updates the method to create a dl instead of a span.  It also renames the method to better explain what is being rendered.
- We have several places where duplicate ids are being used.  This adds the document_id to bookmarks hidden_fields and the online availability buttons to make the ids unique.
- We were missing some important landmarks.  This adds landmarks to the main content and sidebar.  It updates the footer role and adds unique labels to the navigation landmarks to better define them.
Fix syntax errors in search results
  - Adds empty alt tag to decorative icons
  - Removes comma in link 
  - Removes div inside of span
  - Closes span tag for electronic links
- BL-944 Add skip to main content link for keyboard navigation
- BL-934 Remove extra h2 element in search results