### PR TITLE
move general controller rescuing to a concern, handle primo errors

### DIFF
--- a/app/assets/javascripts/blacklight_overrides.js
+++ b/app/assets/javascripts/blacklight_overrides.js
@@ -1,0 +1,10 @@
+
+Blacklight.modal.onFailure = function (data) {
+  message = "Network Error";
+  if(data.hasOwnProperty("responseText")) {
+    message = data.responseText;
+  }
+  var contents = '<div class="modal-header">' + '<div class="modal-title">' + message + '</div>' + '<button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="Close">' + '  <span aria-hidden="true">&times;</span>' + '</button>';
+  $(Blacklight.modal.modalSelector).find('.modal-content').html(contents);
+  $(Blacklight.modal.modalSelector).modal('show');
+};

--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -7,6 +7,7 @@ class AlmawsController < CatalogController
   layout proc { |controller| false if request.xhr? }
 
   before_action :authenticate_user!, except: [:item]
+  before_action :xhr!, only: [:item]
 
   rescue_from Alma::BibItemSet::ResponseError,
     with: :offset_too_large

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,4 +61,9 @@ class ApplicationController < ActionController::Base
       response.headers["Pragma"] = "no-cache"
       response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
     end
+
+    # ensure that rails treats request as xhr
+    def xhr!
+      request.headers["HTTP_X_REQUESTED_WITH"] = "XMLHttpRequest"
+    end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -8,6 +8,7 @@ class CatalogController < ApplicationController
 
   include BlacklightAlma::Availability
   include Blacklight::Marc::Catalog
+  include ServerErrors
 
   before_action :authenticate_purchase_order!, only: [ :purchase_order, :purchase_order_action ]
   before_action :set_thread_request
@@ -20,23 +21,6 @@ class CatalogController < ApplicationController
 
   helper_method :browse_creator
   helper_method :display_duration
-
-  rescue_from BlacklightRangeLimit::InvalidRange do
-    redirect_back(fallback_location: root_path, notice: "The start year must be before the end year.")
-  end
-
-  rescue_from Blacklight::Exceptions::RecordNotFound,
-    with: :invalid_document_id_error
-
-  rescue_from Blacklight::Exceptions::InvalidRequest do |exception|
-    Honeybadger.notify(exception.message)
-    render "errors/unsupported_query"
-  end
-
-  rescue_from NoMethodError do |exception|
-    Honeybadger.notify(exception.message)
-    render "errors/internal_server_error"
-  end
 
   configure_blacklight do |config|
     # default advanced config values

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -512,8 +512,8 @@ class CatalogController < ApplicationController
     }
 
     respond_to do |format|
-      format.xml  { render xml: error_info, status: 404 }
-      format.json { render json: error_info, stautus: 404 }
+      format.xml  { render xml: error_info, status: :not_found }
+      format.json { render json: error_info, status: :not_found }
 
       # default to HTML response, even for other non-HTML formats we don't
       # neccesarily know about, seems to be consistent with what Rails4 does
@@ -523,7 +523,7 @@ class CatalogController < ApplicationController
         # possibly non-html formats, this is consistent with what Rails does
         # on raising an ActiveRecord::RecordNotFound. Rails.root IS needed
         # for it to work under testing, without worrying about CWD.
-        render "errors/not_found"
+        render "errors/not_found", status: :not_found
       end
     end
   end

--- a/app/controllers/concerns/server_errors.rb
+++ b/app/controllers/concerns/server_errors.rb
@@ -31,5 +31,10 @@ module ServerErrors
       Honeybadger.notify(message)
       render "errors/internal_server_error", status: :bad_gateway
     end
+
+    rescue_from Alma::RequestOptions::ResponseError do |exception|
+      Honeybadger.notify(exception.message)
+      render "errors/alma_request_error", status: :bad_gateway
+    end
   end
 end

