### PR TITLE
BL-1175 lccn data attribute

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -31,10 +31,7 @@ module CatalogHelper
   end
 
   def lccn_data_attribute(document)
-    values = document.fetch(:lccn_display, [])
-    values = [values].flatten.map { |value|
-      value.gsub(/\D/, "") if value
-    }.compact.join(",")
+    values = document.fetch(:lccn_display, []).compact.join(",")
 
     "data-lccn=#{values}" if !values.empty?
   end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -29,10 +29,19 @@ RSpec.describe CatalogHelper, type: :helper do
       end
     end
 
-    context "document contains an isbn" do
+    context "document does not contain an isbn" do
       let(:document) { {} }
-      it "returns the data-isbn string" do
+      it "does not return the data-isbn string" do
         expect(isbn_data_attribute(document)).to be_nil
+      end
+    end
+  end
+
+  describe "#lccn_data_attribute" do
+    context "document contains an lccn" do
+      let(:document) { { lccn_display: ["sn#00061556"] } }
+      it "returns the data-lccn string" do
+        expect(lccn_data_attribute(document)).to eql "data-lccn=sn#00061556"
       end
     end
   end


### PR DESCRIPTION
- lccn numbers should include alphabetic prefixes.  This removes the logic that stripped lccn numbers down to only digits and adds a test.