### PR TITLE
Fixes multiple issues with Web Content Search (#1436)

### DIFF
--- a/app/controllers/web_content_controller.rb
+++ b/app/controllers/web_content_controller.rb
@@ -12,9 +12,23 @@ class WebContentController < CatalogController
     config.connection_config[:url] = config.connection_config[:web_content_url]
     config.track_search_session = false
     config.default_solr_params = {
+        defType: "edismax",
         wt: "json",
         fl: %w[
-          * ].join(",")
+          * ].join(","),
+        qf: %w[
+          web_title_display^3
+          web_specialties_display^2
+          web_full_description_t^2
+          text
+        ],
+        pf: %w[
+          web_title_display^3
+          web_specialties_display^2
+          web_full_description_t^2
+          text
+        ],
+        spellcheck: "false",
     }
 
     config.index.title_field = "web_title_display"

--- a/solr_web/conf/schema.xml
+++ b/solr_web/conf/schema.xml
@@ -652,11 +652,12 @@
    <copyField source="subject_addl_t" dest="opensearch_display"/>
 
 
-   <!-- for suggestions -->
+   <!-- for suggestions
+   Suggestions are not used, and are breaking on immense fields
    <copyField source="*_t" dest="suggest"/>
    <copyField source="*_facet" dest="suggest"/>
-
-   <!-- Above, multiple source fields are copied to the [text] field.
+   -->
+     <!-- Above, multiple source fields are copied to the [text] field.
 	  Another way to map multiple source fields to the same
 	  destination field is to use the dynamic field syntax.
 	  copyField also supports a maxChars to copy setting.  -->


### PR DESCRIPTION
Fixes BL-994 - Finding aid not searching description field,
This is actually also true  of other entities like policies. Fixes this for all entity types specifying in the contoller which fields should be searched in qf and pf params, including boosts.

Fixes BL-986 "Did you mean to type: ?" showing up in web results
Adds controller config to turn off suggestions

"Fixes" BL-991 - Select Finding Aids not appearing in Library Search.
This error was caused by copying huge finding aid descriptions into the `suggest` field. `suggest` should be a text field, and thus have no byte limit, but it is throwing errors. "Fixes" that issue by removing the solr schema copyField configuration to suggest since we aren't currently using the suggest fields.

Additionally, not sure if updating the schema in this repo will effect the schema that egst deployed, but wanted to add here for reference and local testing. If another pr is needed elsewhere, happy to do so.