### PR TITLE
no vagrant env file

### DIFF
--- a/.env.vagrant
+++ b/.env.vagrant
@@ -1,4 +1,0 @@
-SOLR_HOST_IP=localhost
-export SOLR_URL="http://$SOLR_HOST_IP:8983/solr/blacklight-core"
-export SOLR_AZ_URL="http://$SOLR_HOST_IP:8983/solr/az-database"
-export SOLR_WEB_CONTENT_URL="http://$SOLR_HOST_IP:8983/solr/web-content"


### PR DESCRIPTION
Since we now have a `.env` file in the repo, having any `.env.INVENTORY_NAME` will break the rails role. Others were previously removed. This removes the vagrant one