### PR TITLE
Update BentoSearch engine root path.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   # mounts
   mount Blacklight::Engine => "/"
   mount BlacklightAdvancedSearch::Engine => "/"
-  mount BentoSearch::Engine => "/bento"
+  mount BentoSearch::Engine => "/everything"
 
   get "books/:id", to: redirect { |_, req| req.url.sub("books", "catalog") }
   get "books", to: redirect { |_, req|


### PR DESCRIPTION
I just noticed that clicking on "Start Over" button always takes you to "/bento".

It should go to "/everything".  This commit fixes that minor issue.