### PR TITLE
BL-1171: Update blacklight_range_limit.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "blacklight", "~> 7.8.0"
 gem "blacklight_advanced_search", git: "https://github.com/projectblacklight/blacklight_advanced_search.git"
 gem "blacklight-marc", git: "https://github.com/projectblacklight/blacklight-marc.git", ref: "v7.0.0.rc1"
-gem "blacklight_range_limit", git: "https://github.com/projectblacklight/blacklight_range_limit.git", ref: "v7.0.0.rc2"
+gem "blacklight_range_limit", git: "https://github.com/projectblacklight/blacklight_range_limit.git", ref: "v7.8.0"
 group :development, :test do
   gem "solr_wrapper", ">= 0.3"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,14 +21,11 @@ GIT
 
 GIT
   remote: https://github.com/projectblacklight/blacklight_range_limit.git
-  revision: 6826dfb8b73554a79f26ca7ff375b0062e37bb22
-  ref: v7.0.0.rc2
+  revision: 44bfecba9d3c123fa01d6874288b0dc452fdb2a6
+  ref: v7.8.0
   specs:
-    blacklight_range_limit (7.0.0.rc2)
-      blacklight
-      jquery-rails
-      rails (>= 3.0)
-      tether-rails
+    blacklight_range_limit (7.8.0)
+      blacklight (>= 7.0)
 
 GIT
   remote: https://github.com/tulibraries/alma_rb.git
@@ -506,8 +503,6 @@ GEM
       json
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    tether-rails (1.4.0)
-      rails (>= 3.1)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -200,3 +200,9 @@ $(document).on('turbolinks:load', function() {
 		document.getElementById("main-toggler-icon").classList.toggle("change");
 	}
 }
+
+// This hack helps with a race condition bug in blacklight_range_limit gem.
+// REF: BL-1171 and project_blacklight/blacklight_range_limit#111
+window.addEventListener('load', function(event) {
+   $("#facet-pub_date_sort").trigger("shown.bs.collapse");
+});

--- a/app/assets/stylesheets/icons.css.erb
+++ b/app/assets/stylesheets/icons.css.erb
@@ -279,6 +279,10 @@ span.remove-icon {
   padding-left: 1.25rem;
 }
 
+.range_limit span.remove-icon {
+  display: none;
+}
+
 span.plus-icon {
   background: transparent url(<%= asset_path "icons/plus.svg" %>) no-repeat top left;
   padding-left: 1.25rem;

--- a/app/assets/stylesheets/tucob.scss.erb
+++ b/app/assets/stylesheets/tucob.scss.erb
@@ -243,6 +243,12 @@ img {
   to { -webkit-transform: rotate(360deg); }
 }
 
+// Overrides blacklight_range_limit settings.
+.range_limit .chart_js {
+  margin-left: 0px !important;
+  margin-right: 0px !important;
+}
+
 // This is a trick that can be used when chrome tools is displaying extra white space
 // It helps to identify which element is causing the problem
 // * {

--- a/app/helpers/render_constraints_helper_behavior_override.rb
+++ b/app/helpers/render_constraints_helper_behavior_override.rb
@@ -19,4 +19,26 @@ module RenderConstraintsHelperBehaviorOverride
                                 classes: ["filter", "filter-" + facet.parameterize])
     end, "\n")
   end
+  ##
+  # Override with v7.5.0 version do to bug.
+  #
+  # @see https://github.com/projectblacklight/blacklight_range_limit/issues/152
+  # #
+  def render_constraints_filters(my_params = params)
+    content = super(my_params)
+    # add a constraint for ranges?
+    if my_params[:range].present? && my_params[:range].respond_to?(:each_pair)
+      my_params[:range].each_pair do |solr_field, hash|
+
+        next unless hash["missing"] || (!hash["begin"].blank?) || (!hash["end"].blank?)
+        content << render_constraint_element(
+          facet_field_label(solr_field),
+          range_display(solr_field, my_params),
+          escape_value: false,
+          remove: remove_range_param(solr_field, my_params)
+        )
+      end
+    end
+    return content
+  end
 end


### PR DESCRIPTION
* Updates blacklight_range_limit to latest version.
* Patches JS issue (projectblacklight/blacklight_range_limit#111)
* Hides remove button (to keep current behavior)
* Patches render_constraints_filters method (projectblacklight/blacklight_range_limit#152)

Does not override the range limit view because we would need to override the entire view and thus lose possible upgrade changes.

New version:
![image](https://user-images.githubusercontent.com/444215/85463915-12d56f00-b575-11ea-9a74-ac5a4c6973b5.png)

Old version:
![image](https://user-images.githubusercontent.com/444215/85463997-2aacf300-b575-11ea-8c67-6c40a55ac06e.png)
