### PR TITLE
BL-1032 Make DVDs requestable

### DIFF
--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -72,6 +72,13 @@ module AlmawsHelper
 
   def available_asrs_items(items = @items.all)
     # Alma bug: item.item_data["requested"] is true for all items on bib level requests.
-    asrs_items(items).select { |item| item.in_place?  }
+    dvds =
+    asrs_items.select { |item|
+      if item.physical_material_type["value"] == "DVD"
+        item
+      else
+        item.in_place?
+      end
+    }
   end
 end

--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -71,7 +71,7 @@ module AlmawsHelper
   end
 
   def available_asrs_items(items = @items.all)
-    asrs_items.select { |item|
+    asrs_items(items).select { |item|
       if item.physical_material_type["value"] == "DVD"
         item
       else

--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -71,8 +71,6 @@ module AlmawsHelper
   end
 
   def available_asrs_items(items = @items.all)
-    # Alma bug: item.item_data["requested"] is true for all items on bib level requests.
-    dvds =
     asrs_items.select { |item|
       if item.physical_material_type["value"] == "DVD"
         item

--- a/spec/helpers/almaws_helper_spec.rb
+++ b/spec/helpers/almaws_helper_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe AlmawsHelper, type: :helper do
       }.to_json
     }
 
-    context "asrs request can be placed on an item" do
+    context "asrs request can be placed on an book that is in_place" do
       let(:item) do
        Alma::BibItem.new(
          "holding_data" => {
@@ -113,6 +113,40 @@ RSpec.describe AlmawsHelper, type: :helper do
              "physical_material_type" => {
                "value" => "BOOK",
                "desc" => "book"
+             },
+         }
+        )
+     end
+
+      it "renders the hold partial" do
+        allow(helper).to receive(:available_asrs_items) { [item] }
+        expect(helper.asrs_allowed_partial(request_options, document)).not_to be_nil
+      end
+    end
+
+    context "asrs request can be placed on a dvd that is checked out" do
+      let(:item) do
+       Alma::BibItem.new(
+         "holding_data" => {
+           "holding_id" => "foo",
+         },
+         "item_data" =>
+         { "base_status" =>
+           { "value" => "0" },
+             "policy" =>
+           { "desc" => "Non-circulating" },
+             "requested" => false,
+             "library" => {
+               "value" => "ASRS",
+               "desc" => "ASRS"
+             },
+             "location" => {
+               "value" => "media",
+               "desc" => "media"
+             },
+             "physical_material_type" => {
+               "value" => "DVD",
+               "desc" => "DVD"
              },
          }
         )


### PR DESCRIPTION
- Currently asrs item requests are restricted to only items that are in place.
- This adjusts the logic so that DVDs can be reserved regardless of whether they are checked out, in trasit, etc.