### PR TITLE
Fix DO_INGEST load data option.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       SOLR_URL: "http://solr:8983/solr/blacklight"
       SOLR_AZ_URL: "http://solr:8983/solr/az-database"
       SOLR_WEB_CONTENT_URL: "http://solr:8983/solr/web-content"
+      DO_INGEST: "${DO_INGEST}"
       LC_ALL: "C.UTF-8"
     labels:
       - "traefik.enable=true"


### PR DESCRIPTION
Passes DO_INGEST from local host into the container so that it can be used in the starter script.