### PR TITLE
Fix styling bug

### DIFF
--- a/app/views/catalog/_results_pagination.html.erb
+++ b/app/views/catalog/_results_pagination.html.erb
@@ -1,0 +1,9 @@
+<% if show_pagination? and @response.total_pages > 1 %>
+ <div class="row record-padding no-gutters">
+  <div class="col-md-12">
+    <nav class="pagination" role="region" aria-label="<%= t('views.pagination.aria.container_label') %>">
+      <%= paginate @response, :outer_window => 2, :theme => 'blacklight' %>
+    </nav>
+  </div>
+ </div>
+<% end %>

--- a/app/views/catalog/_results_pagination.html.erb
+++ b/app/views/catalog/_results_pagination.html.erb
@@ -1,3 +1,5 @@
+<% # Overridden from Blacklight in order to add necessary classes. %>
+
 <% if show_pagination? and @response.total_pages > 1 %>
  <div class="row record-padding no-gutters">
   <div class="col-md-12">

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,4 +1,4 @@
-<div class="row pl-sm-5 pt-md-3 pb-5">
+<div class="row pl-sm-5 pt-md-3 pb-5 no-gutters">
 
   <% if show_sidebar? %>
     <div id="sidebar" class="col-md-4 col-lg-3" role="complementary">


### PR DESCRIPTION
- The automatic row styles were causing extra spacing to appear on small screen sizes.  Adding no-gutters eliminates the problem.