### PR TITLE
Parse out empty params from queries

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -106,7 +106,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def substitute_special_chars(value, _)
-    value.gsub(/[:?]/, " ") rescue value
+    value.gsub(/([:?]|\(\))/, " ") rescue value
   end
 
   def no_journals(solr_parameters)

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -183,6 +183,14 @@ RSpec.describe SearchBuilder , type: :model do
       # @see BL-1301 for ref.  Basically Solr treats ? as a special character.
       expect(subject.substitute_special_chars("foo bar?", nil)).to eq("foo bar ")
     end
+
+    it "substitutes empty parens '()' " do
+      expect(subject.substitute_special_chars("foo () bar", nil)).to eq("foo   bar")
+    end
+
+    it "does not substitutes parens containing values " do
+      expect(subject.substitute_special_chars("foo (bar) baz", nil)).to eq("foo (bar) baz")
+    end
   end
 
   describe "#blacklight_params" do


### PR DESCRIPTION
If an empty param,`()`, is included in a query, the boolen query parser included from advanced search gem throws an error.

It is documented as an issue upstream at projectblacklight/blacklight_advanced_search#101, but at the moment no fix upstream is proposed.

This PR works around the issue by removing empty parens from the query string. It does not impact parens containing content.

