### PR TITLE
Abort if trying to load fixtures into our prod sever.

### DIFF
--- a/lib/tasks/tulsearch.rake
+++ b/lib/tasks/tulsearch.rake
@@ -7,12 +7,17 @@ namespace :tul_cob do
 
     desc "Posts fixtures to Solr"
     task :load_fixtures, [:filepath] do |t, args|
+      solr_url = Blacklight::Configuration.new.connection_config[:url]
+
+      if ENV["SOLRCLOUD"] && solr_url.match(/#{ENV["SOLRCLOUD"]}/)
+        abort "Cannot run :load_fixtures task on production server"
+      end
+
       fixtures = Dir.glob(args.fetch(:filepath, "spec/fixtures/*_marc.xml"))
       if ENV["RELEVANCE"]
         fixtures += Dir.glob("spec/relevance/fixtures/*.xml")
       end
 
-      solr_url = Blacklight::Configuration.new.connection_config[:url]
       fixtures.sort.reverse.each  do |file|
         `SOLR_URL=#{solr_url} cob_index ingest #{file}`
       end
@@ -45,6 +50,10 @@ desc "Ingest a single file or all XML files in the sammple_data folder"
 task :ingest, [:filepath] => [:environment] do |t, args|
   file = args[:filepath]
   solr_url = Blacklight::Configuration.new.connection_config[:url]
+
+  if ENV["SOLRCLOUD"] && solr_url.match(/#{ENV["SOLRCLOUD"]}/)
+    abort "Cannot run :ingest task on production server"
+  end
 
   if file && file.match?(/databases.json/)
     az_url = Blacklight::Configuration.new.connection_config[:az_url]


### PR DESCRIPTION
I've noticed that recently we sometimes are overriding SOLR_URL with the
production URL in our locals to test issues.

Thus, in order to avoid inadvertently polluting the production Solr
database with our local fixtures, I'm adding a snippet to abort when
there's a potential for doing that.