### PR TITLE
Do not add empty date range search.

### DIFF
--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -126,7 +126,7 @@ module Blacklight::PrimoCentral
       primo_central_parameters[:range] = range
 
       # Adding the date range facet prematurely causes search discrepencies.
-      if (min || max)
+      if (min.present? || max.present?)
         primo_central_parameters[:query][:q].date_range_facet(min: min, max: max)
       end
     end

--- a/spec/models/primo_search_builder_spec.rb
+++ b/spec/models/primo_search_builder_spec.rb
@@ -216,6 +216,16 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
       end
     end
 
+    context "range is empty string" do
+      let(:params) { ActionController::Parameters.new(
+        range:  { creationdate: { begin: "", end: "" } }
+      ) }
+
+      it "does not add a default range facet" do
+        expect(facets).to be_nil
+      end
+    end
+
     context "both min and max range are provided" do
       let(:params) { ActionController::Parameters.new(
         range:  { creationdate: { begin: 1, end: 10 } }


### PR DESCRIPTION
TODO: Fix empty date-range search defaults.

If start and end dates are empty string do not add date range facet.