### PR TITLE
BL-1069 seperate out linting, ruby and javascrpit tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,13 @@ jobs:
           name: Build app
           command: NODE_VERSION=v12.13.0 bash .circleci/build.sh
       - run:
-          name: Run tests
+          name: Run linter
+          command: bundle exec rubocop
+      - run:
+          name: Run ruby tests
+          command: RELEVANCE=y bundle exec rake ci
+      - run:
+          name: Run javascript tests
           command: bash .circleci/test.sh
 
   qa_deploy:

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -7,6 +7,4 @@ if [ -z "$(which yarn)" ]; then
   curl -o- -L https://yarnpkg.com/install.sh | bash
 fi
 
-bundle exec rubocop
-RELEVANCE=y bundle exec rake ci
 yarn test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,7 +43,7 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/IndentFirstArgumentIndentation:
+Layout/FirstArgumentIndentation:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
@@ -135,5 +135,7 @@ Layout/EndAlignment:
 Lint/RequireParentheses:
   Enabled: true
 
-Rails:
-  Enabled: true
+# TODO: Fix rubocop-rails not getting used see BL-1072
+#require: rubocop-rails
+#Rails:
+  #Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,8 @@ group :development, :test do
   gem "vcr"
   gem "rails-controller-testing"
   gem "rubocop"
+  # TODO: see BL-1072
+  #gem "rubocop-rails"
 end
 
 gem "rsolr", "~> 2.2"


### PR DESCRIPTION
Fixes ci not reporting failure in ruby tests.