### PR TITLE
BL-1158 Fix deep paging issue

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -10,6 +10,12 @@ class CatalogController < ApplicationController
 
   before_action :authenticate_purchase_order!, only: [ :purchase_order, :purchase_order_action ]
   before_action :set_thread_request
+  before_action only: :index do
+    if params[:page] && params[:page].to_i > 250
+      flash[:error] = t("blacklight.errors.deep_paging")
+      redirect_to root_path
+    end
+  end
 
   helper_method :browse_creator
   helper_method :display_duration

--- a/app/views/kaminari/blacklight/_paginator.html.erb
+++ b/app/views/kaminari/blacklight/_paginator.html.erb
@@ -1,0 +1,23 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    num_pages:     total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+
+   Paginator now using the Bootstrap paginator class
+-%>
+<%= paginator.render do -%>
+  <ul class="pagination">
+    <%= prev_page_tag %>
+    <%= next_page_tag  %>
+    <% each_relevant_page do |page| -%>
+      <% if page.left_outer? || page.inside_window? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+  </ul>
+<% end -%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
       not_found: "We couldn’t find this page!"
 
     errors:
+      deep_paging: "Sorry, LibrarySearch does not serve more than 250 pages for any query."
       not_found_html: "For help, please %{href} or try a"
       not_found_href: "contact us"
       not_found_link: "https://library.temple.edu/contact-us"

--- a/spec/features/indices_spec.rb
+++ b/spec/features/indices_spec.rb
@@ -108,6 +108,12 @@ RSpec.feature "Indices" do
       visit "catalog/#{item['doc_id']}"
       expect(page).to find(:xpath, "//div[@id='requests-container']/a[contains(@href,'redirect_to')]")
     end
+  end
 
+  feature "Pagination" do
+    scenario "User tries to access page past 250" do
+      visit "/catalog?page=400&q=japan&search_field=all_fields"
+      expect(page).to have_text("Sorry, LibrarySearch does not serve more than 250 pages for any query.")
+    end
   end
 end


### PR DESCRIPTION
- We currently allow users to click on or enter into the web url pages that take too long to load and result in a timeout.
- Removes links from pagination and adds a before action to prevent loading pages past 250