### PR TITLE
BL-1011 Availability alerts

### DIFF
--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -62,9 +62,11 @@ module AvailabilityHelper
   end
 
   def availability_alert(document)
-    document["items_json_display"].map { |item|
-      item["availability"].blank?
-    }.any?
+    unless document["electronic_resource_display"]
+      document["items_json_display"].map { |item|
+        item["availability"].blank?
+      }.any?
+    end
   end
 
   def description(item)

--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -62,11 +62,10 @@ module AvailabilityHelper
   end
 
   def availability_alert(document)
-    unless document["electronic_resource_display"]
+    document["electronic_resource_display"].blank? &&
       document["items_json_display"].map { |item|
         item["availability"].blank?
       }.any?
-    end
   end
 
   def description(item)

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -841,5 +841,30 @@ RSpec.describe AvailabilityHelper, type: :helper do
         expect(availability_alert(document)).to eq false
       end
     end
+
+    context "document is an electronic resouce" do
+      let(:document) { { "items_json_display" =>
+        [{
+          "item_pid" => "23237957740003811",
+            "item_policy" => "5",
+            "permanent_library" => "AMBLER",
+            "permanent_location" => "media",
+            "current_library" => "AMBLER",
+            "current_location" => "media",
+            "call_number" => "DVD 13 A165",
+            "availability" => "<span class=\"check\"></span>Library Use Only",
+            "holding_id" => "22237957750003811" }],
+          "electronic_resource_display" =>
+          [
+            { "title" => "Access electronic resource.", "url" => "http://libproxy.temple.edu/login?url=http://www.aspresolver.com/aspresolver.asp?SHM2;1772483" },
+            { "portfolio_id" => "77777", "title" => "Sample Name" },
+          ]
+          }
+        }
+
+      it "returns nil"  do
+        expect(availability_alert(document)).to eq nil
+      end
+    end
   end
 end

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -862,7 +862,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
           }
         }
 
-      it "returns nil"  do
+      it "returns false"  do
         expect(availability_alert(document)).to eq false
       end
     end

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -863,7 +863,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
         }
 
       it "returns nil"  do
-        expect(availability_alert(document)).to eq nil
+        expect(availability_alert(document)).to eq false
       end
     end
   end


### PR DESCRIPTION
- We currently display an alert that availability can't be found for items with blank items_json_display fields.
- Electronic items don't have those fields, so the method is throwing an error.  Refactor the method to not include items with the electronic_resource_display field.