### PR TITLE
BL-1248: Make sure query is URL encoded.

### DIFF
--- a/app/search_engines/bento_search/cdm_engine.rb
+++ b/app/search_engines/bento_search/cdm_engine.rb
@@ -7,7 +7,7 @@ module BentoSearch
     delegate :blacklight_config, to: ::SearchController
 
     def search_implementation(args)
-      query = args.fetch(:query, "")
+      query = CGI.escape(CGI.unescape(args.fetch(:query, "")))
       response = CDM::find(query)
       results = BentoSearch::Results.new
       results.total_items = response.dig("results", "pager", "total") || 0

--- a/spec/search_engines/cdm_seach_spec.rb
+++ b/spec/search_engines/cdm_seach_spec.rb
@@ -4,15 +4,26 @@ require "rails_helper"
 
 RSpec.describe "cdm search engine", type: :search_engine do
 
-  let(:search_results) { BentoSearch.get_engine("cdm").search("foo") }
+  let(:query) { "foo" }
+  let(:search_results) { BentoSearch.get_engine("cdm").search(query) }
   let(:content_dm_results) { { "results" => { "pager" => { "total" => "415" } } } }
 
-  it "sets the total found items" do
+  before do
     stub_request(:get, /contentdm/)
       .to_return(status: 200,
     headers: { "Content-Type" => "application/json" },
     body: JSON.dump(content_dm_results))
+  end
 
+  it "sets the total found items" do
     expect(search_results.total_items).to eq("415")
+  end
+
+  context "non ASCII query" do
+    let(:query) { "Read Myron H. Dembo. 2004. Motivation and Learning Strategies for College Success: A Self-Management Approach, Chapter 1, “Academic Self-Management,” 3-17." }
+
+    it "handles non asci queries" do
+      expect(search_results.total_items).to eq("415")
+    end
   end
 end


### PR DESCRIPTION
Fixes URI::InvalidURIError error in CDM search context.