### PR TITLE
Add back errors in development context.

### DIFF
--- a/app/controllers/concerns/server_errors.rb
+++ b/app/controllers/concerns/server_errors.rb
@@ -4,6 +4,8 @@ module ServerErrors
   extend ActiveSupport::Concern
 
   included do
+    next if Rails.env == "development"
+
     # We handle all unknown and unplanned exceptions here
     # If an exception arises that could benefit from more
     # detailed notification to end user or Honeybadger


### PR DESCRIPTION
We are swallowing errors in the development context. Which is not useful.

This commit skips error handling enhancements when in development mode.