### PR TITLE
Overide Blacklight Show to suppress some items

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -120,7 +120,7 @@ class SolrDocument
   end
 
   def is_suppressed?
-    (response.documents.first || {}).fetch("suppress_items_b", false)
+    fetch("suppress_items_b", false)
   end
 
   private

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -119,6 +119,10 @@ class SolrDocument
     !!self["purchase_order"]
   end
 
+  def is_suppressed?
+    (response.documents.first || {}).fetch("suppress_items_b", false)
+  end
+
   private
     def barcode(item)
       item["item_data"]["pid"]

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe CatalogController, type: :controller do
     it "is properly routed for staff_view" do
       expect(get: "/catalog/:id/staff_view").to route_to(controller: "catalog", action: "librarian_view", id: ":id")
     end
+
+    context "when the record is suppressed" do
+      let(:document) { SolrDocument.new(id: doc_id, suppress_items_b: true) }
+      it "raises a record not found error if the record is suppressed" do
+        allow(search_service).to receive(:fetch).with(doc_id).and_return([mock_response, document])
+        allow(controller).to receive(:search_service).and_return(search_service)
+
+        get :show, params: { id: doc_id }
+        expect(response).to render_template("errors/not_found")
+      end
+    end
   end
 
 

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -246,4 +246,14 @@ RSpec.describe SolrDocument, type: :model do
           end
         end
     end
+
+  describe "#is_suppressed?" do
+    it "returns false when the document does not have the suppress_items_b field" do
+      expect(document.is_suppressed?).to be false
+    end
+
+    it "returns true when the document has suppress_items_b as true" do
+      expect(SolrDocument.new(id: "1", suppress_items_b: true).is_suppressed?).to be true
+    end
+  end
 end


### PR DESCRIPTION
Since we were not able to correctly suppress results form the document and realtime get handlers,
we have opted to override Blacklight Catalog COntroller show method to raise an reocrd not found errors if
a document has the expected value in the suppress field.

Still needs a test.