### PR TITLE
BL-1277 Availability status bug

### DIFF
--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -5,7 +5,7 @@
 
   <% if document.fetch("availability_facet", []).include? "At the Library" %>
     <div class="row button-break pt-md-3"></div>
-    <div data-controller="availability" data-availability-url="<%= item_url(document.alma_availability_mms_ids.first, params.merge(doc_id: document.id, redirect_to: request.url)) %>">
+    <div data-controller="availability" data-availability-url="<%= item_url(document.alma_availability_mms_ids.first, params.merge(doc_id: document.id, redirect_to: request.url).except(:page)) %>">
         <div class="controls">
           <button data-action="availability#item" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" class="btn btn-sm btn-default availability-toggle-details" data-toggle="collapse" data-target="#physical-document-<%=  document.id %>, availability.button" id="available_button-<%=  document.id %>" aria-expanded="false" aria-controls="physical-document-<%= document.id %>">
             <i class="fa fa-spinner" aria-busy="true" aria-live="polite"></i>


### PR DESCRIPTION
- Merging the params in item_url was also merging the page param,  causing availability status to not display after the first page of results. We can use .except to avoid this.