### PR TITLE
BL-1108 Hide begins with text when selected (#1729)

### DIFF
--- a/app/javascript/packs/controllers/advanced_controller.js
+++ b/app/javascript/packs/controllers/advanced_controller.js
@@ -21,8 +21,10 @@ export default class extends Controller {
 
     if(select_id.includes(count)) {
       if(begins_with_options.includes(search_options)) {
+        $(begins_with).children("option[value='begins_with']").text("begins with");
         $(begins_with).children("option[value='begins_with']").show();
       } else {
+        $(begins_with).children("option[value='begins_with']").text("");
         $(begins_with).children("option[value='begins_with']").hide();
       }
     }


### PR DESCRIPTION
- If a user has selected the begins with operator and then goes to a field that doesn't support that, it should not still display the words begins with