### PR TITLE
blacklight-range-limit update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,8 +56,7 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "blacklight", "~> 7.5.1"
 gem "blacklight_advanced_search", git: "https://github.com/projectblacklight/blacklight_advanced_search.git"
 gem "blacklight-marc", git: "https://github.com/projectblacklight/blacklight-marc.git", ref: "v7.0.0.rc1"
-gem "blacklight_range_limit"
-
+gem "blacklight_range_limit", git: "https://github.com/projectblacklight/blacklight_range_limit.git", ref: "v7.0.0.rc2"
 group :development, :test do
   gem "solr_wrapper", ">= 0.3"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,17 @@ GIT
       parslet
 
 GIT
+  remote: https://github.com/projectblacklight/blacklight_range_limit.git
+  revision: 6826dfb8b73554a79f26ca7ff375b0062e37bb22
+  ref: v7.0.0.rc2
+  specs:
+    blacklight_range_limit (7.0.0.rc2)
+      blacklight
+      jquery-rails
+      rails (>= 3.0)
+      tether-rails
+
+GIT
   remote: https://github.com/tulibraries/alma_rb.git
   revision: c42b01abe2a3f2d177e1502e84d934a1e2eca5e1
   branch: master
@@ -165,8 +176,6 @@ GEM
       jbuilder (~> 2.7)
       kaminari (>= 0.15)
       rails (>= 5.1, < 7)
-    blacklight_range_limit (7.7.0)
-      blacklight (>= 7.0)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     bootstrap (4.4.1)
@@ -493,6 +502,8 @@ GEM
       json
     term-ansicolor (1.7.1)
       tins (~> 1.0)
+    tether-rails (1.4.0)
+      rails (>= 3.1)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -565,7 +576,7 @@ DEPENDENCIES
   blacklight-ris!
   blacklight_advanced_search!
   blacklight_alma!
-  blacklight_range_limit
+  blacklight_range_limit!
   bootsnap
   bootstrap (~> 4.4)
   bootstrap-select-rails


### PR DESCRIPTION
- The newer version of this gem is causing multiple issues with the display of the date range facet. - This reverts back to the version we were using before for now.