### PR TITLE
Bl 1019 fix loading page bug

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -34,6 +34,11 @@
 //= require_tree .
 
 $(window).on('turbolinks:load', function() {
+	window.onload= function(){
+		if(location.hash == undefined) {
+			parent.window.scrollTo(0,0);
+		}
+	}
 
 	if ($(window).width() < 768) {
 		$('#nav-tools').insertAfter('#document');

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -35,6 +35,7 @@
 
 $(window).on('turbolinks:load', function() {
 	window.onload= function(){
+		// This fixes a bug where the pages are loading at the bottom in Chrome
 		if(location.hash == undefined) {
 			parent.window.scrollTo(0,0);
 		}


### PR DESCRIPTION
- We have an issue where pages are loading at the bottom.  This adds a javascript function to ensure that pages are loaded at the top unless there is a location hash(we don't want it to override redirects)