### PR TITLE
BL-1007 Illiad text

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -122,7 +122,7 @@ Layout/TrailingWhitespace:
   Enabled: true
 
 # Use quotes for string literals when they are enough.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 # Align `end` with the matching keyword or starting expression except for

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -397,4 +397,10 @@ module CatalogHelper
   def document_show_secondary_fields(document)
     document_show_fields(document).select { |field_name, field| field[:type] != :primary }
   end
+
+  def ez_borrow_list_item(controller_name)
+    if controller_name == "catalog"
+      content_tag(:li, t("no_results.ez_borrow_html", href: link_to(t("no_results.ez_borrow_href"), t("no_results.ez_borrow_link"), target: "_blank")))
+    end
+  end
 end

--- a/app/views/catalog/_other_library_options.html.erb
+++ b/app/views/catalog/_other_library_options.html.erb
@@ -1,7 +1,7 @@
 <div class="not-at-temple">
   <p class="no-results-header"><strong><%= t "no_results.not_at_temple" %></strong></p>
   <ul>
-    <li><%= t("no_results.ez_borrow_html", href: link_to(t("no_results.ez_borrow_href"), t("no_results.ez_borrow_link"), target: "_blank")) %></li>
+    <%= ez_borrow_list_item(controller_name) %>
     <li><%= t("no_results.illiad_html", href: link_to(t("no_results.illiad_href"), t("no_results.illiad_link"), target: "_blank")) %></li>
     <ul>
       <li><%= t("no_results.ginsburg_illiad_html", href: link_to(t("no_results.ginsburg_illiad_href"), t("no_results.ginsburg_illiad_link"), target: "_blank")) %>

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -600,4 +600,20 @@ RSpec.describe CatalogHelper, type: :helper do
       end
     end
   end
+
+  describe "#ez_borrow_list_item(controller_name)" do
+    context "catalog controller" do
+      let(:controller_name) { "catalog" }
+      it "adds an ez_borrow list item" do
+        expect(ez_borrow_list_item(controller_name)).to eql "<li>To request books that are not available at Temple, use <a target=\"_blank\" href=\"https://ezb.relaisd2d.com/?LS=TEMPLE\">E-ZBorrow</a>.</li>"
+      end
+    end
+
+    context "journal controller" do
+      let(:controller_name) { "journal" }
+      it "does not add an ez_borrow list item" do
+        expect(ez_borrow_list_item(controller_name)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
- EZ borrow list item should only appear in the catalog no results page
- Adds a helper method to include this list item when in a catalog search
- Adds specs and updates a rubocop style that was obsolete