### PR TITLE
Update handling HathiTrust data for display and online availability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GIT
 
 GIT
   remote: https://github.com/tulibraries/cob_index.git
-  revision: 25ec172d590f1200ea1ba3e0e7a64f00b55dc07a
+  revision: 79396b7e88a5bc0bb1436ddb87c5580e7151810d
   branch: main
   specs:
     cob_index (0.1.0)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -125,25 +125,25 @@ class CatalogController < ApplicationController
     # In order to decide at query time if we want to include ETAS records considered "Online"
     # we define two availability facets and decide which one to show based on the `config.campus_closed` lambda
     # which can evaluate the URL param as well as the env var set feature flag.
-    # The `if:` and `unless:` params are the only part evaluated at query time. 
-    config.campus_closed = lambda { |context,_,__| ::FeatureFlags.campus_closed?(context.params) }
-    config.add_facet_field "availability_facet_etas", 
+    # The `if:` and `unless:` params are the only part evaluated at query time.
+    config.campus_closed = lambda { |context, _, __| ::FeatureFlags.campus_closed?(context.params) }
+    config.add_facet_field "availability_facet_etas",
       label: "Availability", collapse: false, show: true, home: true, component: true,
       sort: :count,
       query: {
-        "At the Library" => {label: "At the Library", fq: 'availability_facet:"At the Library"' },
-        "Online" =>  {label: "Online", fq: 'availability_facet:(Online OR "ETAS")'},
-        "Rapid Request Access" => {label: "Request Rapid Access",  fq: 'availability_facet:"Request Rapid Access"'}
-      }, 
+        "At the Library" => { label: "At the Library", fq: 'availability_facet:"At the Library"' },
+        "Online" =>  { label: "Online", fq: 'availability_facet:(Online OR "ETAS")' },
+        "Rapid Request Access" => { label: "Request Rapid Access",  fq: 'availability_facet:"Request Rapid Access"' }
+      },
       if: config.campus_closed
-    config.add_facet_field "availability_facet", 
-      label: "Availability", collapse: false, show: true, home: true, component: true, 
+    config.add_facet_field "availability_facet",
+      label: "Availability", collapse: false, show: true, home: true, component: true,
       sort: :count,
       query: {
-        "At the Library" => {label: "At the Library", fq: 'availability_facet:"At the Library"' },
-        "Online" =>  {label: "Online", fq: 'availability_facet:"Online"' },
-        "Rapid Request Access" => {label: "Request Rapid Access", fq: 'availability_facet:"Request Rapid Access"'}
-      }, 
+        "At the Library" => { label: "At the Library", fq: 'availability_facet:"At the Library"' },
+        "Online" =>  { label: "Online", fq: 'availability_facet:"Online"' },
+        "Rapid Request Access" => { label: "Request Rapid Access", fq: 'availability_facet:"Request Rapid Access"' }
+      },
       unless: config.campus_closed
 
     config.add_facet_field "library_facet", label: "Library", limit: -1, show: true, home: true, component: true
@@ -158,7 +158,7 @@ class CatalogController < ApplicationController
     config.add_facet_field "genre_full_facet", label: "Genre", limit: true, show: false, component: true
     config.add_facet_field "language_facet", label: "Language", limit: true, show: true, component: true
 
-    
+
 
 
 

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -210,34 +210,36 @@ module CatalogHelper
       relevant_locations.include?(item["current_location"]) }
   end
 
-  def build_hathitrust_url(document)
-    record_id = document.fetch("hathi_trust_bib_key_display", nil)
+  def build_hathitrust_url(field)
+    record_id = field.fetch("bib_key", nil)
     return if record_id.nil?
     URI::HTTPS.build(host: "catalog.hathitrust.org",
-      path: "/Record/#{record_id.first}",
+      path: "/Record/#{record_id}",
       query: "signon=swle:https://fim.temple.edu/idp/shibboleth"
     ).to_s
   end
 
