### PR TITLE
set up release v0.14.2

### DIFF
--- a/app/javascript/packs/controllers/advanced_controller.js
+++ b/app/javascript/packs/controllers/advanced_controller.js
@@ -21,8 +21,10 @@ export default class extends Controller {
 
     if(select_id.includes(count)) {
       if(begins_with_options.includes(search_options)) {
+        $(begins_with).children("option[value='begins_with']").text("begins with");
         $(begins_with).children("option[value='begins_with']").show();
       } else {
+        $(begins_with).children("option[value='begins_with']").text("");
         $(begins_with).children("option[value='begins_with']").hide();
       }
     }


### PR DESCRIPTION
Release notes:
* Add additional webpages to Website search results
* Add phonetic matching for Website search results (ex. a query for “Matt” now returns results for “Matthew”)
* Updated indexing process to exclude “empty” catalog records that do not have an attached holding/item, portfolio, or other electronic resource link
* Updated subject heading displays for “noncitizens" and "undocumented immigrants"
* Fixed “Begins With” operator in Books & Media and Journals advanced search