### PR TITLE
BL-1003 Fix item request sometimes fails when more than 100 items.

### DIFF
--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -58,7 +58,7 @@ module AlmawsHelper
     item.library == "ASRS"
   end
 
-  def available_asrs_items(items = @items)
+  def available_asrs_items(items = @items.all)
     # Alma bug: item.item_data["requested"] is true for all items on bib level requests.
     asrs_items(items).select { |item| item.in_place?  }
   end

--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -131,6 +131,7 @@ module CobAlma
         .select { |item| item.library == "ASRS" && item.in_place? }
         .map(&:description)
         .uniq
+        .sort
     end
 
     def self.booking_location(items_list)


### PR DESCRIPTION
If the item selected is beyond the default 100 returned then there is
items is not found when trying to submit request.

* Makes sure we process all items.
* Adds error notice if no request was possible.
* Sorts items.