### PR TITLE
Add placeholder implementation for libguides search term

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -554,4 +554,8 @@ module CatalogHelper
   def campus_closed?
     ::FeatureFlags.campus_closed?(params)
   end
+
+  def derived_libguides_search_term
+    params.fetch("q", "")
+  end
 end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -906,4 +906,15 @@ RSpec.describe CatalogHelper, type: :helper do
       end
     end
   end
+
+  describe "#derived_libguides_search_term" do
+    before do
+      allow(helper).to receive(:params) { params }
+    end
+    let(:params) { { "q" => "thing" } }
+
+    it "returns the origial search term as term to search in libguides" do
+      expect(derived_libguides_search_term).to eq("thing")
+    end
+  end
 end


### PR DESCRIPTION

Adds a helper than can be used to derive the search term we should use to search libguides for a recommendation.

At present, it only returns the original search query being sent to solr. Added as helper so underlying implmentation can be swapped.


