### PR TITLE
BL-1018 Request bug

### DIFF
--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -161,7 +161,9 @@ module CobAlma
     end
 
     def self.item_holding_ids(items_list)
-      items_list.collect { |item| [item["holding_data"]["holding_id"], item["item_data"]["pid"]] }.to_h
+      items_list
+      .select { |item| item["holding_data"]["temp_location"]["value"] != "storage" }
+      .collect { |item| [item["holding_data"]["holding_id"], item["item_data"]["pid"]] }.to_h
     end
 
     def self.second_attempt_item_holding_ids(items_list)

--- a/spec/fixtures/requests/temp_storage.json
+++ b/spec/fixtures/requests/temp_storage.json
@@ -1,0 +1,135 @@
+{
+    "item": [
+      {
+            "bib_data": {
+                "mms_id": "991026246599703811",
+                "title": "Revue des etudes latines.",
+                "author": "Marouzeau, J.",
+                "issn": "0373-5737",
+                "isbn": null,
+                "complete_edition": "",
+                "network_number": [
+                    "(OCLC)ocm01152816",
+                    "ocm01152816",
+                    "PATG05842625S",
+                    "ocn471943959",
+                    "(PPT)b15419800-01tuli_inst"
+                ],
+                "place_of_publication": "Paris :",
+                "publisher_const": "Societe d'Edition \"Les Belles Lettres\" etc",
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026246599703811"
+            },
+            "holding_data": {
+                "holding_id": "22454302730003811",
+                "call_number_type": {
+                    "value": "0",
+                    "desc": "Library of Congress classification"
+                },
+                "call_number": "PA2002.R4",
+                "accession_number": "",
+                "copy_id": "1",
+                "in_temp_location": true,
+                "temp_library": {
+                    "value": "MAIN",
+                    "desc": "Charles Library"
+                },
+                "temp_location": {
+                    "value": "storage",
+                    "desc": "Main Storage"
+                },
+                "temp_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "temp_call_number": "",
+                "temp_policy": {
+                    "value": "",
+                    "desc": null
+                },
+                "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026246599703811/holdings/22454302730003811"
+            },
+            "item_data": {
+                "pid": "23315206210003811",
+                "barcode": "39074009145269",
+                "creation_date": "2017-06-20Z",
+                "modification_date": "2019-08-24Z",
+                "base_status": {
+                    "value": "1",
+                    "desc": "Item in place"
+                },
+                "awaiting_reshelving": false,
+                "physical_material_type": {
+                    "value": "ISSUE",
+                    "desc": "Issue"
+                },
+                "policy": {
+                    "value": "0",
+                    "desc": "Normal Circulation per location"
+                },
+                "provenance": {
+                    "value": "",
+                    "desc": null
+                },
+                "po_line": "",
+                "is_magnetic": false,
+                "arrival_date": "1999-02-02Z",
+                "year_of_issue": "",
+                "enumeration_a": "",
+                "enumeration_b": "",
+                "enumeration_c": "",
+                "enumeration_d": "",
+                "enumeration_e": "",
+                "enumeration_f": "",
+                "enumeration_g": "",
+                "enumeration_h": "",
+                "chronology_i": "",
+                "chronology_j": "",
+                "chronology_k": "",
+                "chronology_l": "",
+                "chronology_m": "",
+                "description": "v.70 (1992)",
+                "receiving_operator": "import",
+                "process_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "inventory_number": "",
+                "inventory_price": "",
+                "library": {
+                    "value": "ASRS",
+                    "desc": "ASRS"
+                },
+                "location": {
+                    "value": "ASRS",
+                    "desc": "Automated Storage System"
+                },
+                "alternative_call_number": "",
+                "alternative_call_number_type": {
+                    "value": "",
+                    "desc": null
+                },
+                "storage_location_id": "",
+                "pages": "",
+                "pieces": "$0.00",
+                "public_note": "",
+                "fulfillment_note": "",
+                "internal_note_1": "",
+                "internal_note_2": "",
+                "internal_note_3": "ITEM LOC: pstk",
+                "statistics_note_1": "TOT RENEW: 0",
+                "statistics_note_2": "LYCIRC: 0",
+                "statistics_note_3": "",
+                "requested": false,
+                "edition": null,
+                "imprint": null,
+                "language": null,
+                "physical_condition": {
+                    "value": null,
+                    "desc": null
+                }
+            },
+            "link": "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991026246599703811/holdings/22454302730003811/items/23315206210003811"
+            }
+        ],
+        "total_record_count": 1
+    }

--- a/spec/lib/cob_alma/requests_spec.rb
+++ b/spec/lib/cob_alma/requests_spec.rb
@@ -221,4 +221,23 @@ RSpec.describe CobAlma::Requests do
       end
     end
   end
+
+  describe "#item_holding_ids(items_list)" do
+    let(:items_list) { Alma::BibItem.find("multiple_descriptions") }
+
+    context "collects holding ids and item pids for regular items" do
+      it "returns hash with item holding ids and item pids" do
+        expect(described_class.item_holding_ids(items_list)).to eq("22255855450003811" => "23255855440003811", "22255855480003811" => "23255855460003811")
+      end
+    end
+
+    context "does not collect holding ids and item pids for items in temporary storage" do
+      let(:items_list) { Alma::BibItem.find("temp_storage") }
+
+      it "returns each material type hash once" do
+        expect(described_class.item_holding_ids(items_list)).to eq({})
+      end
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -232,6 +232,12 @@ RSpec.configure do |config|
                 headers: { "Content-Type" => "application/json" },
                 body: File.open(SPEC_ROOT + "/fixtures/requests/blank_material_type.json"))
 
+    stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/temp_storage\/holdings\/.*\/items/).
+      to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/temp_storage.json"))
+
+
   end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
- Records that have items in temporary storage are not returning the correct request options.
- This filters out items in the temporary storage location right now from the method that gets request options so that we don't return nil options
- Adds specs for the method since there weren't any previously