### PR TITLE
Bl 1108 begins with operator

### DIFF
--- a/app/javascript/packs/controllers/advanced_controller.js
+++ b/app/javascript/packs/controllers/advanced_controller.js
@@ -6,25 +6,25 @@ import { Controller } from "stimulus"
     }
 
 export default class extends Controller {
-  static targets = [ "operator" ]
+  static targets = [ "operator", "options" ]
 
-  connect() {
+  initialize() {
     $("option[value='begins_with']").hide();
   }
 
   select() {
-    let search_options_1 = $("#f_1 option:selected").text();
-    let search_options_2 = $("#f_2 option:selected").text();
-    let search_options_3 = $("#f_3 option:selected").text();
-
+    let count = $(event.currentTarget).data("count");
+    let select_id = $(event.currentTarget).attr("id");
+    let search_options = $(event.currentTarget).children("option:selected").text();
+    let begins_with = document.getElementById(`operator[q_${count}]`);
     let begins_with_options = ["Title", "Author/creator/contributor", "Subject", "Publisher", "Call Number", "Series Title"]
 
-    if(begins_with_options.includes(search_options_1)) {
-      console.log("HI")
-      $("option[value='begins_with']").show();
-      $("option[value='begins_with']").text("begins with");
-    } else {
-      $("option[value='begins_with']").hide();
+    if(select_id.includes(count)) {
+      if(begins_with_options.includes(search_options)) {
+        $(begins_with).children("option[value='begins_with']").show();
+      } else {
+        $(begins_with).children("option[value='begins_with']").hide();
+      }
     }
   }
 }

--- a/app/javascript/packs/controllers/advanced_controller.js
+++ b/app/javascript/packs/controllers/advanced_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "stimulus"
+
+  function getMetaValue(name) {
+      const element = document.head.querySelector(`meta[name="${name}"]`)
+      return element.getAttribute("content")
+    }
+
+export default class extends Controller {
+  static targets = [ "operator" ]
+
+  connect() {
+    $("option[value='begins_with']").hide();
+  }
+
+  select() {
+    let search_options_1 = $("#f_1 option:selected").text();
+    let search_options_2 = $("#f_2 option:selected").text();
+    let search_options_3 = $("#f_3 option:selected").text();
+
+    let begins_with_options = ["Title", "Author/creator/contributor", "Subject", "Publisher", "Call Number", "Series Title"]
+
+    if(begins_with_options.includes(search_options_1)) {
+      console.log("HI")
+      $("option[value='begins_with']").show();
+      $("option[value='begins_with']").text("begins with");
+    } else {
+      $("option[value='begins_with']").hide();
+    }
+  }
+}

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -1,14 +1,14 @@
-<div class="advanced-search-fields container">
+<div class="advanced-search-fields container" data-controller="advanced">
   <% (1..advanced_search_config[:fields_row_count]).each do |count| %>
   <div class="row">
     <div class="col-sm-3 form-group">
       <label for="<%= "f_#{count}" %>" class="sr-only">Options for advanced search</label>
-      <%= select_tag("f_#{count}", options_for_select(advanced_key_value, label_tag_default_for("f_#{count}")), :class=>"form-control") %>
+      <%= select_tag("f_#{count}", options_for_select(advanced_key_value, label_tag_default_for("f_#{count}")), { data: { "action": "advanced#select", count: "#{count}" }, :class=>"form-control" })  %>
     </div>
 
     <div class="col-sm-3 form-group">
       <label for="<%= "operator[q_#{count}]" %>" class="sr-only">Operator</label>
-      <%= select_tag("operator[q_#{count}]", options_for_select({"contains"=> :contains, "is (exact)" => :is, "begins with" => :begins_with}.sort, operator_default(count)), :class => "form-control", :id =>"operator[q_#{count}]") %>
+      <%= select_tag("operator[q_#{count}]", options_for_select({"contains"=> :contains, "is (exact)" => :is, "begins with" => :begins_with}.sort, operator_default(count)), :class => "form-control", :id =>"operator[q_#{count}]", data: { "target": "advanced.operator" }) %>
     </div>
 
     <div class="col-sm-5 form-group">

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -3,12 +3,12 @@
   <div class="row">
     <div class="col-sm-3 form-group">
       <label for="<%= "f_#{count}" %>" class="sr-only">Options for advanced search</label>
-      <%= select_tag("f_#{count}", options_for_select(advanced_key_value, label_tag_default_for("f_#{count}")), { data: { "action": "advanced#select", "count": "#{count}", "target": "advanced.options" }, :class=>"form-control advanced-search-options" })  %>
+      <%= select_tag("f_#{count}", options_for_select(advanced_key_value, label_tag_default_for("f_#{count}")), { data: { "action": "advanced#select", "count": "#{count}" }, :class=>"form-control advanced-search-options" })  %>
     </div>
 
     <div class="col-sm-3 form-group">
       <label for="<%= "operator[q_#{count}]" %>" class="sr-only">Operator</label>
-      <%= select_tag("operator[q_#{count}]", options_for_select({"contains"=> :contains, "is (exact)" => :is, "begins with" => :begins_with}.sort, operator_default(count)), :class => "form-control", :id =>"operator[q_#{count}]", data: { "target": "advanced.operator" }) %>
+      <%= select_tag("operator[q_#{count}]", options_for_select({"contains"=> :contains, "is (exact)" => :is, "begins with" => :begins_with}.sort, operator_default(count)), :class => "form-control", :id =>"operator[q_#{count}]") %>
     </div>
 
     <div class="col-sm-5 form-group">

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col-sm-3 form-group">
       <label for="<%= "f_#{count}" %>" class="sr-only">Options for advanced search</label>
-      <%= select_tag("f_#{count}", options_for_select(advanced_key_value, label_tag_default_for("f_#{count}")), { data: { "action": "advanced#select", count: "#{count}" }, :class=>"form-control" })  %>
+      <%= select_tag("f_#{count}", options_for_select(advanced_key_value, label_tag_default_for("f_#{count}")), { data: { "action": "advanced#select", "count": "#{count}", "target": "advanced.options" }, :class=>"form-control advanced-search-options" })  %>
     </div>
 
     <div class="col-sm-3 form-group">


### PR DESCRIPTION
- The begins with operator does not currently work for all fields.
- This hides the begins with operator when a user selects a field from the search options dropdown that does not support that functionality