### PR TITLE
BL-1048 Message on open shelving materials

### DIFF
--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -88,7 +88,7 @@ module AvailabilityHelper
     when "SCRC"
       render partial: "scrc_instructions", locals: { key: key, document: document }
     when "MAIN"
-      if main_stacks_message(key, document) == true
+      if main_stacks_message(key, document)
         render partial: "main_open_shelving_instructions", locals: { key: key, document: document }
       end
     end

--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -74,6 +74,13 @@ module AvailabilityHelper
     }&.any?
   end
 
+  def main_stacks_message(key, document)
+    open_shelf_locations = /hirsch|juvenile|leisure|newbooks|stacks/i
+    current_locations = document["items_json_display"]&.collect { |item| open_shelf_locations.match(item["current_location"]) }
+
+    key == "MAIN" && current_locations.any?
+  end
+
   def library_specific_instructions(key, document)
     case key
     when "ASRS"
@@ -81,7 +88,9 @@ module AvailabilityHelper
     when "SCRC"
       render partial: "scrc_instructions", locals: { key: key, document: document }
     when "MAIN"
-      render partial: "main_open_shelving_instructions", locals: { key: key }
+      if main_stacks_message(key, document) == true
+        render partial: "main_open_shelving_instructions", locals: { key: key, document: document }
+      end
     end
   end
 

--- a/app/views/catalog/_main_open_shelving_instructions.html.erb
+++ b/app/views/catalog/_main_open_shelving_instructions.html.erb
@@ -1,5 +1,3 @@
-<% if key == "MAIN" %>
-  <div id="open-shelving-instructions" class="alert alert-info rounded-0 pl-3 m-0" role="alert">
-    <p class="mb-0"><%= t("requests.open_shelving_instructions") %></p>
-  </div>
-<% end %>
+<div id="open-shelving-instructions" class="alert alert-info rounded-0 pl-3 m-0" role="alert">
+  <p class="mb-0"><%= t("requests.open_shelving_instructions") %></p>
+</div>

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Availability displays" do
   end
 
   feature "MAIN open shelving instructions display" do
-    let (:item) { fixtures.fetch("main_item") }
+    let (:item) { fixtures.fetch("main_item_open_stacks") }
 
     scenario "Items in MAIN open shelving have retrieval instructions" do
       visit "/catalog/#{item['doc_id']}"
@@ -40,5 +40,14 @@ RSpec.feature "Availability displays" do
     end
   end
 
+  feature "MAIN open shelving instructions do not display for closed stack items" do
+    let (:item) { fixtures.fetch("main_item_closed_stacks") }
 
+    scenario "Items in MAIN closed shelving do not display retrieval instructions" do
+      visit "/catalog/#{item['doc_id']}"
+      within first("div.physical-holding-panel") do
+        expect(page).to_not have_css("#open-shelving-instructions")
+      end
+    end
+  end
 end

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -45,9 +45,7 @@ RSpec.feature "Availability displays" do
 
     scenario "Items in MAIN closed shelving do not display retrieval instructions" do
       visit "/catalog/#{item['doc_id']}"
-      within first("div.physical-holding-panel") do
         expect(page).to_not have_css("#open-shelving-instructions")
-      end
     end
   end
 end

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Availability displays" do
 
     scenario "Items in MAIN closed shelving do not display retrieval instructions" do
       visit "/catalog/#{item['doc_id']}"
-        expect(page).to_not have_css("#open-shelving-instructions")
+      expect(page).to_not have_css("#open-shelving-instructions")
     end
   end
 end

--- a/spec/fixtures/availability_features.yml
+++ b/spec/fixtures/availability_features.yml
@@ -4,9 +4,9 @@ asrs_item:
 scrc_item:
   doc_id: "991019830779703811"
   title: "A Peking Opera master in New York."
-main_item_open_stacks:
-  doc_id: "991030159019703811"
-  title: "Education ; being the report of the Ministry of Education and the statistics of public education for England and Wales."
 main_item_closed_stacks:
   doc_id: "991011577589703811"
+  title: "Education ; being the report of the Ministry of Education and the statistics of public education for England and Wales."
+main_item_open_stacks:
+  doc_id: "991030159019703811"
   title: "Dark at the crossing / Elliot Ackerman."

--- a/spec/fixtures/availability_features.yml
+++ b/spec/fixtures/availability_features.yml
@@ -4,6 +4,9 @@ asrs_item:
 scrc_item:
   doc_id: "991019830779703811"
   title: "A Peking Opera master in New York."
-main_item:
+main_item_open_stacks:
   doc_id: "991030159019703811"
+  title: "Education ; being the report of the Ministry of Education and the statistics of public education for England and Wales."
+main_item_closed_stacks:
+  doc_id: "991011577589703811"
   title: "Dark at the crossing / Elliot Ackerman."

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -880,4 +880,51 @@ RSpec.describe AvailabilityHelper, type: :helper do
       end
     end
   end
+
+  describe "#main_stacks_message(key, document)" do
+    context "an item is located on open shelving" do
+      let(:key) { "MAIN" }
+      let(:document) { { "items_json_display" =>
+        [{
+          "item_pid" => "23243112990003811",
+          "item_policy" => "0",
+          "permanent_library" => "MAIN",
+          "permanent_location" => "stacks",
+          "current_library" => "MAIN",
+          "current_location" => "stacks",
+          "call_number_type" => "0",
+          "call_number" => "PS3601.C5456 D37 2017",
+          "holding_id" => "22243113010003811",
+          "material_type" => "BOOK"
+        }]
+      } }
+
+      it "returns true" do
+        expect(main_stacks_message(key, document)).to eq true
+      end
+    end
+
+    context "an item is located on closed shelving" do
+      let(:key) { "MAIN" }
+      let(:document) { { "items_json_display" =>
+        [{
+          "item_pid" => "23303480160003811",
+          "item_policy" => "0",
+          "description" => "1954",
+          "permanent_library" => "ASRS",
+          "permanent_location" => "ASRS",
+          "current_library" => "MAIN",
+          "current_location" => "storage",
+          "call_number_type" => "0",
+          "call_number" => "L341 .A3",
+          "holding_id" => "22454243690003811",
+          "material_type" => "ISSUE"
+        }]
+      } }
+
+      it "returns false" do
+        expect(main_stacks_message(key, document)).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
- We currently display a banner message on all items that are in the MAIN library.  This is misleading for items that are not in the bookbot, but are also not on open shelving(reserves, reference, etc.)
- Refactors the code to display the message based on location and library.  The message should display for any items found in these locations: hirsch, juvenile, leisure, newbooks, stacks