### PR TITLE
Update e-notes value field to be text not json.

### DIFF
--- a/app/models/json_store.rb
+++ b/app/models/json_store.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class JsonStore < ApplicationRecord
+  serialize :value, JSON
 end

--- a/db/migrate/20200422020027_create_json_stores.rb
+++ b/db/migrate/20200422020027_create_json_stores.rb
@@ -4,7 +4,7 @@ class CreateJsonStores < ActiveRecord::Migration[5.2]
   def change
     create_table :json_stores do |t|
       t.string :name, index: { unique: true }
-      t.json :value
+      t.text :value
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2020_04_22_020027) do
 
   create_table "json_stores", force: :cascade do |t|
     t.string "name"
-    t.json "value"
+    t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_json_stores_on_name", unique: true


### PR DESCRIPTION
JSON fields are not allowed in our version of MariaDb.

This commit updates our schema/migration to create and use a text field.

The model has been updated to auto-magically serialize into JSON.