### PR TITLE
Fix recursive cache copying on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,10 @@ jobs:
 
       - restore_cache:
           keys:
-            - gem-cache-v3-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - gem-cache-v3-{{ arch }}-{{ .Branch }}
-            - gem-cache-v3-{{ arch }}
-            - yarn-cache-v3-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
+            - gem-cache-v4-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - gem-cache-v4-{{ arch }}-{{ .Branch }}
+            - gem-cache-v4-{{ arch }}
+            - yarn-cache-v4-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
 
       
       - setup_remote_docker:
@@ -84,11 +84,11 @@ jobs:
           command: make ci-copy-node-modules-to-local
       
       - save_cache:
-          key: gem-cache-v3-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: gem-cache-v4-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
               - vendor/bundle
       - save_cache:    
-          key: yarn-cache-v3-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          key: yarn-cache-v4-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
               - node_modules
 

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,16 @@ ci-up:
 	$(CI-DOCKER) up -d
 
 ci-copy-bundle-files:
-	if [ -d vendor/bundle ]; then docker cp vendor/bundle tul_cob_app_1:/app/vendor/bundle; fi
+	if [ -d vendor/bundle ]; then docker cp vendor/bundle tul_cob_app_1:/app/vendor/; fi
 
 ci-copy-bundle-files-to-local:
-	docker cp tul_cob_app_1:/app/vendor/bundle vendor/bundle
+	docker cp tul_cob_app_1:/app/vendor/bundle vendor/
 
 ci-copy-node-modules:
-	if [ -d node_modules ]; then  docker cp node_modules tul_cob_app_1:/app/node_modules; fi
+	if [ -d node_modules ]; then  docker cp node_modules tul_cob_app_1:/app/; fi
 
 ci-copy-node-modules-to-local:
-	docker cp tul_cob_app_1:/app/node_modules node_modules 
+	docker cp tul_cob_app_1:/app/node_modules .
 
 ci-bundle-install:
 	$(CI-DOCKER) exec app bundle install --path vendor/bundle


### PR DESCRIPTION
The way we were copying cache between circle coordinator and remote
docker machines was recursively copying direcctoires inside of already
existing directories. Doing this over and over again built a huge cache
of many copies of our bundled files. This fixes that.