### PR TITLE
BL-972 Duplicate Ids

### DIFF
--- a/app/assets/javascripts/listeners.js
+++ b/app/assets/javascripts/listeners.js
@@ -4,6 +4,7 @@ $(document).ready(function(){
 		const tracks = [
 			{id: "logo-navbar", category: "navigation"},
 			{id: "my-account", category: "navigation"},
+			{id: "my-account-mobile", category: "navigation"},
 			{id: "login", category: "navigation"},
 			{id: "logout", category: "navigation"},
 			{id: "bookmarks_nav", category: "navigation"},

--- a/app/views/application/_mobile_nav.html.erb
+++ b/app/views/application/_mobile_nav.html.erb
@@ -36,7 +36,7 @@
         <div class="col">
           <%= image_tag "person.png", class: "person-icon decorative" %>
           <% if current_user %>
-            <%= link_to "My Account", users_account_path, id: "my-account" %>
+            <%= link_to "My Account", users_account_path, id: "my-account-mobile" %>
           <% else %>
             <%= link_to "My Account", new_user_session_path, id: "login" %>
           <% end %>


### PR DESCRIPTION
- Having the my-acocunt id in both website headers is throwing a duplicate Id accessibility error.  This changes the id for the mobile link and adds it to the Google Analytics listeners