### PR TITLE
BL-1016 Request options bug

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -62,7 +62,7 @@ class AlmawsController < CatalogController
       @second_attempt_holdings = CobAlma::Requests.second_attempt_item_holding_ids(@items)
       @request_options = get_largest_request_options_set(@item_level_holdings)
 
-      if @request_options.nil?
+      if @request_options.request_options.nil?
         @request_options = get_largest_request_options_set(@second_attempt_holdings)
       end
     else


### PR DESCRIPTION
- @request_options is no longer returning nil when empty, so when the first set of request options is empty, it does not try another item
- This ensures that @request_options.request_options is nil so that another attempt is made to get the request options from alma