### PR TITLE
Bl 998 request options bug

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -60,20 +60,10 @@ class AlmawsController < CatalogController
     if @request_level == "item" || @asrs_request_level == "item"
       @item_level_holdings = CobAlma::Requests.item_holding_ids(@items)
       @second_attempt_holdings = CobAlma::Requests.second_attempt_item_holding_ids(@items)
-      @request_options = @item_level_holdings.map { |holding_id, item_pid|
-        log = { type: "item_request_options", mms_id: @mms_id, holding_id: holding_id, item_pid: item_pid, user: current_user.id }
-        do_with_json_logger(log) { Alma::ItemRequestOptions.get(@mms_id, holding_id, item_pid, user_id: @user_id) }
-      }
-        .sort_by { |r| r.request_options.count }
-        .last
+      @request_options = get_largest_request_options_set(@item_level_holdings)
 
       if @request_options.nil?
-        @request_options = @second_attempt_holdings.map { |holding_id, item_pid|
-          log = { type: "item_request_options", mms_id: @mms_id, holding_id: holding_id, item_pid: item_pid, user: current_user.id }
-          do_with_json_logger(log) { Alma::ItemRequestOptions.get(@mms_id, holding_id, item_pid, user_id: @user_id) }
-        }
-          .sort_by { |r| r.request_options.count }
-          .last
+        @request_options = get_largest_request_options_set(@second_attempt_holdings)
       end
     else
       log = { type: "bib_request_options", user: current_user.id }
@@ -230,6 +220,15 @@ class AlmawsController < CatalogController
       else
         has_desc?(items) ? "item" : "bib"
       end
+    end
+
+    def get_largest_request_options_set(items)
+      items.map { |holding_id, item_pid|
+        log = { type: "item_request_options", mms_id: @mms_id, holding_id: holding_id, item_pid: item_pid, user: current_user.id }
+        do_with_json_logger(log) { Alma::ItemRequestOptions.get(@mms_id, holding_id, item_pid, user_id: @user_id) }
+      }
+        .sort_by { |r| r.request_options.count }
+        .last
     end
 
     def has_desc?(items)

--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -227,7 +227,7 @@ class AlmawsController < CatalogController
         log = { type: "item_request_options", mms_id: @mms_id, holding_id: holding_id, item_pid: item_pid, user: current_user.id }
         do_with_json_logger(log) { Alma::ItemRequestOptions.get(@mms_id, holding_id, item_pid, user_id: @user_id) }
       }
-        .sort_by { |r| r.request_options.count }
+        .sort_by { |r| r.request_options&.count || 0 }
         .last
     end
 

--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -54,7 +54,7 @@ class AlmawsController < CatalogController
     if @asrs_request_level == "item"
       @asrs_description =  CobAlma::Requests.asrs_descriptions(@items)
     else
-      @asrs_description = @description
+      @asrs_description = @description || @asrs_description = ""
     end
 
     if @request_level == "item" || @asrs_request_level == "item"
@@ -64,7 +64,7 @@ class AlmawsController < CatalogController
         log = { type: "item_request_options", mms_id: @mms_id, holding_id: holding_id, item_pid: item_pid, user: current_user.id }
         do_with_json_logger(log) { Alma::ItemRequestOptions.get(@mms_id, holding_id, item_pid, user_id: @user_id) }
       }
-        .sort_by { |r| r.raw_response.parsed_response.count }
+        .sort_by { |r| r.request_options.count }
         .last
 
       if @request_options.nil?
@@ -72,7 +72,7 @@ class AlmawsController < CatalogController
           log = { type: "item_request_options", mms_id: @mms_id, holding_id: holding_id, item_pid: item_pid, user: current_user.id }
           do_with_json_logger(log) { Alma::ItemRequestOptions.get(@mms_id, holding_id, item_pid, user_id: @user_id) }
         }
-          .sort_by { |r| r.raw_response.parsed_response.count }
+          .sort_by { |r| r.request_options.count }
           .last
       end
     else


### PR DESCRIPTION
Refactor request_options to use a private method to get the largest set of request options instead of duplicating code
 - Moved the code to a private message so that it isn't duplicated
 - Handles cases where request_options is nil