### PR TITLE
BL-1102 Request bug

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -45,7 +45,7 @@ class AlmawsController < CatalogController
 
     @books = CobAlma::Requests.physical_material_type(@items).collect { |item| item["value"] if item["value"].include?("BOOK") }.compact
     @author = @items.map { |item| item["bib_data"]["author"].to_s }.first
-    @description = CobAlma::Requests.descriptions(@items)
+    @description = CobAlma::Requests.physical_material_type_and_descriptions(@items)
     @item_level_locations = CobAlma::Requests.item_level_locations(@items)
     @equipment = CobAlma::Requests.equipment(@items)
     @booking_location = CobAlma::Requests.booking_location(@items)
@@ -63,7 +63,7 @@ class AlmawsController < CatalogController
     @asrs_request_level = get_request_level(@items, "asrs")
 
     if @asrs_request_level == "item"
-      @asrs_description =  CobAlma::Requests.asrs_descriptions(@items)
+      @asrs_description =  CobAlma::Requests.material_type_and_asrs_descriptions(@items)
     else
       @asrs_description = @description || @asrs_description = ""
     end

--- a/app/javascript/packs/controllers/form_controller.js
+++ b/app/javascript/packs/controllers/form_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = [ "pickups" ]
+  static targets = [ "pickups", "descriptions" ]
 
   connect() {
     this.booking_end_date()
@@ -37,6 +37,21 @@ export default class extends Controller {
       $(this.pickupsTarget).html(options);
     } else {
       $(this.pickupsTarget);
+    }
+  }
+
+  typeSelect() {
+    // We need this variable to be global so that it doesn't mutate in multiple uses
+    if (typeof window.item_level_descriptions == "undefined") {
+       window.item_level_descriptions = $(this.descriptionsTarget).html();
+    }
+    let material_type = $("#material_type option").filter(":selected").text();
+    let emptyOption = $('<option />').attr('value', '');
+    let options = $(window.item_level_descriptions).filter(`optgroup[label='${material_type}']`).prepend(emptyOption).html();
+    if(options) {
+      $(this.descriptionsTarget).html(options);
+    } else {
+      $(this.descriptionsTarget);
     }
   }
 }

--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -175,7 +175,7 @@ module CobAlma
     def self.physical_material_type_and_descriptions(items_list)
       types_and_descriptions = items_list.all.map { |item|
         Hash[item.physical_material_type["desc"], [item.description]] unless item.physical_material_type["value"] == ""
-      }.uniq
+      }.uniq.compact
 
       types_and_descriptions.reduce({}) do |acc, rec|
         key, value = rec.to_a.flatten

--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -127,12 +127,23 @@ module CobAlma
       descriptions.uniq.sort
     end
 
-    def self.asrs_descriptions(items_list)
-      items_list.all
+    def self.material_type_and_asrs_descriptions(items_list)
+      types_and_descriptions = items_list.all
         .select { |item| item.library == "ASRS" && item.in_place? }
-        .map(&:description)
-        .uniq
-        .sort
+        .map { |item|
+          Hash[item.physical_material_type["desc"], [item.description]] unless item.physical_material_type["value"] == ""
+        }
+
+      types_and_descriptions.reduce({}) do |acc, rec|
+        key, value = rec.to_a.flatten
+        if acc[key]
+          acc[key] << value
+          acc[key].uniq!
+        else
+          acc[key] = [value]
+        end
+        acc
+      end.to_a
     end
 
     def self.booking_location(items_list)
@@ -160,6 +171,24 @@ module CobAlma
       end
       material_types.uniq.compact
     end
+
+    def self.physical_material_type_and_descriptions(items_list)
+      types_and_descriptions = items_list.all.map { |item|
+        Hash[item.physical_material_type["desc"], [item.description]] unless item.physical_material_type["value"] == ""
+      }.uniq
+
+      types_and_descriptions.reduce({}) do |acc, rec|
+        key, value = rec.to_a.flatten
+        if acc[key]
+          acc[key] << value
+          acc[key].uniq!
+        else
+          acc[key] = [value]
+        end
+        acc
+      end.to_a
+    end
+
 
     def self.item_holding_ids(items_list)
       items_list