--- a/app/controllers/concerns/server_errors.rb
+++ b/app/controllers/concerns/server_errors.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ServerErrors
+  extend ActiveSupport::Concern
+
+  included do
+    # We handle all unknown and unplanned exceptions here
+    # If an exception arises that could benefit from more
+    # detailed notification to end user or Honeybadger
+    # consider writing a custom handler below.
+    rescue_from Exception do |exception|
+      message = "#{exception.message} \n #{exception.backtrace[0]}"
+      Honeybadger.notify(message)
+      render "errors/internal_server_error", status: :internal_server_error
+    end
+
+    rescue_from BlacklightRangeLimit::InvalidRange do
+      redirect_back(fallback_location: root_path, notice: "The start year must be before the end year.")
+    end
+
+    rescue_from Blacklight::Exceptions::RecordNotFound,
+                with: :invalid_document_id_error
+
+    rescue_from Blacklight::Exceptions::InvalidRequest do |exception|
+      Honeybadger.notify(exception.message)
+      render "errors/unsupported_query", status: :bad_request
+    end
+
+    rescue_from Primo::Search::SearchError do |exception|
+      message = exception.message
+      Honeybadger.notify(message)
+      render "errors/internal_server_error", status: :bad_gateway
+    end
+  end
+end

--- a/app/views/errors/alma_request_error.html.erb
+++ b/app/views/errors/alma_request_error.html.erb
@@ -1,0 +1,6 @@
+<div class="pt-3">
+  <%= render :partial=>'/shared/flash_msg' %>
+</div>
+
+<h4 class="error-header">We're sorry, but something went wrong.</h4>
+<p>The item request service did not respond or encountered a problem.</p>

--- a/spec/controllers/almaws_controller_spec.rb
+++ b/spec/controllers/almaws_controller_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "rails_helper"
 
 RSpec.describe AlmawsController, type: :controller do
+
   before(:all) do
     DatabaseCleaner.clean
     DatabaseCleaner.strategy = :truncation
@@ -78,6 +79,18 @@ RSpec.describe AlmawsController, type: :controller do
       it "does not redirect to login page" do
         get(:item, params)
         expect(response).not_to redirect_to new_user_session_url
+      end
+    end
+
+    context "logged in user" do
+      before(:each) do
+        sign_in @user, scope: :user
+      end
+
+      it "doesn't render the layout, even when there's an error" do
+        allow(Alma::BibItem).to receive(:find).and_raise("oof")
+        get :item, params
+        expect(response).not_to render_template("layouts/blacklight")
       end
     end
   end

--- a/spec/controllers/catalog_controller_errors_spec.rb
+++ b/spec/controllers/catalog_controller_errors_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CatalogController, type: :controller do
+  render_views
+
+  controller do
+    def test_basic_exception
+      raise Exception.new("oof")
+    end
+
+    def test_primo_error
+      raise Primo::Search::SearchError.new("Primo isn't home today")
+    end
+  end
+
+  before :each do
+    routes.draw do
+      get "test_basic_exception" => "catalog#test_basic_exception"
+      get "test_primo_error" => "catalog#test_primo_error"
+    end
+  end
+
+  it "handles its own errors gracefully" do
+    get :test_basic_exception
+    expect(response).to have_http_status 500
+    expect(response.body).to include "We're sorry, but something went wrong"
+  end
+
+  it "handles primo's errors  gracefully" do
+    get :test_primo_error
+    expect(response).to have_http_status 502
+    expect(response.body).to include "We're sorry, but something went wrong"
+  end
+end

--- a/spec/controllers/primo_central_controller_spec.rb
+++ b/spec/controllers/primo_central_controller_spec.rb
@@ -39,9 +39,18 @@ RSpec.describe PrimoCentralController, type: :controller do
   end
 
   describe "show action" do
+    render_views
+
     it "gets refwork format" do
       get :show, params: { id: 1, format: "refworks" }
       expect(response).to be_successful
+    end
+
+    it "handles a record not found exception" do
+      allow(search_service).to receive(:fetch).and_raise(Primo::Search::ArticleNotFound, "glub glub glub")
+      get :show, params: { id: 1 }
+      expect(response.code).to eq "404"
+      expect(response.body).to include "error-header not-found"
     end
   end
 end


### PR DESCRIPTION
Improves error handling by:

- ensuring we don't send the rails 500 message to the end user
- consolidating error handling in a 'concern'
- giving us a headstart when we find out a primo query has caused an error.

See also:
https://github.com/tulibraries/primo/pull/35