### PR TITLE
BL-1310: Reenable article bookmark deletes.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -485,6 +485,8 @@ class CatalogController < ApplicationController
     count = (params["document_counter"] || 0 rescue 0).to_i
     begin
       (@response, doc) = search_service.fetch(params["id"])
+      # In bookmark context we'll want to make sure doc.id is the same as what we fetched.
+      doc["pnxId"] = params["id"]
     rescue Primo::Search::ArticleNotFound => _
       Honeybadger.notify("The article with id #{params["id"]} could not be found.
                          This happens when the primo id is no longer valid.")

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -31,8 +31,8 @@ class PrimoCentralController < CatalogController
 
     config.add_show_tools_partial(:bookmark, partial: "bookmark_control", if: false)
     config.add_show_tools_partial(:refworks, partial: "tagged_refworks", modal: false)
-    config.add_nav_action(:bookmark, partial: "blacklight/nav/bookmark", if: false)
-    config.add_results_document_tool(:bookmark, partial: "bookmark_control", if: false)
+    config.add_nav_action(:bookmark, partial: "blacklight/nav/bookmark", if: true)
+    config.add_results_document_tool(:bookmark, partial: "bookmark_control", if: :render_articles_bookmark_control?)
 
     # Search fields
     config.add_search_field :any, label: "All Fields", catalog_map: :all_fields
@@ -115,5 +115,10 @@ class PrimoCentralController < CatalogController
       format.json
       additional_export_formats(@document, format)
     end
+  end
+
+  def render_articles_bookmark_control?
+    # TODO: Remove once article bookmarks are no longer supported.
+    params["action"] == "index_item"
   end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -97,8 +97,14 @@ module CatalogHelper
 
   # Overridden because we want to use our merged @response["docs"] with docs
   # from solr and primo together.
-  def bookmarked?(document)
-    current_bookmarks(document.response["docs"]).any? { |doc| doc.document_id == document.id && doc.document_type == document.class }
+  #
+  # TODO: Remove this override once we no longer support article bookmarks.
+  def current_bookmarks(response = nil)
+    response ||= @response
+    @current_bookmarks ||=
+      current_or_guest_user
+      .bookmarks_for_documents(@response["docs"] ||
+    response.documents).to_a
   end
 
   ##

--- a/app/javascript/packs/controllers/index_controller.js
+++ b/app/javascript/packs/controllers/index_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
     .then(response => response.text())
     .then(html => {
       this.element.innerHTML = html
-      Blacklight.do_bookmark_toggle_behavior();
+      Blacklight.doBookmarkToggleBehavior();
     })
   }
 }

--- a/app/search_engines/catalog_bookmark_search.rb
+++ b/app/search_engines/catalog_bookmark_search.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# TODO: Remove once we no longer support article bookmarks.
 class CatalogBookmarkSearch < CatalogController
   include Searcher
   include BookmarksConfig

--- a/app/services/primo_search_service.rb
+++ b/app/services/primo_search_service.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# TODO: Remove once we no longer support article bookmarks.
 class PrimoSearchService < Blacklight::SearchService
   def fetch(primo_doc_ids)
     # Primo cannot string more than 10 OR queries.
@@ -24,7 +25,7 @@ class PrimoSearchService < Blacklight::SearchService
       if docs.length == ids.length
         []
       else
-        (ids - docs.map { |doc| doc["pnxId"] })
+        (ids - docs.map(&:id))
           .map { |id| PrimoCentralDocument.new("pnxId" => id, "ajax" => true, "status" => "Attempting to reload...") }
       end
     end


### PR DESCRIPTION
This adds back bookmark options for articles in the bookmarks context.

This also fixes a bug with bookmark deletes do to pnx to cdi id
conflicts.

Finally, and unfortunately,  I had to also revert some changes we made
earlier that removed deprecation warnings.  However, without the revert
there is a bug that we did not notice because we had disabled article
bookmarks prior to merging that change.

Since we will be removing the custom code that was required to enable
article bookmarks, I think that it's OK to revert this one change as we
will fix the issue soon simply by removing the deprecated code.