--- a/app/views/almaws/_asrs_request_form.html.erb
+++ b/app/views/almaws/_asrs_request_form.html.erb
@@ -28,10 +28,10 @@
     <% if @material_types.present? && @material_types.count > 1 %>
       <div class="hold-form form-group row">
         <%= label("", :material_type, t("requests.form.material_type_html")) %>
-        <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, "aria-required": true }, {class: "request-form form-control"}) %>
+        <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, "aria-required": true }, {class: "request-form form-control", data: { "action": "form#typeSelect" }}) %>
       </div>
     <% else %>
-      <%= form.hidden_field :material_type, value: @material_types.collect { |mat| [ mat.values.first ] }  %>
+      <%= form.hidden_field :material_type, value: @material_types.collect { |mat| [ mat.values.first ] } %>
     <% end %>
 
     <% if @asrs_request_level == "item" %>
@@ -39,7 +39,7 @@
         <div class="form-group hold-form">
           <%= form.label(:asrs_description, t("requests.form.description_label_html")) %>
           <p><%= t("requests.form.description_additional_text") %></p>
-          <%= select_tag(:asrs_description, options_for_select(@asrs_description), { data: { "action": "form#select" }, class: "request-form form-control", include_blank: true }) %>
+          <%= select_tag(:asrs_description, grouped_options_for_select(@asrs_description), { data: { "action": "form#select", "target": "form.descriptions" }, class: "request-form form-control", include_blank: true }) %>
         </div>
       <% else %>
         <%= form.hidden_field :asrs_description, value: @asrs_description %>

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -12,7 +12,7 @@
     <% if @material_types.present? && @material_types.count > 1 %>
       <div class="row hold-form form-group">
         <%= label("", :material_type, t("requests.form.material_type_html")) %>
-        <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, required: true, "aria-required": true }, {class: "request-form form-control"}) %>
+        <%= select("", :material_type,@material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, "aria-required": true }, {class: "request-form form-control", data: { "action": "form#typeSelect" }}) %>
       </div>
     <% else %>
       <%= form.hidden_field :material_type, value: @material_types.collect { |mat| [ mat.values.first ] }  %>
@@ -22,7 +22,7 @@
       <div class="hold-form form-group">
         <%= form.label(:booking_description, t("requests.form.description_label_html")) %>
         <p><%= t("requests.form.description_additional_text") %></p>
-        <%= select_tag(:booking_description, options_for_select(@description), class: "request-form form-control", include_blank: true) %>
+        <%= select_tag(:booking_description,  grouped_options_for_select(@description), data: { "target": "form.descriptions" }, class: "request-form form-control", include_blank: true) %>
       </div>
     <% else %>
         <%= form.hidden_field :booking_description, value: @description %>

--- a/app/views/almaws/_digitization_request_form.html.erb
+++ b/app/views/almaws/_digitization_request_form.html.erb
@@ -21,7 +21,7 @@
       <div class="form-group hold-form">
         <%= form.label(:digitization_description, t("requests.form.description_label_html")) %>
         <p><%= t("requests.form.description_additional_text") %></p>
-        <%= select_tag(:digitization_description, options_for_select(@description), class: "request-form form-control", include_blank: true) %>
+        <%= select_tag(:digitization_description, grouped_options_for_select(@description), class: "request-form form-control", include_blank: true) %>
       </div>
     <% else %>
       <%= form.hidden_field :digitization_description, value: @description %>

--- a/app/views/almaws/_hold_request_form.html.erb
+++ b/app/views/almaws/_hold_request_form.html.erb
@@ -24,7 +24,7 @@
     <% if @material_types.present? && @material_types.count > 1 %>
       <div class="row hold-form form-group">
         <%= label("", :material_type, t("requests.form.material_type_html")) %>
-        <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, "aria-required": true }, {class: "request-form form-control"}) %>
+        <%= select("", :material_type, @material_types.collect { |mat| [ mat.values.last, mat.values.first ] }, {include_blank: true, "aria-required": true }, {class: "request-form form-control", data: { "action": "form#typeSelect" }}) %>
       </div>
     <% else %>
       <%= form.hidden_field :material_type, value: @material_types.collect { |mat| [ mat.values.first ] } %>
