### PR TITLE
#BL-1127 Workwround for improperly formatted expiry date

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GIT
 
 GIT
   remote: https://github.com/tulibraries/primo
-  revision: 90d827bea5f85cfebc4e43004deadf232116568a
+  revision: fdbeda21a96480861e73d1e9b941786de1b3580a
   branch: main
   specs:
     primo (0.1.0)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -4,10 +4,16 @@ module UsersHelper
   require "date"
 
   def expiry_date(hold)
-    # Correct improper ISO8601 date from Alma - Trailing 'Z'
-    hold.expiry_date.chop! if hold.expiry_date.last == "Z"
-
-    make_date(hold.expiry_date) rescue "N/A"
+    begin
+      make_date(hold.expiry_date)
+    rescue
+      # Correct improper ISO8601 date from Alma - Trailing 'Z'
+      if hold.expiry_date.last == "Z"
+        make_date(hold.expiry_date.chop) rescue "N/A"
+      else
+        "N/A"
+      end
+    end
   end
 
   def make_date(date)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -7,7 +7,7 @@ module UsersHelper
     begin
       make_date(DateTime.parse(hold.expiry_date).to_s)
     rescue => exception
-      Honeybadger.notify("On Hold Expiry Date error: #{exception.message}")
+      Honeybadger.notify("On Hold Expiry Date error: #{exception.message}") unless hold.expiry_date.blank?
       "N/A"
     end
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -5,14 +5,10 @@ module UsersHelper
 
   def expiry_date(hold)
     begin
-      make_date(hold.expiry_date)
-    rescue
-      # Correct improper ISO8601 date from Alma - Trailing 'Z'
-      if hold.expiry_date.last == "Z"
-        make_date(hold.expiry_date.chop) rescue "N/A"
-      else
-        "N/A"
-      end
+      make_date(DateTime.parse(hold.expiry_date).to_s)
+    rescue => exception
+      Honeybadger.notify("On Hold Expiry Date error: #{exception.message}")
+      "N/A"
     end
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -4,6 +4,9 @@ module UsersHelper
   require "date"
 
   def expiry_date(hold)
+    # Correct improper ISO8601 date from Alma - Trailing 'Z'
+    hold.expiry_date.chop! if hold.expiry_date.last == "Z"
+
     make_date(hold.expiry_date) rescue "N/A"
   end
 

--- a/app/views/almaws/request_options.html.erb
+++ b/app/views/almaws/request_options.html.erb
@@ -16,8 +16,8 @@
   <%= digitization_allowed_partial(@request_options, @document) %>
   <%= booking_allowed_partial(@request_options, @document) %>
   <%= resource_sharing_broker_allowed_partial(@request_options, @books, @document) %>
-  <%= digital_copy_partial(@request_options, @books, @document) %>
   <%= aeon_request_partial(@request_options, @document) %>
+  <%= digital_copy_partial(@request_options, @books, @document) %>
   <%= no_temple_request_options_available(@request_options, @books, @document) %>
 
   </div>

--- a/app/views/almaws/request_options.html.erb
+++ b/app/views/almaws/request_options.html.erb
@@ -8,7 +8,9 @@
   </div>
 
   <div class="panel-group request-group" id="request-accordian-<%= @mms_id %>">
-  <%= open_shelves_partial(@request_options, @books, @document) %>
+  <% if @items.any?(&:in_place?) %>
+    <%= open_shelves_partial(@request_options, @books, @document) %>
+  <% end %>
   <%= asrs_allowed_partial(@request_options, @document) %>
   <%= hold_allowed_partial(@request_options, @document) %>
   <%= digitization_allowed_partial(@request_options, @document) %>

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe UsersHelper, type: :helper do
       hold = Hold.new("2020-09-01")
 
       it "returns a valid time" do
+        expect(Honeybadger).to_not receive(:notify)
         expect(expiry_date(hold)).to eq "08/31/2020"
       end
     end
@@ -25,6 +26,7 @@ RSpec.describe UsersHelper, type: :helper do
       hold = Hold.new("2020-09-01Z")
 
       it "returns a valid time anyway" do
+        expect(Honeybadger).to_not receive(:notify)
         expect(expiry_date(hold)).to eq "08/31/2020"
       end
     end
