### PR TITLE
BL-947 Refactor show field templates

### DIFF
--- a/app/views/catalog/_show_fields.html.erb
+++ b/app/views/catalog/_show_fields.html.erb
@@ -1,0 +1,35 @@
+<% doc_presenter = show_presenter(document) %>
+
+<% if should_render_show_field? document, field %>
+  <dt class="blacklight-<%= field_name.parameterize %>col-xs-12 col-sm-3 col-md-3"><%= render_document_show_field_label document, field: field_name %></dt>
+  <% if document[field_name]&.length == 1 || !document[field_name]&.is_a?(Array) %>
+
+    <% if doc_presenter.configuration.show_fields.fetch(field_name)[:helper_method] %>
+      <% value = doc_presenter.field_value field %>
+    <% else %>
+      <% value = document[field_name] %>
+    <% end %>
+
+    <% value = raw value if field[:raw] %>
+    <dd class="blacklight-<%= field_name.parameterize %> col-xs-12 col-sm-9"><%= safe_join(Array.wrap(value)) %></dd>
+
+    <% else %>
+      <% document[field_name].each do |value| %>
+         <% value %>
+    <% end %>
+
+    <dd class="blacklight-<%= field_name.parameterize %> col-xs-12 col-sm-9">
+      <ul>
+        <% if doc_presenter.configuration.show_fields.fetch(field_name)[:helper_method] %>
+          <% values = Array.wrap(doc_presenter.field_value field) %>
+        <% else %>
+          <% values = document[field_name] %>
+        <% end %>
+        <% values.each do |value| %>
+          <li class="list_items"> <%= safe_join(Array.wrap(value)) %> </li>
+        <% end %>
+      </ul>
+    </dd>
+
+  <% end %>
+<% end -%>

--- a/app/views/catalog/_show_primary_fields.html.erb
+++ b/app/views/catalog/_show_primary_fields.html.erb
@@ -2,37 +2,6 @@
 
 <dl class="row document-metadata mb-0 show-page-list mb-3">
   <% document_show_primary_fields(document).each do |field_name, field| %>
-    <% if should_render_show_field? document, field %>
-      <dt class="blacklight-<%= field_name.parameterize %>col-xs-12 col-sm-3 col-md-3"><%= render_document_show_field_label document, field: field_name %></dt>
-      <% if document[field_name]&.length == 1 || !document[field_name]&.is_a?(Array) %>
-        <% if doc_presenter.configuration.show_fields.fetch(field_name)[:helper_method] %>
-          <% value = doc_presenter.field_value field %>
-        <% else %>
-          <% value = document[field_name] %>
-        <% end %>
-
-        <% value = raw value if field[:raw] %>
-
-        <dd class="blacklight-<%= field_name.parameterize %> col-xs-12 col-sm-9"><%= safe_join(Array.wrap(value)) %></dd>
-
-        <% else %>
-          <% document[field_name].each do |value| %>
-             <% value %>
-          <% end %>
-          <dd class="blacklight-<%= field_name.parameterize %> col-xs-12 col-sm-9">
-
-          <ul>
-          <% if doc_presenter.configuration.show_fields.fetch(field_name)[:helper_method] %>
-            <% values = Array.wrap(doc_presenter.field_value field) %>
-          <% else %>
-            <% values = document[field_name] %>
-          <% end %>
-          <% values.each do |value| %>
-            <li class="list_items"> <%= safe_join(Array.wrap(value)) %> </li>
-          <% end %>
-          </ul>
-        </dd>
-      <% end %>
-    <% end -%>
+    <%= render "show_fields", document: document, field: field, field_name: field_name %>
   <% end -%>
 </dl>

--- a/app/views/catalog/_show_secondary_fields.html.erb
+++ b/app/views/catalog/_show_secondary_fields.html.erb
@@ -7,36 +7,6 @@
 
 <dl class="row document-metadata mb-0 show-page-list no-gutters pl-1">
   <% document_show_secondary_fields(document).each do |field_name, field| %>
-    <% if should_render_show_field? document, field %>
-      <dt class="blacklight-<%= field_name.parameterize %>col-xs-12 col-sm-3 col-md-3"><%= render_document_show_field_label document, field: field_name %></dt>
-      <% if document[field_name]&.length == 1 || !document[field_name]&.is_a?(Array) %>
-        <% if doc_presenter.configuration.show_fields.fetch(field_name)[:helper_method] %>
-          <% value = doc_presenter.field_value field %>
-        <% else %>
-          <% value = document[field_name] %>
-        <% end %>
-
-        <% value = raw value if field[:raw] %>
-
-        <dd class="blacklight-<%= field_name.parameterize %> col-xs-12 col-sm-9"><%= safe_join(Array.wrap(value)) %></dd>
-      <% else %>
-        <% document[field_name].each do |value| %>
-           <% value %>
-        <% end %>
-
-        <dd class="blacklight-<%= field_name.parameterize %> col-xs-12 col-sm-9">
-          <ul>
-          <% if doc_presenter.configuration.show_fields.fetch(field_name)[:helper_method] %>
-            <% values = Array.wrap(doc_presenter.field_value field) %>
-          <% else %>
-            <% values = document[field_name] %>
-          <% end %>
-          <% values.each do |value| %>
-            <li class="list_items"> <%= safe_join(Array.wrap(value)) %> </li>
-          <% end %>
-          </ul>
-        </dd>
-      <% end %>
-    <% end -%>
+    <%= render "show_fields", document: document, field: field, field_name: field_name %>
   <% end -%>
 </dl>


### PR DESCRIPTION
- The code to generate the fields was being duplicated in both the primary and secondary partials. This pulls the duplicate code to its own partial so that we can use it only once.