### PR TITLE
Set default_per_page to be 100.

### DIFF
--- a/app/controllers/concerns/bookmarks_config.rb
+++ b/app/controllers/concerns/bookmarks_config.rb
@@ -11,7 +11,7 @@ module BookmarksConfig
 
       # Disable the per_page configuration
       config.per_page = []
-      config.default_per_page = 1000
+      config.default_per_page = 100
 
       config.add_show_tools_partial(:citation)
       # Need to add citation for side effect only.

--- a/app/models/blacklight/primo_central/repository.rb
+++ b/app/models/blacklight/primo_central/repository.rb
@@ -18,11 +18,6 @@ module Blacklight::PrimoCentral
     def search(params = {})
       data = params[:query]
 
-      # TODO: Fix this in Primo gem
-      unless data[:id].present?
-        data = data.merge(limit: 100)
-      end
-
       duration =
         if data[:id]
           duration_for(:article_record_cache_life)

--- a/app/models/blacklight/primo_central/repository.rb
+++ b/app/models/blacklight/primo_central/repository.rb
@@ -18,6 +18,11 @@ module Blacklight::PrimoCentral
     def search(params = {})
       data = params[:query]
 
+      # TODO: Fix this in Primo gem
+      unless data[:id].present?
+        data = data.merge(limit: 100)
+      end
+
       duration =
         if data[:id]
           duration_for(:article_record_cache_life)


### PR DESCRIPTION
Will limit number of bookmarks to 100 but fixes page brake.