@@ -34,6 +36,7 @@ RSpec.describe UsersHelper, type: :helper do
       hold = Hold.new("2018-10-16T02:00:00Z")
 
       it "returns N/A" do
+        expect(Honeybadger).to_not receive(:notify)
         expect(expiry_date(hold)).to eq "10/15/2018"
       end
     end
@@ -43,6 +46,17 @@ RSpec.describe UsersHelper, type: :helper do
       hold = Hold.new("")
 
       it "returns N/A" do
+        expect(Honeybadger).to receive(:notify)
+        expect(expiry_date(hold)).to eq "N/A"
+      end
+    end
+
+    context "No expiry date" do
+      Hold = Struct.new(:expiry_date)
+      hold = Hold.new(nil)
+
+      it "returns N/A" do
+        expect(Honeybadger).to receive(:notify)
         expect(expiry_date(hold)).to eq "N/A"
       end
     end
@@ -52,6 +66,7 @@ RSpec.describe UsersHelper, type: :helper do
       hold = Hold.new("XYZ")
 
       it "returns N/A" do
+        expect(Honeybadger).to receive(:notify)
         expect(expiry_date(hold)).to eq "N/A"
       end
     end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe UsersHelper, type: :helper do
       hold = Hold.new("")
 
       it "returns N/A" do
-        expect(Honeybadger).to receive(:notify)
+        expect(Honeybadger).to_not receive(:notify)
         expect(expiry_date(hold)).to eq "N/A"
       end
     end
@@ -56,7 +56,7 @@ RSpec.describe UsersHelper, type: :helper do
       hold = Hold.new(nil)
 
       it "returns N/A" do
-        expect(Honeybadger).to receive(:notify)
+        expect(Honeybadger).to_not receive(:notify)
         expect(expiry_date(hold)).to eq "N/A"
       end
     end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -22,16 +22,34 @@ RSpec.describe UsersHelper, type: :helper do
 
     context "Improperly formatted ISO8601 date" do
       Hold = Struct.new(:expiry_date)
-      hold = Hold.new(+"2020-09-01Z")
+      hold = Hold.new("2020-09-01Z")
 
       it "returns a valid time anyway" do
         expect(expiry_date(hold)).to eq "08/31/2020"
       end
     end
 
+    context "Full date time" do
+      Hold = Struct.new(:expiry_date)
+      hold = Hold.new("2018-10-16T02:00:00Z")
+
+      it "returns N/A" do
+        expect(expiry_date(hold)).to eq "10/15/2018"
+      end
+    end
+
     context "No expiry date" do
       Hold = Struct.new(:expiry_date)
-      hold = Hold.new('')
+      hold = Hold.new("")
+
+      it "returns N/A" do
+        expect(expiry_date(hold)).to eq "N/A"
+      end
+    end
+
+    context "non-date eiding with a 'Z'" do
+      Hold = Struct.new(:expiry_date)
+      hold = Hold.new("XYZ")
 
       it "returns N/A" do
         expect(expiry_date(hold)).to eq "N/A"

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -9,4 +9,33 @@ RSpec.describe UsersHelper, type: :helper do
       expect(make_date(iso8601_dt)).to eql "10/15/2018"
     end
   end
+
+  describe "wrong iso8601 formatted date returned by Alma" do
+    context "Properly formatted ISO8601" do
+      Hold = Struct.new(:expiry_date)
+      hold = Hold.new("2020-09-01")
+
+      it "returns a valid time" do
+        expect(expiry_date(hold)).to eq "08/31/2020"
+      end
+    end
+
+    context "Improperly formatted ISO8601 date" do
+      Hold = Struct.new(:expiry_date)
+      hold = Hold.new(+"2020-09-01Z")
+
+      it "returns a valid time anyway" do
+        expect(expiry_date(hold)).to eq "08/31/2020"
+      end
+    end
+
+    context "No expiry date" do
+      Hold = Struct.new(:expiry_date)
+      hold = Hold.new('')
+
+      it "returns N/A" do
+        expect(expiry_date(hold)).to eq "N/A"
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Ruby DateTime class doesn't recognize date string with
trailing 'Z'. Strip trailing 'Z' if it's on the expiry_date