### PR TITLE
Add feature flag for campus closure

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,6 +54,11 @@ class ApplicationController < ActionController::Base
     redirect_to request.referer
   end
 
+  def campus_closed?
+    ::FeatureFlags.campus_closed?(params)
+  end
+  helper_method :campus_closed?
+
   protected
 
     def no_cache

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module FeatureFlags
+  def self.campus_closed?(params = nil)
+    # a passed campus_closed param overrides env var
+    if !params.nil? && params.has_key?("campus_closed")
+      return (params["campus_closed"] == "false") ? false : true
+    end
+    !!Rails.configuration.features.fetch(:campus_closed, false)
+  end
+end

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -3,3 +3,6 @@
 Rails.application.config.features[:login_disabled] = ENV["RAILS_LOGIN_DISABLED"] || false
 Rails.application.config.features[:email_document_action_disabled] = ENV["EMAIL_DOCUMENT_ACTION_DISABLED"] || false
 Rails.application.config.features[:sms_document_action_disabled] = ENV["SMS_DOCUMENT_ACTION_DISABLED"] || false
+
+# Deaults to false. If env var is set, will only evaluate to false if the value is "false". All others values evaluate to true
+Rails.configuration.features[:campus_closed] = (ENV.fetch("CAMPUS_CLOSED", "false") == "false") ? false : true

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,4 +12,14 @@ RSpec.describe ApplicationController, type: :controller do
     expect(sign_out_url).to_not be_nil
     expect(controller.after_sign_out_path_for(:foo)).to eq(sign_out_url)
   end
+
+  describe "#campus_closed?" do
+    it "returns false with an empty params object method" do
+      expect(controller.campus_closed?).to be(false)
+    end
+    it "returns true when campus_closed param is not 'false'" do
+      controller.params["campus_closed"] = "true"
+      expect(controller.campus_closed?).to be(true)
+    end
+  end
 end

--- a/spec/lib/feature_flags_spec.rb
+++ b/spec/lib/feature_flags_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rails_helper"
+
+RSpec.describe ::FeatureFlags do
+  describe "#campus_closed?" do
+
+    let(:params_hash) { {} }
+    let(:params) { ActionController::Parameters.new(params_hash) }
+    let(:cc_with_param) { described_class.campus_closed?(params) }
+
+    context "when the Rails.config.features[:campus_closed] is default value"  do
+      it "returns false" do
+        expect(described_class.campus_closed?).to be(false)
+      end
+      context "when request_params parameter is passed" do
+        context "that does not include a campus_closed param" do
+          it "returns false" do
+            (expect(cc_with_param).to be(false))
+          end
+        end
+        context "that includes a campus_closed param of 'true'" do
+          let(:params_hash) { { campus_closed: "true" } }
+          it "returns true" do
+            (expect(cc_with_param).to be(true))
+          end
+        end
+        context "that includes a campus_closed param of 'yes'" do
+          let(:params_hash) { { campus_closed: "yes" } }
+          it "returns true" do
+            (expect(cc_with_param).to be(true))
+          end
+        end
+        context "that includes a campus_closed param of 'false'" do
+          let(:params_hash) { { campus_closed: "false" } }
+          it "returns false" do
+            (expect(cc_with_param).to be(false))
+          end
+        end
+        context "that includes a campus_closed param of '0'" do
+          let(:params_hash) { { campus_closed: "0" } }
+          it "returns false" do
+            (expect(cc_with_param).to be(true))
+          end
+        end
+      end
+    end
+    context "when Rails.config.features[:campus_closed] has been set" do
+      before(:each) do
+        allow(Rails.configuration.features)
+          .to receive(:fetch)
+          .with(:campus_closed, false)
+          .and_return("true")
+      end
+
+      it "returns true" do
+        expect(described_class.campus_closed?).to be(true)
+      end
+      context "when request_params parameter is passed" do
+        context "that does not include a campus_closed param" do
+          it "returns true" do
+            (expect(cc_with_param).to be(true))
+          end
+        end
+        context "that includes a campus_closed param of 'true'" do
+          let(:params_hash) { { campus_closed: "true" } }
+          it "returns true" do
+            (expect(cc_with_param).to be(true))
+          end
+        end
+        context "that includes a campus_closed param of 'yes'" do
+          let(:params_hash) { { campus_closed: "yes" } }
+          it "returns true" do
+            (expect(cc_with_param).to be(true))
+          end
+        end
+        context "that includes a campus_closed param of 'false'" do
+          let(:params_hash) { { campus_closed: "false" } }
+          it "returns false" do
+            (expect(cc_with_param).to be(false))
+          end
+        end
+        context "that includes a campus_closed param of '0'" do
+          let(:params_hash) { { campus_closed: "0" } }
+          it "returns false" do
+            (expect(cc_with_param).to be(true))
+          end
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION

﻿Adds a feature flag that can toggle functionality that depends if our campus as open as ususal,  or closed for long periods of time because of social distancing requirements.

The feature flag uses the env var $CAMPUS_CLOSED, defaulting to false if the env var does not exist. If env var is set, will only evaluate to false if the value is "false". All others values evaluate to true.

The env var flag can be overriden by a URL paramter "campus_closed". If the URL parameter is present passed and the value is "false", the flag will evaluate as false. Any other value passed to the URL paramter will icause the flag to be evaluated as true.

Adds the class `FeatureFlags` with the method `campus_closed?` so that it can be called from anywhere in the code base.

Adds a convenience helper_method to the application_controller so that it can be called from controller or views with the the controller `params` hash passed as a paramater.