@@ -35,7 +35,7 @@
         <div class="hold-form form-group">
           <%= form.label(:hold_description, t("requests.form.description_label_html")) %>
           <p><%= t("requests.form.description_additional_text") %></p>
-          <%= select_tag(:hold_description, options_for_select(@description), { data: { "action": "form#select" }, class: "request-form form-control", include_blank: true, required: true, "aria-required": true } ) %>
+          <%= select_tag(:hold_description, grouped_options_for_select(@description), { data: { "action": "form#select", "target": "form.descriptions" }, class: "request-form form-control", include_blank: true, required: true, "aria-required": true } ) %>
         </div>
       <% else %>
         <%= form.hidden_field :hold_description, value: @description %>

--- a/spec/lib/cob_alma/requests_spec.rb
+++ b/spec/lib/cob_alma/requests_spec.rb
@@ -132,20 +132,20 @@ RSpec.describe CobAlma::Requests do
     end
   end
 
-  describe "#asrs_descriptions" do
+  describe "#material_type_and_asrs_descriptions(items_list)" do
     context "record has multiple empty descriptions" do
       let(:items_list) { Alma::BibItem.find("asrs_empty_descriptions") }
 
       it "returns an empty array" do
-        expect(described_class.asrs_descriptions(items_list)).to eq([""])
+        expect(described_class.material_type_and_asrs_descriptions(items_list)).to eq([["DVD", [""]]])
       end
     end
 
     context "record has empty description and is ASRS and available" do
       let(:items_list) { Alma::BibItem.find("asrs_empty_and_description") }
 
-      it "returns one description" do
-        expect(described_class.asrs_descriptions(items_list)).to eq(["", "sample"])
+      it "returns one description and one empty string" do
+        expect(described_class.material_type_and_asrs_descriptions(items_list)).to eq([["DVD", ["", "sample"]]])
       end
     end
 
@@ -153,15 +153,15 @@ RSpec.describe CobAlma::Requests do
       let(:items_list) { Alma::BibItem.find("empty_and_description_not_in_place") }
 
       it "returns an empty list" do
-        expect(described_class.asrs_descriptions(items_list)).to eq([])
+        expect(described_class.material_type_and_asrs_descriptions(items_list)).to eq([])
       end
     end
 
-    context "record many description but non are from ASRS" do
+    context "record many description but none are from ASRS" do
       let(:items_list) { Alma::BibItem.find("multiple_descriptions") }
 
       it "returns empty list" do
-        expect(described_class.asrs_descriptions(items_list)).to eq([])
+        expect(described_class.material_type_and_asrs_descriptions(items_list)).to eq([])
       end
     end
 
@@ -169,7 +169,7 @@ RSpec.describe CobAlma::Requests do
       let(:items_list) { Alma::BibItem.find("asrs_repeated_descriptions") }
 
       it "returns unique descriptions" do
-        expect(described_class.asrs_descriptions(items_list)).to eq(["sample"])
+        expect(described_class.material_type_and_asrs_descriptions(items_list)).to eq([["DVD", ["sample"]]])
       end
     end
   end
@@ -209,6 +209,23 @@ RSpec.describe CobAlma::Requests do
 
       it "returns each material type hash once" do
         expect(described_class.physical_material_type(items_list)).to eq([])
+      end
+    end
+  end
+
+  describe "#physical_material_type_and_descriptions(items_list)" do
+
+    context "material type and description" do
+      let(:items_list) { Alma::BibItem.find("multiple_descriptions") }
+      it "returns an array of hashes with materials types and descriptions" do
+        expect(described_class.physical_material_type_and_descriptions(items_list)).to eq([["DVD", ["sample", "second"]]])
+      end
+    end
+
+    context "material type with empty description" do
+      let(:items_list) { Alma::BibItem.find("empty_descriptions") }
+      it "returns an array of hashes with materials types and blank strings for description" do
+        expect(described_class.physical_material_type_and_descriptions(items_list)).to eq([["DVD", [""]]])
       end
     end
   end


### PR DESCRIPTION
- We are currently throwing errors when a user selects a material type and a description that does not exist for the selected material type.
- This code groups the descriptions by material types and filters the description dropdown based on the material type selected