### PR TITLE
BL-898 Disable multiple clicks on email/text submit buttons

### DIFF
--- a/app/views/catalog/_email_form.html.erb
+++ b/app/views/catalog/_email_form.html.erb
@@ -1,0 +1,40 @@
+<%= form_tag url_for(controller: controller_name, action: "email"),
+             data: { blacklight_modal: 'trigger' },
+             id: 'email_form',
+             class: "modal_form",
+             method: :post do %>
+
+  <div class="modal-body">
+    <%= render '/shared/flash_msg' %>
+    <div class="form-group row">
+      <label class="control-label col-sm-2" for="to">
+        <%= t('blacklight.email.form.to') %>
+      </label>
+      <div class="col-sm-10">
+        <%= email_field_tag :to, params[:to], class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class="form-group row">
+      <label class="control-label col-sm-2" for="message">
+        <%= t('blacklight.email.form.message') %>
+      </label>
+      <div class="col-sm-10">
+        <%= text_area_tag :message, params[:message], class: 'form-control' %>
+      </div>
+    </div>
+
+    <% @documents.each do |doc| %>
+      <%=hidden_field_tag "id[]", doc.id %>
+    <% end %>
+    <%- if params[:sort] -%>
+      <%= hidden_field_tag "sort", params[:sort] %>
+    <%- end -%>
+    <%- if params[:per_page] -%>
+      <%= hidden_field_tag "per_page", params[:per_page] %>
+    <%- end -%>
+  </div>
+  <div class="modal-footer">
+    <%= button_tag t('blacklight.sms.form.submit'), type: "submit", class:"btn btn-primary", data: { disable_with: "Sending email..." } %>
+  </div>
+<% end %>

--- a/app/views/catalog/_sms_form.html.erb
+++ b/app/views/catalog/_sms_form.html.erb
@@ -32,6 +32,6 @@
   </div>
 
   <div class="modal-footer">
-    <button type="submit" class="btn btn-primary"> <%= t('blacklight.sms.form.submit') %></button>
+    <%= button_tag t('blacklight.sms.form.submit'), type: "submit", class:"btn btn-primary", data: { disable_with: "Sending text..." } %>
   </div>
 <% end %>


### PR DESCRIPTION
- Emails and texts take a few seconds to process.  Users are not given any indication that their request was made, which sometimes results in them clicking submit multiple times.  
- This adds a data disable_with attribute to both buttons that disables the button so that it can't be clicked again and changes the text to read Sending email/text... to let the user know it is being processed.