### PR TITLE
BL-1190 Hide temporary recall link

### DIFF
--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -13,9 +13,10 @@ module AvailabilityHelper
     if unavailable_libraries.include?(item.library) ||
         unavailable_locations.include?(item.location)
 
-      library_link = "#{Rails.configuration.library_link}forms/storage-request"
+      # library_link = "#{Rails.configuration.library_link}forms/storage-request"
 
-      label = "In temporary storage — " + link_to("Recall item now", library_link)
+      label = "In temporary storage"
+      # + link_to("Recall item now", library_link)
 
       content_tag(:span, "", class: "close-icon") + raw(label)
     elsif item.in_place? && item.item_data["requested"] == false

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
       end
 
       it "links to new outside form" do
-        label = "<span class=\"close-icon\"></span>In temporary storage — <a href=\"https://library.temple.edu/forms/storage-request\">Recall item now</a>"
+        label = "<span class=\"close-icon\"></span>In temporary storage"
 
         expect(availability_status(item)).to eq(label)
       end


### PR DESCRIPTION
- This is a temporary change due to the library closure so that patrons can't request physical materials