### PR TITLE
BL-955 Aeon button

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,7 +48,7 @@ module ApplicationHelper
     libraries = document_items.collect { |item| library(item) }
 
     if libraries.include?("SCRC")
-      button_to(t("requests.aeon_button_text"), aeon_request_url(document), class: "btn btn-primary request-button")
+      button_to(t("requests.aeon_button_text"), aeon_request_url(document), class: "btn btn-primary")
     end
   end
 


### PR DESCRIPTION
- Use the same classes as the request form submit buttons
- "Go to SCRC Researcher Account" should not be bold