### PR TITLE
Don't limit to app in deploys

### DIFF
--- a/.circleci/deploy-prod.sh
+++ b/.circleci/deploy-prod.sh
@@ -10,5 +10,5 @@ pipenv run ansible-galaxy install -r requirements.yml # install playbook role re
 echo $ANSIBLE_VAULT_PASSWORD > ~/.vault
 
 # deploy to qa using ansible-playbook
-pipenv run ansible-playbook -i inventory/prod playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' --private-key=~/.ssh/.conan_the_deployer --limit=app -e rails_app_git_branch=$CIRCLE_TAG -vv
+pipenv run ansible-playbook -i inventory/prod playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' --private-key=~/.ssh/.conan_the_deployer -e rails_app_git_branch=$CIRCLE_TAG -vv
 echo "BE AWARE THAT SOLR CONFIG CHANGES WERE NOT DEPLOYED AS PART OF THIS BUILD"

--- a/.circleci/deploy-qa.sh
+++ b/.circleci/deploy-qa.sh
@@ -10,5 +10,5 @@ pipenv run ansible-galaxy install -r requirements.yml # install playbook role re
 echo $ANSIBLE_VAULT_PASSWORD > ~/.vault
 
 # deploy to qa using ansible-playbook
-pipenv run ansible-playbook -i inventory/qa playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' --private-key=~/.ssh/.conan_the_deployer --limit=app -e rails_app_git_branch=main -vv
+pipenv run ansible-playbook -i inventory/qa playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' --private-key=~/.ssh/.conan_the_deployer -e rails_app_git_branch=main -vv
 echo "BE AWARE THAT SOLR CONFIG CHANGES WERE NOT DEPLOYED AS PART OF THIS BUILD"

--- a/.circleci/deploy-stage.sh
+++ b/.circleci/deploy-stage.sh
@@ -10,5 +10,5 @@ pipenv run ansible-galaxy install -r requirements.yml # install playbook role re
 echo $ANSIBLE_VAULT_PASSWORD > ~/.vault
 
 # deploy to qa using ansible-playbook
-pipenv run ansible-playbook -i inventory/stage playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' --private-key=~/.ssh/.conan_the_deployer --limit=app -e rails_app_git_branch=$CIRCLE_TAG -vv
+pipenv run ansible-playbook -i inventory/stage playbook.yml --vault-password-file=~/.vault -e 'ansible_ssh_port=9229' --private-key=~/.ssh/.conan_the_deployer -e rails_app_git_branch=$CIRCLE_TAG -vv
 echo "BE AWARE THAT SOLR CONFIG CHANGES WERE NOT DEPLOYED AS PART OF THIS BUILD"


### PR DESCRIPTION
We introduced ansible flag `--limit=app` to preovent solr changes from being pushed, but this also prevented db changes from being pushed, which was an undesired side effect.

Now that all deplys happen via thos repo, and not via tul_cob_playbook, we need to remove the limit so changes to the db server get deployed.