### PR TITLE
Switch to using alpine based container.

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -7,5 +7,4 @@ RUN bundle install
 CMD ["bash"]
 
 FROM production as development
-RUN apk --update add vim ctags tmux \
-      && cd; wget -qO - https://raw.github.com/dkinzer/.vim/master/deploy.sh | bash
+RUN apk --update add vim

--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,25 +1,11 @@
-FROM ruby:2.6.5-stretch as production
-RUN \
-      wget -qO- https://deb.nodesource.com/setup_8.x | bash - && \
-      wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-      echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-      apt-get update -qq && \
-      apt-get install -y --force-yes --no-install-recommends \
-      nodejs yarn build-essential libpq-dev
+FROM ruby:2.6.5-alpine3.11 as production
+RUN apk --update add nodejs yarn git build-base bash  mysql-dev sqlite-dev tzdata
 RUN mkdir /app
 WORKDIR /app
-ADD Gemfile .
-ADD Gemfile.lock .
-RUN bundle install
 COPY . .
+RUN bundle install
+CMD ["bash"]
 
 FROM production as development
-RUN apt-get update -qq \
-      && apt-get install -y vim ctags tmux \
-      && apt-get clean \
+RUN apk --update add vim ctags tmux \
       && cd; wget -qO - https://raw.github.com/dkinzer/.vim/master/deploy.sh | bash
-ADD Gemfile .
-ADD Gemfile.lock .
-RUN bundle install
-WORKDIR /app
-CMD ["bash"]

--- a/bin/app-start.rb
+++ b/bin/app-start.rb
@@ -20,7 +20,9 @@ File.delete server_pid if File.exist? server_pid
 `bundle install`
 
 # Start rails app but do not block the rest of the script.
-system("rails db:migrate") || raise("Failed rails db:migrate commad")
+if ENV["RAILS_ENV"] != "production"
+  system("rails db:migrate") || raise("Failed rails db:migrate commad")
+end
 system("yarn") || raise("Failed yarn command")
 system("rails webpacker:compile") || raise("Failed rails webpacker:compile command")
 exec("rails s -p 3000 -b '0.0.0.0'") if fork == nil
@@ -28,6 +30,9 @@ exec("rails s -p 3000 -b '0.0.0.0'") if fork == nil
 # Next, provision with test data.
 # (If we do this first it works, but site will be blank until rails app loads).
 # But only ingest if solr is empty
+#
+# Note:
+# This will not work outside of the docker-compose environment.
 def solr_empty?
   solr = RSolr.connect url: "http://solr:8983/solr/blacklight"
   response = solr.get("select", params: { q: "test", rows: 0 })


### PR DESCRIPTION
## Why?
* alpine is a supported official docker image flavor.
* Temple IST scans images for vulnerabilities and debian images always
fail.
* Temple IST will host official ruby alpine images for us on request.

## NOTE:
* The first time you run this use `docker-compose -f docker-compose.yml -f docker-compose.local.yml build --no-cache` in order to force it to rebuild your local images using the new alpine base.
* The first time will take longer because you are fetching the base image and rebuilding your local images from scratch.
