### PR TITLE
Do not inherit default solr configs from the catalog.

### DIFF
--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -12,6 +12,9 @@ class DatabasesController < CatalogController
     config.connection_config = config.connection_config.dup
     config.connection_config[:url] = config.connection_config[:az_url]
 
+    # Do not inherit default solr configs from the catalog.
+    config.default_solr_params = {}
+
     # Facet fields
     config.add_facet_field "az_subject_facet", field: "subject_facet", label: "Subject", limit: true, show: true, collapse: false
     config.add_facet_field "az_format", field: "format", label: "Database Type", limit: -1, show: true, home: true, collapse: false


### PR DESCRIPTION
Catalog solr configs break the databases solr because solr will now
throw an error (solr8 change) when we try to query using fields are not
defined.