### PR TITLE
BL-1088 Blacklight modal bug

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery3
+//= require jquery
 //= require 'blacklight_advanced_search'
 //= require rails-ujs
 //= require popper


### PR DESCRIPTION
- Changing our jQuery to 3 in the application.js file caused the modal functionality to stop working. Revert back to requiring only jQuery