### PR TITLE
Bl 1247 bento empty query errors

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -32,6 +32,11 @@ class CatalogController < ApplicationController
     render "errors/unsupported_query"
   end
 
+  rescue_from NoMethodError do |exception|
+    Honeybadger.notify(exception.message)
+    render "errors/internal_server_error"
+  end
+
   configure_blacklight do |config|
     # default advanced config values
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new

--- a/app/search_engines/bento_search/primo_engine.rb
+++ b/app/search_engines/bento_search/primo_engine.rb
@@ -10,7 +10,7 @@ module BentoSearch
 
       # Avoid making a costly call for no reason.
       if query.empty?
-        response = { "docs" => [] }
+        response = Blacklight::PrimoCentral::Response.new({ "docs" => [], "numFound" => 0 })
       else
         user_params = { q: query, per_page: per_page }
         config = blacklight_config

--- a/spec/search_engines/primo_search_spec.rb
+++ b/spec/search_engines/primo_search_spec.rb
@@ -22,6 +22,15 @@ RSpec.describe BentoSearch, type: :search_engine do
     it "uses TulStandardDecorator" do
       expect(item.decorator).to eq("TulDecorator")
     end
+
+    it "doesn't bother sending an empty query to Primo" do
+      empty_search_results = VCR.use_cassette("bento_search_primo") do
+        primo_se.search("")
+      end
+
+      expect(empty_search_results).to be_a(BentoSearch::Results)
+      expect(empty_search_results.none?).to be true
+    end
   end
 
 end


### PR DESCRIPTION
This will change the Primo bento message from an error to a "no results found" when the query is empty. It also adds a catch for NoMethod errors in the controller.