### PR TITLE
BL-1164-nested-facets-ui-fixes

### DIFF
--- a/app/components/facet_item_component.rb
+++ b/app/components/facet_item_component.rb
@@ -1,12 +1,11 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 class FacetItemComponent < Blacklight::FacetItemComponent
   # Overrides Blacklight method to allow facet icons to be displayed
-  def render_facet_value
+  def render_facet_value(options = {})
     content_tag(:span, class: "facet-label") do
       link_to_unless(@suppress_link, @label, @href, class: "facet_select facet_#{@facet_item.facet_item.value.downcase.parameterize.underscore}")
-    end + render_facet_count
+    end + render_facet_count(options)
   end
 
   def render_selected_facet_value
@@ -18,5 +17,12 @@ class FacetItemComponent < Blacklight::FacetItemComponent
               content_tag(:span, "[remove]", class: "sr-only")
           end
       end + render_facet_count(classes: ["selected"])
+  end
+
+  def render_facet_count(options = {})
+    return super unless options[:indefinite_facet_count]
+
+    classes = (options[:classes] || []) << "facet-count"
+    content_tag("span", "+", class: classes)
   end
 end

--- a/app/components/facet_item_pivot_component.rb
+++ b/app/components/facet_item_pivot_component.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class FacetItemPivotComponent < Blacklight::FacetItemPivotComponent
+  with_collection_parameter :facet_item
+
+  def uncollapse?
+    return view_context.facet_field_in_params?(@facet_item.items[0].field) &&
+           params["f"][@facet_item.items[0].field] &&
+           params["f"][@facet_item.items[0].field].include?(@facet_item.items[0].value)
+  end
+
+  def call
+    facet = Blacklight::FacetItemComponent.new(facet_item: @facet_item, wrapping_element: nil, suppress_link: @suppress_link)
+
+    id = "h-#{self.class.mint_id}" if @collapsing && has_items?
+
+    content_tag @wrapping_element, role: "treeitem" do
+      concat facet_toggle_button(id) if has_items? && @collapsing
+      concat content_tag("span", render_component(facet), class: "facet-values #{'facet-leaf-node' if has_items? && @collapsing}", id: id && "#{id}_label")
+
+      if has_items?
+        concat(content_tag("ul", class: "pivot-facet list-unstyled #{'collapse' if @collapsing} #{'show' if uncollapse?}", id: id, role: "group") do
+                 render_component(
+                   self.class.with_collection(
+                     @facet_item.items.map { |i| facet_item_presenter(i) }
+                   )
+                 )
+               end)
+      end
+    end
+  end
+
+  def facet_toggle_button(id)
+    content_tag "button", class: "btn facet-toggle-handle #{'collapsed' unless uncollapse?}",
+                data: { toggle: "collapse", target: "##{id}" },
+                aria: { expanded: uncollapse?, controls: id, describedby: "#{id}_label" } do
+      concat toggle_icon(:show)
+      concat toggle_icon(:hide)
+    end
+  end
+end

--- a/app/presenters/facet_item_presenter.rb
+++ b/app/presenters/facet_item_presenter.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class FacetItemPresenter < Blacklight::FacetItemPresenter
+  # If we are rendering a more general facet in a state
+  # where a more specific facet is selected, we are
+  # effectively offering the user a chance to cancel the
+  # specific facet and replace it with the more general facet.
+  # So we don't want the specific one sticking around.
+  def hide_facet_param(facet_item)
+    @hidden_facet_params ||= []
+    @hidden_facet_params << facet_item
+  end
+
+  def search_state
+    @hidden_facet_params ||= []
+    Blacklight::SearchState.new(
+      @hidden_facet_params.reduce(super) { |_search_state, facet_item| _search_state.remove_facet_params(facet_item.field, facet_item) },
+      view_context.blacklight_config
+    );
+  end
+
+  def keep_in_params!
+    @keep_in_params ||= true
+  end
+
+  def keep_in_params?
+    @keep_in_params
+  end
+
+  def href
+    if selected? && keep_in_params?
+      view_context.search_action_path(search_state)
+    else
+      super
+    end
+  end
+end


### PR DESCRIPTION
Modifications to the pivot facet logic:

- Renders a nesting facet as unselected if it contains a selected nested facet. The hyperlink of the nesting facet should effectively remove the nested facet and add the nesting facet if it isn't already there.
- Renders nesting facet in open state if it contains a selected nested facet.

Tests are still needed, but perhaps it would be better to wait until it has been evaluated for usability.