### PR TITLE
BL-1299: Skip article search on empty search.

### DIFF
--- a/app/models/blacklight/primo_central/repository.rb
+++ b/app/models/blacklight/primo_central/repository.rb
@@ -14,8 +14,12 @@ module Blacklight::PrimoCentral
       search(query: { id: id }.merge(params))
     end
 
-    # Execute a search against Primo PNXS API.
+    # Execute a search against Primo API
     def search(params = {})
+      if params[:skip_search?]
+        return blacklight_config.response_model.new({ "docs" => [] }, {}, numFound: 0)
+      end
+
       data = params[:query]
 
       duration =

--- a/app/models/blacklight/primo_central/search_builder.rb
+++ b/app/models/blacklight/primo_central/search_builder.rb
@@ -7,11 +7,17 @@ module Blacklight::PrimoCentral
 
     self.default_processor_chain = [
       :add_query_to_primo_central,
+      :skip_search?,
       :set_query_field,
       :process_advanced_search,
       :previous_and_next_document,
       :add_query_facets,
       :process_date_range_query,
     ]
+
+    def skip_search?(params)
+      # Skip useless searches
+      params[:skip_search?] = ["*", "", nil].include?(blacklight_params["q"])
+    end
   end
 end

--- a/app/search_engines/bento_search/primo_engine.rb
+++ b/app/search_engines/bento_search/primo_engine.rb
@@ -8,16 +8,11 @@ module BentoSearch
       query = args.fetch(:query, "")
       per_page = args.fetch(:per_page)
 
-      # Avoid making a costly call for no reason.
-      if query.empty?
-        response = Blacklight::PrimoCentral::Response.new({ "docs" => [] }, {}, numFound: 0)
-      else
-        user_params = { q: query, per_page: per_page }
-        config = blacklight_config
-        search_service = search_service_class.new(config: config, user_params: user_params)
+      user_params = { q: query, per_page: per_page }
+      config = blacklight_config
+      search_service = search_service_class.new(config: config, user_params: user_params)
 
-        (response, _) = search_service.search_results
-      end
+      (response, _) = search_service.search_results
       results(response)
     end
 

--- a/app/search_engines/bento_search/primo_engine.rb
+++ b/app/search_engines/bento_search/primo_engine.rb
@@ -8,7 +8,7 @@ module BentoSearch
       query = args.fetch(:query, "")
       per_page = args.fetch(:per_page)
 
-      user_params = { q: query, per_page: per_page }
+      user_params = { q: query, per_page: per_page }.with_indifferent_access
       config = blacklight_config
       search_service = search_service_class.new(config: config, user_params: user_params)
 

--- a/app/services/primo_search_service.rb
+++ b/app/services/primo_search_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PrimoSearchService < Blacklight::SearchService
-  def fetch(primo_doc_ids)
+  def fetch(primo_doc_ids, params = {})
     # Primo cannot string more than 10 OR queries.
     documents = []
 

--- a/spec/controllers/primo_central_controller_spec.rb
+++ b/spec/controllers/primo_central_controller_spec.rb
@@ -9,12 +9,13 @@ RSpec.describe PrimoCentralController, type: :controller do
   let(:document) { PrimoCentralDocument.new(doc, options) }
   let(:helpers) { double("helper", base_path: "/") }
   let(:mock_response) { instance_double(Blacklight::PrimoCentral::Response) }
-  let(:search_service) { instance_double(Blacklight::SearchService) }
+  let(:search_service) { instance_double(PrimoSearchService) }
 
   before(:each) do
     allow(controller).to receive(:helpers).and_return(helpers)
     allow(controller).to receive(:search_service).and_return(search_service)
     allow(search_service).to receive(:fetch).and_return([mock_response, document])
+    allow(search_service).to receive(:search_results).and_return([mock_response, document])
   end
 
   describe "#browse_creator" do

--- a/spec/models/primo_central_repository_spec.rb
+++ b/spec/models/primo_central_repository_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+
+RSpec.describe Blacklight::PrimoCentral::Repository , type: :model do
+  let(:config) { PrimoCentralController.blacklight_config }
+  let(:repo) { Blacklight::PrimoCentral::Repository.new(config) }
+
+  subject { repo }
+
+  describe ".search" do
+    context "skip_search? true" do
+      it "returns empty response" do
+        expect(subject.search(skip_search?: true)).to eq(
+          {
+            "response" => { "numFound" => 0, "start" => 0, "docs" => [] },
+            "facets" => [],
+            "stats" => { "stats_fields" => {} } }
+        )
+      end
+    end
+  end
+end

--- a/spec/models/primo_search_builder_spec.rb
+++ b/spec/models/primo_search_builder_spec.rb
@@ -288,4 +288,40 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
       end
     end
   end
+
+  describe ".skip_search?" do
+    before(:example) do
+      subject.skip_search?(primo_central_parameters)
+    end
+
+    context "no query" do
+      it "sets skip_search? true" do
+        expect(primo_central_parameters["skip_search?"]).to eq(true)
+      end
+    end
+
+    context "empty query" do
+      let(:params) { ActionController::Parameters.new(q: "") }
+
+      it "sets skip_search? true" do
+        expect(primo_central_parameters["skip_search?"]).to eq(true)
+      end
+    end
+
+    context "* query" do
+      let(:params) { ActionController::Parameters.new(q: "*") }
+
+      it "sets skip_search? true" do
+        expect(primo_central_parameters["skip_search?"]).to eq(true)
+      end
+    end
+
+    context "basic query" do
+      let(:params) { ActionController::Parameters.new(q: "foo") }
+
+      it "sets skip_search? false" do
+        expect(primo_central_parameters["skip_search?"]).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
We are still doing an unnecessary search when we switch to article view
but have not done a search (the blank page)