### PR TITLE
Add BUNDLE_PATH env.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,14 +61,6 @@ jobs:
           command: make ci-up
 
       - run:
-          name: Copy local bundler files to app container
-          command: make ci-copy-bundle-files
-
-      - run:
-          name: Copy local node_modules to app container
-          command: make ci-copy-node-modules
-
-      - run:
           name: Run bundler on the app container
           command: make ci-bundle-install
 
@@ -77,7 +69,7 @@ jobs:
           command: make ci-yarn-install
 
       - run:
-          name: Copy the vendor/bundle frome the container to local
+          name: Copy the vendor/bundle from the container to local
           command: make ci-copy-bundle-files-to-local
       
       - run:

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,8 @@ ci-up:
 	git submodule update
 	$(CI-DOCKER) up -d
 
-ci-copy-bundle-files:
-	if [ -d vendor/bundle ]; then docker cp vendor/bundle tul_cob_app_1:/app/vendor/; fi
-
 ci-copy-bundle-files-to-local:
 	docker cp tul_cob_app_1:/app/vendor/bundle vendor/
-
-ci-copy-node-modules:
-	if [ -d node_modules ]; then  docker cp node_modules tul_cob_app_1:/app/; fi
 
 ci-copy-node-modules-to-local:
 	docker cp tul_cob_app_1:/app/node_modules .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       SOLR_AZ_URL: "http://solr:8983/solr/az-database"
       SOLR_WEB_CONTENT_URL: "http://solr:8983/solr/web-content"
       DO_INGEST: "${DO_INGEST}"
+      BUNDLE_PATH: /app/vendor/bundle
       LC_ALL: "C.UTF-8"
     labels:
       - "traefik.enable=true"


### PR DESCRIPTION
When we set this path bundle install inside docker happens inside of /app/vendor/bundle vs /usr/local/bundle by default.

* We don't need to copy local root files to the docker instance because
by default this is done for us.