### PR TITLE
[BL-1016] avoid throwing error if options truly nil.

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -62,7 +62,7 @@ class AlmawsController < CatalogController
       @second_attempt_holdings = CobAlma::Requests.second_attempt_item_holding_ids(@items)
       @request_options = get_largest_request_options_set(@item_level_holdings)
 
-      if @request_options.request_options.nil?
+      if @request_options&.request_options.nil?
         @request_options = get_largest_request_options_set(@second_attempt_holdings)
       end
     else


### PR DESCRIPTION
In cases where items is an empty set, `get_largest_request_options_set`
method will return `nil` so `@request_optioins.request_options` would
throw an error. We can avoid the error by using guard operator, &.