### PR TITLE
BL-1004 Display public notes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GIT
 
 GIT
   remote: https://github.com/tulibraries/cob_index.git
-  revision: 2d0f68f7c8f6d8f7d1b25af7d5aa2e779a93a665
+  revision: 5b620fc77ac1c5bbbf631d9530ee91b629831b7d
   branch: qa
   specs:
     cob_index (0.1.0)

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -326,11 +326,12 @@ module CatalogHelper
     collection_id = field["collection_id"]
     service_id = field["service_id"]
 
+    public_notes = field["public_note"]
     collection_notes = Rails.configuration.electronic_collection_notes[collection_id] || {}
     service_notes = Rails.configuration.electronic_service_notes[service_id] || {}
 
-    if collection_notes.present? || service_notes.present?
-      render partial: "electronic_notes", locals: { collection_notes: collection_notes, service_notes: service_notes }
+    if collection_notes.present? || service_notes.present? || public_notes.present?
+      render partial: "electronic_notes", locals: { collection_notes: collection_notes, service_notes: service_notes, public_notes: public_notes }
     end
   end
 

--- a/app/views/catalog/_electronic_notes.html.erb
+++ b/app/views/catalog/_electronic_notes.html.erb
@@ -7,4 +7,6 @@
   <% service_notes.values.select(&:present?).each do |note| %>
     <p><%= raw note %></p>
   <% end %>
+
+  <p><%= public_notes %></p>
 </div>

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -259,6 +259,7 @@ RSpec.describe CatalogHelper, type: :helper do
   describe "#render_electronic_notes" do
     let(:service_notes) {  { "foo" => "bar" } }
     let(:collection_notes) {  { "bizz" => "buzz" } }
+    let(:public_notes) { "public note" }
     let(:config) { OpenStruct.new(
       electronic_collection_notes: service_notes,
       electronic_service_notes: collection_notes
@@ -274,6 +275,14 @@ RSpec.describe CatalogHelper, type: :helper do
 
       it "should not render any notes" do
         expect(render_electronic_notes(field)).to be_nil
+      end
+    end
+
+    context "with public notes" do
+      let(:field) { { "public_note" => "public note" } }
+
+      it "should render the notes" do
+        expect(render_electronic_notes(field)).to eq("rendered note")
       end
     end
 


### PR DESCRIPTION
- We are not currently displaying portfolio-level public notes in the electronic_resources_display field.
- This adds them to the display in the same way that collection and service notes were implemented previously