### PR TITLE
#BL-1261 Styling - Remove cancel button

### DIFF
--- a/app/views/almaws/request_options.html.erb
+++ b/app/views/almaws/request_options.html.erb
@@ -1,6 +1,5 @@
 <div class="modal-header request-options-header justify-space-between">
   <h1 id="modal-title"><%= t("requests.header") %></h1>
-  <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true"><%= modal_exit_button_name(@make_modal_link) %></span></button>
 </div>
 
 <div class="modal-body">


### PR DESCRIPTION
Removed X close button from request pop-up.

Removing the Cancel button had negative implications for users tabbing, or using other assistive technologies. 