### PR TITLE
Update tul_cob CI to be master branch only.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,15 @@ workflows:
          filters:
            branches:
              only:
-               - qa
+               - master
   stage_deploy:
     jobs:
       - stage_deploy:
           filters:
             branches:
-              only:
-                - master
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*$/
   prod_deploy:
     jobs:
       - request-prod-deploy:

--- a/.circleci/deploy-stage.sh
+++ b/.circleci/deploy-stage.sh
@@ -11,5 +11,5 @@ cp .circleci/.vault ~/.vault # setup vault password retrieval from travis envvar
 chmod +x ~/.vault  # setup vault password retrieval from travis envvar
 
 # deploy to qa using ansible-playbook
-pipenv run ansible-playbook -i inventory/stage playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' --private-key=~/.ssh/.conan_the_deployer --skip-tags "solr"
+pipenv run ansible-playbook -i inventory/stage playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' --private-key=~/.ssh/.conan_the_deployer --limit=app -e rails_app_git_branch=$CIRCLE_TAG -vv
 echo "BE AWARE THAT SOLR CONFIG CHANGES WERE NOT DEPLOYED AS PART OF THIS BUILD"

--- a/doc/deployment-process.md
+++ b/doc/deployment-process.md
@@ -7,12 +7,12 @@ QA, Stage and Production Deployments
 
 ### Stage Deployments
 * Stage deployments are triggered automatically by the CI service [when a new release
-  is tagged](doc/new-release-process.md).
+  is tagged](new-release-process.md).
 
 ### Production Deployments
 * Production deployments are triggered on confirmation. The deployment
   confirmation is queued [when a new release is
-  tagged](doc/new-release-process.md).
+  tagged](new-release-process.md).
 
 ## Production Deployment Checklist
 Deployments to the production environment MUST adhere to the following checklist.

--- a/doc/deployment-process.md
+++ b/doc/deployment-process.md
@@ -1,0 +1,27 @@
+QA, Stage and Production Deployments
+====
+
+### QA Deployments
+* Deployments to the QA environment are triggered automatically by the CI service
+  whenever a PR is merged to the master branch.
+
+### Stage Deployments
+* Stage deployments are triggered automatically by the CI service [when a new release
+  is tagged](doc/new-release-process.md).
+
+### Production Deployments
+* Production deployments are triggered on confirmation. The deployment
+  confirmation is queued [when a new release is
+  tagged](doc/new-release-process.md).
+
+## Production Deployment Checklist
+Deployments to the production environment MUST adhere to the following checklist.
+
+- [ ] Verify that all required updates have been made to tul_cob_playbook/master
+- [ ] Before confirming a production for deployment check that the stage
+  version is up and that you have confirmation that it is ready to be deployed.
+- [ ] Announce on the #blacklight_project channel that deployment is about to take place.
+- [ ] Allow a minute or two to get any objections via slack.
+- [ ] Follow the deployment on the CI service in case there are issues.
+- [ ] After the deployment is complete post success or failure on slack (to be automated).
+- [ ] Smoke test the deployment.

--- a/doc/new-release-process.md
+++ b/doc/new-release-process.md
@@ -1,0 +1,18 @@
+Create a new tagged release for tul_cob
+===
+
+This document describes how to create a new tag for the tul_cob project.  This
+is required when we want to deploy a change to stage or production.
+
+* Go to the release pages on tul_cob: https://github.com/tulibraries/tul_cob/releases
+* Click on the "Draft New Release" button on the top right.
+* In the "Tag Version" text box, enter the new tag name (ex. v0.7.5)
+* Click the target button and select appropriate target branch.
+  * Regular deployment: *master*.
+  * Hotfix deployment: `hotfix` branch (whatever it's called)
+* Fill out the "Release title" input (ex. HotFix(v0.7.5) ) 
+* Add the description.
+* Save
+
+_Note: If you need to save a draft just make sure that when you come back to it
+that you are still pointing the release to the master branch._


### PR DESCRIPTION
CI will now.
* Deploy to tul_cob/qa on merges to master branch.
* Automatically deploy to stage when a new release is created.
* Deploy to production on confirmation when a new release is created.