### PR TITLE
BL-1301: Fix no results for some queries with '?' in them.

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -84,7 +84,7 @@ class SearchBuilder < Blacklight::SearchBuilder
     # These named procedures MUST take a value, and an operator as arguments
     # and return a value that can be processed by the next procedure on the
     # list.
-    [ :process_begins_with, :process_is, :substitute_colons ]
+    [ :process_begins_with, :process_is, :substitute_special_chars]
   end
 
   def process_begins_with(value, op)
@@ -105,8 +105,8 @@ class SearchBuilder < Blacklight::SearchBuilder
     end
   end
 
-  def substitute_colons(value, _)
-    value.gsub(/:/, " ") rescue value
+  def substitute_special_chars(value, _)
+    value.gsub(/[:?]/, " ") rescue value
   end
 
   def no_journals(solr_parameters)

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -165,18 +165,23 @@ RSpec.describe SearchBuilder , type: :model do
     end
   end
 
-  describe "#substitute_colons" do
+  describe "#substitute_special_chars" do
     it "can handle nil case with grace" do
-      expect(subject.substitute_colons(nil, nil)).to be_nil
-      expect(subject.substitute_colons("foo", nil)).to eq("foo")
+      expect(subject.substitute_special_chars(nil, nil)).to be_nil
+      expect(subject.substitute_special_chars("foo", nil)).to eq("foo")
     end
 
     it "substitutes colons from values no matter what op is" do
-      expect(subject.substitute_colons("foo:bar", nil)).to eq("foo bar")
+      expect(subject.substitute_special_chars("foo:bar", nil)).to eq("foo bar")
     end
 
     it "substitutes all the colons from values" do
-      expect(subject.substitute_colons("foo:bar:bum", nil)).to eq("foo bar bum")
+      expect(subject.substitute_special_chars("foo:bar:bum", nil)).to eq("foo bar bum")
+    end
+
+    it "substitute ? marks" do
+      # @see BL-1301 for ref.  Basically Solr treats ? as a special character.
+      expect(subject.substitute_special_chars("foo bar?", nil)).to eq("foo bar ")
     end
   end
 


### PR DESCRIPTION
Solr treasts '?' as a special wild character.  If you search for "hats?"
it is actually trying to search for something more like "hats[a-z]"
where that last character cannot be null.

Easiest way to fix this issue is just to strip ? chars from our query
string since we don't actually expect our users to know about these Solr
quirks.