-  def render_hathitrust_link(document)
-    render "hathitrust_link", document: document
+  def render_hathitrust_link(ht_bib_key_field)
+    render "hathitrust_link", ht_bib_key_field: ht_bib_key_field
   end
 
   def render_hathitrust_display(document)
-    field = document.fetch("hathi_trust_bib_key_display", "")
+    ht_bib_key_field = document.fetch("hathi_trust_bib_key_display", []).first rescue nil
+    return if ht_bib_key_field.nil?
     online_resources = []
-    online_resources << render_hathitrust_link(document)
+    online_resources << render_hathitrust_link(ht_bib_key_field)
 
-    if field.present?
+    if (campus_closed? || ht_bib_key_field.fetch("access", "deny") == "allow")
       render "online_availability", online_resources: online_resources
     end
   end
 
   def render_hathitrust_button(document)
-    field = document.fetch("hathi_trust_bib_key_display", "")
-    link = render_hathitrust_link(document)
+    ht_bib_key_field = document.fetch("hathi_trust_bib_key_display", []).first rescue nil
+    return if ht_bib_key_field.nil?
+    link = render_hathitrust_link(ht_bib_key_field)
 
-    if field.present?
+    if (campus_closed? || ht_bib_key_field.fetch("access", "deny") == "allow")
       render "hathitrust_button", document: document, links: link
     end
   end

--- a/app/views/advanced/_advanced_search_facets.html.erb
+++ b/app/views/advanced/_advanced_search_facets.html.erb
@@ -1,25 +1,27 @@
 <div class="container" id="advanced-search-facets" style="margin-top: 14px;">
 <% facets_from_request(facet_field_names, @response).each do |display_facet| %>
-  <% facet_config = facet_configuration_for_field(display_facet.name) %>
-  <div class="form-group advanced-search-facet row align-items-center">
-    <%= label_tag display_facet.name.parameterize, class: "col-sm-3 control-label" do %>
-      <%= facet_config.label %>
-    <% end %>
-    <div class="col-sm-8">
-      <%= content_tag(:select, multiple: true,
-        name: "f_inclusive[#{display_facet.name}][]",
-        id: display_facet.name.parameterize,
-        class: "form-control custom-select selectpicker",
-        data: { "live-search": "true", placeholder: "Type or select #{facet_field_label(display_facet.name).downcase.pluralize}"}) do %>
-        <% display_facet.items.each do |facet_item| %>
-          <% facet_item_presenter = facet_item_presenter(facet_config, facet_item, display_facet) %>
-          <%= content_tag :option, value: facet_item.value, selected: facet_value_checked?(display_facet.name, facet_item.value) do %>
-            <%= facet_item_presenter.label %>
-          <% end %>
+  <% if should_render_facet?(display_facet) %>
+    <% facet_config = facet_configuration_for_field(display_facet.name) %>
+      <div class="form-group advanced-search-facet row align-items-center">
+        <%= label_tag display_facet.name.parameterize, class: "col-sm-3 control-label" do %>
+          <%= facet_config.label %>
         <% end %>
-      <% end %>
-    </div>
-  </div>
-<% end %>
+        <div class="col-sm-8">
+          <%= content_tag(:select, multiple: true,
+            name: "f_inclusive[#{display_facet.name}][]",
+            id: display_facet.name.parameterize,
+            class: "form-control custom-select selectpicker",
+            data: { "live-search": "true", placeholder: "Type or select #{facet_field_label(display_facet.name).downcase.pluralize}"}) do %>
+            <% display_facet.items.each do |facet_item| %>
+              <% facet_item_presenter = facet_item_presenter(facet_config, facet_item, display_facet) %>
+              <%= content_tag :option, value: facet_item.value, selected: facet_value_checked?(display_facet.name, facet_item.value) do %>
+                <%= facet_item_presenter.label %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  <% end%>
 </div>
 <%= render_pub_date_range %>

--- a/app/views/catalog/_hathitrust_link.html.erb
+++ b/app/views/catalog/_hathitrust_link.html.erb
@@ -1,4 +1,5 @@
 <div class="online-list-item">
