### PR TITLE
Apply security updates for js.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "@stimulus/polyfills": "^1.1.0",
     "babel-preset-es2015": "^6.24.1",
     "bootstrap-select": "^1.13.2",
+    "js-yaml": "3.13.1",
     "npm": "^6.4.0",
+    "serialize-javascript": "2.1.1",
     "stimulus": "^1.1.0",
     "whatwg-fetch": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6010,7 +6010,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.12.0, js-yaml@^3.13.1, js-yaml@^3.7.0:
+js-yaml@3.13.1, js-yaml@^3.12.0, js-yaml@^3.13.1, js-yaml@^3.7.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -10298,6 +10298,11 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
+
+serialize-javascript@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.1.tgz#952907a04a3e3a75af7f73d92d15e233862048b2"
+  integrity sha512-MPLPRpD4FNqWq9tTIjYG5LesFouDhdyH0EPY3gVK4DRD5+g4aDqdNSzLIwceulo3Yj+PL1bPh6laE5+H6LTcrQ==
 
 serialize-javascript@^1.4.0:
   version "1.9.1"


### PR DESCRIPTION
* Js-yaml: prior to 3.13.1 are vulnerable to Code Injection. The load()
function may execute arbitrary code injected through a malicious YAML
file.

* serialize-javascript: Affected versions of this package are vulnerable
to Cross-site Scripting (XSS). It does not properly mitigate against
unsafe characters in serialized regular expressions.