### PR TITLE
BL-1304 Digital copy exception

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -197,6 +197,8 @@ module CatalogHelper
       .include?("At the Library") &&
     document.fetch("format", [])
       .exclude?("Archival Material") &&
+    document.fetch("format", [])
+      .exclude?("Object") &&
     !document["electronic_resource_display"] &&
     !document["hathi_trust_bib_key_display"]
   end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -728,6 +728,12 @@ RSpec.describe CatalogHelper, type: :helper do
         expect(digital_help_allowed?(document)).to be true
       end
     end
+    context "is an object" do
+      let(:document) { { "format" => "Object" } }
+      it "returns false" do
+        expect(digital_help_allowed?(document)).to be false
+      end
+    end
     context "is a physical item and an online item" do
       let(:document) { {
         "availability_facet" => "At the Library",


### PR DESCRIPTION
- Add object resources to the exclusions for displaying "get help finding a digital copy"