### PR TITLE
BL-1079 Prevent parselet errors on empty advanced search fields

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -96,7 +96,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def process_is(value, op)
-    return if value.blank?
+    return if value.nil?
     return value if value.match(/"/)
 
     if op == "is"

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -96,8 +96,8 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def process_is(value, op)
-    return nil if value.nil?
-    return value if value.match(/"/) rescue true
+    return if value.blank?
+    return value if value.match(/"/)
 
     if op == "is"
       "\"#{value}\""

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -96,6 +96,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def process_is(value, op)
+    return nil if value.nil?
     return value if value.match(/"/) rescue true
 
     if op == "is"

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -97,8 +97,6 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   def process_is(value, op)
     return if value.nil?
-    return value if value.match(/"/)
-
     if op == "is"
       "\"#{value}\""
     else

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -97,6 +97,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   def process_is(value, op)
     return if value.nil?
+    return value if value.match(/"/) rescue true
     if op == "is"
       "\"#{value}\""
     else

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -224,4 +224,14 @@ RSpec.describe CatalogController, type: :controller do
       expect(controller.params["f"]["foo"].size).to eq(1)
     end
   end
+
+  describe "advanced search" do
+    it "doesn't error on empty search fields" do
+      expect {
+        get :index, params: { search_field: "advanced", f_1: "all_fields", f_2: "all_fields", f_3: "all_fields",
+                              op_1: "AND", operator: { q_1: "contains", q_2: "contains", q_3: "is" } }
+        expect(response.code).to eq "200"
+      }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
https://app.honeybadger.io/projects/56250/faults/53917673