-  <%= link_to("HathiTrust Digital Library", build_hathitrust_url(document), target: "_blank", class: "hathitrust-link") %>
+  
+  <%= link_to("HathiTrust Digital Library", build_hathitrust_url(ht_bib_key_field), target: "_blank", class: "hathitrust-link") %>
   <p class="font-weight-bold electronic-notes"><%= t("blacklight.hathitrust_text_html", href: link_to(t("blacklight.hathitrust_href"), t("blacklight.hathitrust_link"))) %></p>
 </div>

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -799,7 +799,7 @@ RSpec.describe CatalogHelper, type: :helper do
   end
 
   describe "#build_hathitrust_url(field)" do
-    let(:field) { {"bib_key" => "000005117", "access" => "allow"} }
+    let(:field) { { "bib_key" => "000005117", "access" => "allow" } }
     let(:base_url) { "https://catalog.hathitrust.org/Record/000005117?signon=swle:https://fim.temple.edu/idp/shibboleth" }
     let(:constructed_url) { helper.build_hathitrust_url(field) }
 
@@ -811,7 +811,7 @@ RSpec.describe CatalogHelper, type: :helper do
   describe "#render_hathitrust_display(document)" do
     context "record has a hathi_trust_bib_key_display field" do
       context "with allow access" do
-        let(:document) { { "hathi_trust_bib_key_display" => [ { "bib_key" =>  "000005117", "access" => "allow" } ] } }
+        let(:document) { { "hathi_trust_bib_key_display" => [ { "bib_key" => "000005117", "access" => "allow" } ] } }
 
         it "renders the online partial" do
           expect(helper.render_hathitrust_display(document)).not_to be_nil

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -798,10 +798,10 @@ RSpec.describe CatalogHelper, type: :helper do
     end
   end
 
-  describe "#build_hathitrust_url(document)" do
-    let(:document) { { "hathi_trust_bib_key_display" => ["000005117"] } }
+  describe "#build_hathitrust_url(field)" do
+    let(:field) { {"bib_key" => "000005117", "access" => "allow"} }
     let(:base_url) { "https://catalog.hathitrust.org/Record/000005117?signon=swle:https://fim.temple.edu/idp/shibboleth" }
-    let(:constructed_url) { helper.build_hathitrust_url(document) }
+    let(:constructed_url) { helper.build_hathitrust_url(field) }
 
     it "returns a correctly formed url" do
       expect(constructed_url).to eq base_url
@@ -810,10 +810,27 @@ RSpec.describe CatalogHelper, type: :helper do
 
   describe "#render_hathitrust_display(document)" do
     context "record has a hathi_trust_bib_key_display field" do
-      let(:document) { { "hathi_trust_bib_key_display" => ["000005117"] } }
+      context "with allow access" do
+        let(:document) { { "hathi_trust_bib_key_display" => [ { "bib_key" =>  "000005117", "access" => "allow" } ] } }
 
-      it "renders the online partial" do
-        expect(helper.render_hathitrust_display(document)).not_to be_nil
+        it "renders the online partial" do
+          expect(helper.render_hathitrust_display(document)).not_to be_nil
+        end
+      end
+
+      context "with deny access" do
+        let(:document) { { "hathi_trust_bib_key_display" => [ { "bib_key" => "000005117", "access" => "deny" }] } }
+
+        it "does not render the online partial" do
+          expect(helper.render_hathitrust_display(document)).to be_nil
+        end
+
+        context "when campus closed flag is true" do
+          it "renders the online partial" do
+            allow(helper).to receive(:campus_closed?).and_return("true")
+            expect(helper.render_hathitrust_display(document)).not_to be_nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
* Handle JSON formatted hathi fields that now include access details and add  display handling logic that respects the "campus_closed" feature flag.
* Update Availability facet to include Hathi "ETAS" records when campus is closed
* Update Advanced Search facet handling to respect facet config `if`/`else` attributes.