### PR TITLE
[BL-1011] Fix avaiability_alert helper error.

### DIFF
--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -62,10 +62,11 @@ module AvailabilityHelper
   end
 
   def availability_alert(document)
-    document["electronic_resource_display"].blank? &&
-      document["items_json_display"].map { |item|
-        item["availability"].blank?
-      }.any?
+    # nil is returned in cases where document has no items_json_display field.
+    # Use double bang to force coerce nils to false.
+    !!document["items_json_display"]&.map { |item|
+      item["availability"].blank?
+    }&.any?
   end
 
   def description(item)


### PR DESCRIPTION
When "items_json_display" is not present we throw a no map method on
nil.  This commit fixes the issues by using &. operator and checking is
results are `.present?`