### PR TITLE
BL-1061 Fix for digital collections bug

### DIFF
--- a/app/assets/stylesheets/partials/_bento.scss
+++ b/app/assets/stylesheets/partials/_bento.scss
@@ -89,7 +89,7 @@
 	width: 30%;
 
 	a {
-		color: $black;
+		color: $black !important;
 		text-decoration: underline;
 	}
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -36,7 +36,7 @@ class SearchController < CatalogController
   private
     def process_results(results)
       # We only care about cdm results count not bento box.
-      cdm_total_items = results["cdm"]&.total_items
+      cdm_total_items = view_context.number_with_delimiter(results["cdm"]&.total_items)
 
       unless results["books_and_media"].blank?
         items = results["books_and_media"][0...-1]

--- a/app/search_engines/bento_search/cdm_engine.rb
+++ b/app/search_engines/bento_search/cdm_engine.rb
@@ -8,14 +8,7 @@ module BentoSearch
 
     def search_implementation(args)
       query = args.fetch(:query, "")
-
-      # Avoid making a costly call for no reason.
-      if query.empty?
-        response = { "docs" => [] }
-      else
-        response = CDM::find(query)
-      end
-
+      response = CDM::find(query)
       results = BentoSearch::Results.new
       results.total_items = response.dig("results", "pager", "total") || 0
       results << BentoSearch::ResultItem.new(custom_data: response)


### PR DESCRIPTION
- Removes if/else statement so that the total number of results is returned when search query is empty
- Fixes css error where some resource type links were red instead of black
- returns cdm totals with comma delimiter