### PR TITLE
BL-1050 Request form displays

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,7 +43,7 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/IndentFirstArgument:
+Layout/IndentFirstArgumentIndentation:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
@@ -114,7 +114,7 @@ Layout/Tab:
   Enabled: true
 
 # Blank lines should not have any spaces.
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 # No trailing whitespace.

--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -45,16 +45,17 @@ module AlmawsHelper
     end
   end
 
-  def relevant_request_options(request_options, document)
-    [ request_options.hold_allowed?,
+  def relevant_request_options(request_options, books, document)
+    [ request_options.hold_allowed? && non_asrs_items.present?,
+      request_options.hold_allowed? && available_asrs_items.present?,
       request_options.digitization_allowed?,
       request_options.booking_allowed?,
-      request_options.resource_sharing_broker_allowed?,
+      request_options.resource_sharing_broker_allowed? && books.present?,
       aeon_request_allowed(document)]
   end
 
-  def only_one_option_allowed(request_options, document)
-    relevant_request_options(request_options, document).select(&:itself).count == 1
+  def only_one_option_allowed(request_options, books, document)
+    relevant_request_options(request_options, books, document).select(&:itself).count == 1
   end
 
   def non_asrs_items(items = @items)

--- a/app/views/almaws/_asrs_allowed.html.erb
+++ b/app/views/almaws/_asrs_allowed.html.erb
@@ -5,7 +5,7 @@
     </h2>
   </div>
 
-  <div id="collapseASRS-<%= @mms_id %>" class="collapse <%= 'show' if only_one_option_allowed(request_options, document)%>">
+  <div id="collapseASRS-<%= @mms_id %>" class="collapse <%= 'show' if only_one_option_allowed(request_options, @books, document)%>">
     <div class="card-body">
         <%= render "asrs_request_form" %>
     </div>

--- a/app/views/almaws/_booking_allowed.html.erb
+++ b/app/views/almaws/_booking_allowed.html.erb
@@ -5,7 +5,7 @@
     </h2>
   </div>
 
-  <div id="collapseThree-<%= @mms_id %>" class="collapse <%= 'show' if only_one_option_allowed(request_options, document)%>">
+  <div id="collapseThree-<%= @mms_id %>" class="collapse <%= 'show' if only_one_option_allowed(request_options, @books, document)%>">
     <div class="card-body">
       <%= render "booking_request_form" %>
     </div>

--- a/app/views/almaws/_digitization_allowed.html.erb
+++ b/app/views/almaws/_digitization_allowed.html.erb
@@ -5,7 +5,7 @@
     </h2>
   </div>
 
-  <div id="collapseTwo-<%= @mms_id %>" class="collapse <%= 'show' if only_one_option_allowed(request_options, document)%>">
+  <div id="collapseTwo-<%= @mms_id %>" class="collapse <%= 'show' if only_one_option_allowed(request_options, @books, document)%>">
     <div class="card-body">
       <%= render "digitization_request_form" %>
     </div>

--- a/app/views/almaws/_hold_allowed.html.erb
+++ b/app/views/almaws/_hold_allowed.html.erb
@@ -5,7 +5,7 @@
     </h2>
   </div>
 
-  <div id="collapseOne-<%= @mms_id %>" class="collapse <%= 'show' if only_one_option_allowed(request_options, document)%>">
+  <div id="collapseOne-<%= @mms_id %>" class="collapse <%= 'show' if only_one_option_allowed(request_options, @books, document)%>">
     <div class="card-body">
         <%= render "hold_request_form" %>
     </div>

--- a/app/views/almaws/_resource_sharing_broker_allowed.html.erb
+++ b/app/views/almaws/_resource_sharing_broker_allowed.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<div id="collapseFour-<%= @mms_id %>" class="collapse <%= 'show' if only_one_option_allowed(request_options, document)%>">
+<div id="collapseFour-<%= @mms_id %>" class="collapse <%= 'show' if only_one_option_allowed(request_options, @books, document)%>">
   <div class="card-body pb-0">
     <p><%= t("requests.resource_sharing_broker_text") %></p>
       <%= link_to(t("requests.resource_sharing_broker_link"), ez_borrow_link_with_updated_query(request_options.ez_borrow_link), id: "ez-borrow-button", class: "btn btn-primary request-button search-results-request-btn text-white", target: "_blank") %>

--- a/spec/helpers/almaws_helper_spec.rb
+++ b/spec/helpers/almaws_helper_spec.rb
@@ -446,6 +446,59 @@ RSpec.describe AlmawsHelper, type: :helper do
       end
     end
 
+    context "only an EZ Borrow request is allowed for a book" do
+      let(:books) { "BOOK" }
+      let(:document) { { "items_json_display" =>
+        [{ "item_pid" => "23237957740003811",
+        "item_policy" => "5",
+        "permanent_library" => "AMBLER",
+        "permanent_location" => "media",
+        "current_library" => "AMBLER",
+        "current_location" => "media",
+        "call_number" => "DVD 13 A165",
+        "holding_id" => "22237957750003811" }]
+          } }
+      let(:json) {
+        { request_option:
+          [{
+          "type" => { "value" => "RS_BROKER", "desc" => "Resource Sharing Broker" },
+          "request_url" => "https://e-zborrow.relais-host.com/user/login.html?group=patron&LS=TEMPLE&dest=discovery&PI=915602377&RK=915602377&rft.stitle=A+thin+bright+line+%2F&rft.pub=The+University+of+Wisconsin+Press%2C&rft.place=Madison%2C+Wisconsin+%3A&rft.isbn=0299309304&rft.btitle=A+thin+bright+line+%2F&rft.genre=book&rft.normalized_isbn=9780299309305&rft.oclcnum=946770187&rft.mms_id=991028550499703811&rft.object_type=BOOK&rft.publisher=The+University+of+Wisconsin+Press%2C&rft.au=Bledsoe%2C+Lucy+Jane%2C+author.&rft.pubdate=%5B2016%5D&rft.title=A+thin+bright+line+%2F"
+          }]
+        }.to_json
+      }
+
+      it "is true" do
+        expect(helper.only_one_option_allowed(request_options, books, document)).to be true
+      end
+    end
+
+    context "only an EZ Borrow request is allowed for a DVD" do
+      let(:books) {}
+      let(:document) { { "items_json_display" =>
+        [{ "item_pid" => "23237957740003811",
+        "item_policy" => "5",
+        "permanent_library" => "AMBLER",
+        "permanent_location" => "media",
+        "current_library" => "AMBLER",
+        "current_location" => "media",
+        "call_number" => "DVD 13 A165",
+        "holding_id" => "22237957750003811" }]
+          } }
+      let(:json) {
+        { request_option:
+          [{
+          "type" => { "value" => "RS_BROKER", "desc" => "Resource Sharing Broker" },
+          "request_url" => "https://e-zborrow.relais-host.com/user/login.html?group=patron&LS=TEMPLE&dest=discovery&PI=915602377&RK=915602377&rft.stitle=A+thin+bright+line+%2F&rft.pub=The+University+of+Wisconsin+Press%2C&rft.place=Madison%2C+Wisconsin+%3A&rft.isbn=0299309304&rft.btitle=A+thin+bright+line+%2F&rft.genre=book&rft.normalized_isbn=9780299309305&rft.oclcnum=946770187&rft.mms_id=991028550499703811&rft.object_type=BOOK&rft.publisher=The+University+of+Wisconsin+Press%2C&rft.au=Bledsoe%2C+Lucy+Jane%2C+author.&rft.pubdate=%5B2016%5D&rft.title=A+thin+bright+line+%2F"
+          }]
+        }.to_json
+      }
+
+      it "is false" do
+        expect(helper.only_one_option_allowed(request_options, books, document)).to be false
+      end
+    end
+
+
     context "both a hold and a booking are allowed" do
       let(:books) {}
       let(:document) { { "items_json_display" =>

--- a/spec/helpers/almaws_helper_spec.rb
+++ b/spec/helpers/almaws_helper_spec.rb
@@ -341,6 +341,7 @@ RSpec.describe AlmawsHelper, type: :helper do
     end
 
     context "Temple request options are available" do
+      let(:books) {}
       let(:document) { { "items_json_display" =>
         [{ "item_pid" => "23237957740003811",
         "item_policy" => "5",
@@ -368,6 +369,7 @@ RSpec.describe AlmawsHelper, type: :helper do
 
   describe "#only_one_option_allowed(request_options)" do
     context "only a hold is allowed" do
+      let(:books) {}
       let(:document) { { "items_json_display" =>
         [{ "item_pid" => "23237957740003811",
         "item_policy" => "5",
@@ -388,11 +390,12 @@ RSpec.describe AlmawsHelper, type: :helper do
       }
 
       it "is true" do
-        expect(helper.only_one_option_allowed(request_options, document)).to be true
+        expect(helper.only_one_option_allowed(request_options, books, document)).to be true
       end
     end
 
     context "only an aeon request is allowed" do
+      let(:books) {}
       let(:document) { { "items_json_display" =>
         [{ "item_pid" => "23237957740003811",
         "item_policy" => "5",
@@ -413,11 +416,12 @@ RSpec.describe AlmawsHelper, type: :helper do
       }
 
       it "is true" do
-        expect(helper.only_one_option_allowed(request_options, document)).to be true
+        expect(helper.only_one_option_allowed(request_options, books, document)).to be true
       end
     end
 
     context "only a booking is allowed" do
+      let(:books) {}
       let(:document) { { "items_json_display" =>
         [{ "item_pid" => "23237957740003811",
         "item_policy" => "5",
@@ -438,11 +442,12 @@ RSpec.describe AlmawsHelper, type: :helper do
       }
 
       it "is true" do
-        expect(helper.only_one_option_allowed(request_options, document)).to be true
+        expect(helper.only_one_option_allowed(request_options, books, document)).to be true
       end
     end
 
     context "both a hold and a booking are allowed" do
+      let(:books) {}
       let(:document) { { "items_json_display" =>
         [{ "item_pid" => "23237957740003811",
         "item_policy" => "5",
@@ -481,7 +486,7 @@ RSpec.describe AlmawsHelper, type: :helper do
       }
 
       it "is false" do
-        expect(helper.only_one_option_allowed(request_options, document)).to be false
+        expect(helper.only_one_option_allowed(request_options, books, document)).to be false
       end
     end
   end


### PR DESCRIPTION
- If only one request option is available, the collapse form is supposed to default to being open.  This was not always happening.
- We currently are just checking whether different request options are available, which sometimes results in multiple options being true.  This updates the relevant request options to include additional logic that we pass to limit displays, such as available_asrs_item or non_asrs_item.