### PR TITLE
Enable searchCDI for Article searches.

### DIFF
--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -22,7 +22,7 @@ module Blacklight::PrimoCentral::Document
     @url_query = url_query
 
     # Dots and slahes break links to articles.
-    doc["pnxId"] ||= doc.dig("pnx", "search", "recordid")&.first
+    doc["pnxId"] ||= doc.dig("pnx", "control", "recordid")&.first
     doc["pnxId"] = doc["pnxId"]&.gsub(".", "-dot-")
     doc["pnxId"] = doc["pnxId"]&.gsub("/", "-slash-")
     doc["pnxId"] = doc["pnxId"]&.gsub(";", "-semicolon-")

--- a/app/models/blacklight/primo_central/repository.rb
+++ b/app/models/blacklight/primo_central/repository.rb
@@ -17,6 +17,7 @@ module Blacklight::PrimoCentral
     # Execute a search against Primo PNXS API.
     def search(params = {})
       data = params[:query]
+      data["searchCDI"] = true
 
       duration =
         if data[:id]


### PR DESCRIPTION
* Fixes issue with using the incorrect id.
* Enables searchCDI for Primo Search API requests.

Depends on:
- [ ] tulibraries/primo#30