### PR TITLE
Do not swallow the test errors.

### DIFF
--- a/app/controllers/concerns/server_errors.rb
+++ b/app/controllers/concerns/server_errors.rb
@@ -4,7 +4,7 @@ module ServerErrors
   extend ActiveSupport::Concern
 
   included do
-    next if Rails.env == "development"
+    next if ["development", "test"].include?(Rails.env)
 
     # We handle all unknown and unplanned exceptions here
     # If an exception arises that could benefit from more

--- a/spec/controllers/catalog_controller_errors_spec.rb
+++ b/spec/controllers/catalog_controller_errors_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe CatalogController, type: :controller do
   end
 
   before :each do
+    allow(Rails).to receive(:env) { "production".inquiry }
+
     routes.draw do
       get "test_basic_exception" => "catalog#test_basic_exception"
       get "test_primo_error" => "catalog#test_primo_error"


### PR DESCRIPTION
Errors are being swallowed locally when running tests (Rails env == test) and this is making it harder to figure out what is going on.