### PR TITLE
BL-1037 Citations bug

### DIFF
--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -65,7 +65,13 @@ class Citation
 
     def response
       @response ||= begin
-        HTTParty.get(api_url)
+        resp = HTTParty.get(api_url)
+        if resp["diagnostics"]
+          Honeybadger.notify("Citation responding with non-html for #{api_url}")
+          ""
+        else
+          resp
+        end
         rescue HTTParty::Error::ConnectionFailed, HTTParty::TimeoutError => e
           Rails.logger.warn("HTTP GET for #{api_url} failed with #{e}")
           ""


### PR DESCRIPTION
- Currently, if a HTTParty response is not in html format, it is throwing an error.
- This checks the response, and if it is invalid it will notify Honeybadger and give the user the default no citations message instead of an error