### PR TITLE
Removes obsolete cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,12 +14,6 @@ AllCops:
 Style/AndOr:
   Enabled: true
 
-# Do not use braces for hash literals when they are the last argument of a
-# method call.
-Style/BracesAroundHashParameters:
-  Enabled: true
-  EnforcedStyle: context_dependent
-
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true


### PR DESCRIPTION
The Style/BracesAroundHashParameters cop has been removed from Rubocop.  We need to remove it in order to get the latest Rubocop version.