### PR TITLE
[BL-1008] Fix web content search error.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,11 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 #gem "blacklight", "~> 7.3.0"
 # TODO: revert once https://github.com/projectblacklight/blacklight/pull/2193 is released.
 gem "blacklight", git: "https://github.com/dkinzer/blacklight.git", branch: "92-fix-backwards-incompatible-breaking-change"
-gem "blacklight_advanced_search", git: "https://github.com/projectblacklight/blacklight_advanced_search.git"
+# TODO: revert once https://github.com/projectblacklight/blacklight_advanced_search/pull/106 gets meged
+gem "blacklight_advanced_search",
+  git: "https://github.com/dkinzer/blacklight_advanced_search.git",
+  branch: "fix-local-param-hash-fails"
+  #git: "https://github.com/projectblacklight/blacklight_advanced_search.git"
 gem "blacklight-marc", git: "https://github.com/projectblacklight/blacklight-marc.git", ref: "v7.0.0.rc1"
 gem "blacklight_range_limit", git: "https://github.com/projectblacklight/blacklight_range_limit.git", ref: "v7.0.0.rc2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,15 @@ GIT
       rails (>= 5.1, < 7)
 
 GIT
+  remote: https://github.com/dkinzer/blacklight_advanced_search.git
+  revision: badde44ddf51e19df7ed765fa51cfb1db1c9111e
+  branch: fix-local-param-hash-fails
+  specs:
+    blacklight_advanced_search (7.0.0.alpha)
+      blacklight (~> 7.0)
+      parslet
+
+GIT
   remote: https://github.com/projectblacklight/blacklight-marc.git
   revision: 582c68255d73e21926234f2ad5bb1ddf37dc6684
   ref: v7.0.0.rc1
@@ -22,14 +31,6 @@ GIT
       marc-fastxmlwriter
       rails
       traject (~> 3.0)
-
-GIT
-  remote: https://github.com/projectblacklight/blacklight_advanced_search.git
-  revision: ae7e3b7242337dceaabb23d212466e7504dedb0e
-  specs:
-    blacklight_advanced_search (7.0.0.alpha)
-      blacklight (~> 7.0)
-      parslet
 
 GIT
   remote: https://github.com/projectblacklight/blacklight_range_limit.git


### PR DESCRIPTION
Fixes error that gets thrown when user does a web content search
immediately after an advanced search for a field not defined in web
content.

REF BL-1008
REF https://github.com/projectblacklight/blacklight_advanced_search/pull/106