### PR TITLE
Add dotenv-rails to the project.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,7 @@ gem "httparty"
 
 gem "traject", "~> 3.1"
 gem "traject_plus"
-gem "dotenv"
+gem "dotenv-rails"
 
 gem "cob_web_index", git: "https://github.com/tulibraries/cob_web_index.git",
   branch: "master"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,9 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dot-properties (0.1.3)
     dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.8.0)
     execjs (2.7.0)
     ezwadl (0.0.1)
@@ -584,7 +587,7 @@ DEPENDENCIES
   database_cleaner
   devise
   devise-guests (~> 0.7)
-  dotenv
+  dotenv-rails
   ezwadl
   factory_bot_rails
   foreman


### PR DESCRIPTION
In order for rails to pick up .env variables we need to install
dotenv-rails.