### PR TITLE
BL-1005 Bug with bento direct links

### DIFF
--- a/app/helpers/primo_central_helper.rb
+++ b/app/helpers/primo_central_helper.rb
@@ -52,7 +52,7 @@ module PrimoCentralHelper
 
   def bento_availability(item)
     if item.has_direct_link?
-      link_to "Online", single_link_builder(bento_link(item)), class: "bento-online btn btn-sm bento-avail-btn mt-1", title: "This link opens the resource in a new tab.", target: "_blank"
+      link_to "Online", bento_link(item), class: "bento-online btn btn-sm bento-avail-btn mt-1", title: "This link opens the resource in a new tab.", target: "_blank"
     else
       link_to "Online", primo_central_document_url(item), class: "bento-online btn btn-sm bento-avail-btn mt-1"
     end


### PR DESCRIPTION
- Article direct links in the bento search are currently not working.  
- Removing the use of the single_link_builder method inside bento_availability seems to resolve the issue.