### PR TITLE
[BL-1017] Fix dummy_range field bug

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -176,7 +176,7 @@ module ApplicationHelper
     if controller_name == "bookmarks"
       bookmarks_path(opts.merge(format: "ris"))
     elsif controller_name == "primo_central"
-      primo_central_document_path(opts.merge(format: "ris"))
+      article_document_path(opts.merge(format: "ris"))
     else
       solr_document_path(opts.merge(format: "ris"))
     end

--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -57,7 +57,8 @@ module BentoSearch
     end
 
     def url(helper)
-      helper.search_catalog_path(q: helper.params[:q])
+      params = helper.params.except(:action, :controller)
+      helper.search_catalog_path(params)
     end
 
     def view_link(total = nil, helper)

--- a/app/search_engines/bento_search/databases_engine.rb
+++ b/app/search_engines/bento_search/databases_engine.rb
@@ -9,8 +9,8 @@ module BentoSearch
     end
 
     def url(helper)
-      params = helper.params
-      helper.search_databases_path(q: params[:q])
+      params = helper.params.except(:action, :controller)
+      helper.search_databases_path(params)
     end
 
     def view_link(total = nil, helper)

--- a/app/search_engines/bento_search/journals_engine.rb
+++ b/app/search_engines/bento_search/journals_engine.rb
@@ -9,8 +9,8 @@ module BentoSearch
     end
 
     def url(helper)
-      params = helper.params
-      helper.search_journals_path(q: params[:q])
+      params = helper.params.except(:action, :controller)
+      helper.search_journals_path(params)
     end
 
     def view_link(total = nil, helper)

--- a/app/search_engines/bento_search/primo_engine.rb
+++ b/app/search_engines/bento_search/primo_engine.rb
@@ -32,12 +32,12 @@ module BentoSearch
     end
 
     def doc_link(id)
-      Rails.application.routes.url_helpers.primo_central_document_path(id)
+      Rails.application.routes.url_helpers.article_document_path(id)
     end
 
     def url(helper)
-      params = helper.params
-      helper.url_for(action: :index, controller: :primo_central, q: params[:q])
+      params = helper.params.except(:action, :controller)
+      helper.articles_path(params)
     end
 
     def view_link(total = nil, helper)

--- a/app/search_engines/bento_search/web_content_engine.rb
+++ b/app/search_engines/bento_search/web_content_engine.rb
@@ -18,8 +18,8 @@ module BentoSearch
     end
 
     def url(helper)
-      params = helper.params
-      helper.search_web_content_path(q: params[:q])
+      params = helper.params.except(:action, :controller)
+      helper.search_web_content_path(params)
     end
 
     def content_type(item)

--- a/app/views/primo_central/_tagged_refworks.erb
+++ b/app/views/primo_central/_tagged_refworks.erb
@@ -1,1 +1,1 @@
-<%= link_to t('blacklight.tools.refworks'), refworks_export_url(url: primo_central_document_url(format: :refworks), filter: "RefWorks Tagged Format"), id: "refworksLink", target: "_blank" %>
+<%= link_to t('blacklight.tools.refworks'), refworks_export_url(url: article_document_url(format: :refworks), filter: "RefWorks Tagged Format"), id: "refworksLink", target: "_blank" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
     concerns :exportable
   end
 
-  resources :article_documents, only: [:show], path: "/articles", controller: "catalog" do
+  resources :article_documents, only: [:show], path: "/articles", controller: "primo_central" do
     concerns :exportable
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,9 +40,8 @@ Rails.application.routes.draw do
     concerns :range_searchable
   end
 
-  resource :journals, only: [:index], as: "journals", path: "/journals", controller: "journals" do
+  resources :articles, only: [:index], as: "articles", path: "/articles", controller: "primo_central" do
     concerns :searchable
-    concerns :range_searchable
   end
 
   resource :databases, only: [:index], as: "databases", path: "/databases", controller: "databases" do
@@ -50,20 +49,33 @@ Rails.application.routes.draw do
     concerns :range_searchable
   end
 
+  resource :journals, only: [:index], as: "journals", path: "/journals", controller: "journals" do
+    concerns :searchable
+    concerns :range_searchable
+  end
+
   resource :web_content, only: [:index], as: "web_content", path: "/web_content", controller: "web_content" do
     concerns :searchable
-    #concerns :range_searchable
   end
+
 
   resources :solr_documents, only: [:show], path: "/catalog", controller: "catalog" do
     concerns :exportable
   end
 
-  resources :solr_journal_documents, only: [:show], path: "/journals", controller: "journals" do
+  resources :article_documents, only: [:show], path: "/articles", controller: "catalog" do
+    concerns :exportable
+  end
+
+  resources :primo_central_documents, only: [:show], path: "/articles", controller: "primo_central" do
     concerns :exportable
   end
 
   resources :solr_database_documents, only: [:show], path: "/databases", controller: "databases" do
+    concerns :exportable
+  end
+
+  resources :solr_journal_documents, only: [:show], path: "/journals", controller: "journals" do
     concerns :exportable
   end
 
@@ -73,10 +85,6 @@ Rails.application.routes.draw do
     collection do
       delete "clear"
     end
-  end
-
-  resources :primo_central_documents, only: [:show], path: "/articles", controller: "primo_central" do
-    concerns :exportable
   end
 
   post "catalog/:id/track" => "catalog#track"


### PR DESCRIPTION
Blacklight Raange Limit adds search_field=dummy_range if dummy_range is
not set in the query. This seems to be an outdated requirement that I'm
trying to get removed and thus fix issue, but in the mean time we can
fix our issue simply by making sure we set the param searc_field=all
when submitting queries to the catalog.

REF: projectblacklight/blacklight_range_limit#109
REF: BL-1017