### PR TITLE
avoid using SearchState::to_h when tweaking facet href params

### DIFF
--- a/app/presenters/facet_item_presenter.rb
+++ b/app/presenters/facet_item_presenter.rb
@@ -23,16 +23,12 @@ class FacetItemPresenter < Blacklight::FacetItemPresenter
     @keep_in_params
   end
 
-  def href(path_options = {})
-    if selected? && keep_in_params?
-      search_path(search_state.to_h)
-    else
-      super
-    end
-  end
-
   def remove_href(path = search_state)
-    search_path(path.remove_facet_params(facet_config.key, facet_item))
+    if keep_in_params?
+      search_path(path.remove_facet_params(nil, nil))
+    else
+      search_path(path.remove_facet_params(facet_config.key, facet_item))
+    end
   end
 
   def add_href(path_options = {})

--- a/spec/presenters/facet_item_presenter_spec.rb
+++ b/spec/presenters/facet_item_presenter_spec.rb
@@ -52,5 +52,16 @@ RSpec.describe FacetItemPresenter, type: :presenter do
       expect(CGI.unescape(presenter.href)).to include "[pet][]=cat"
       expect(CGI.unescape(presenter.href)).not_to include "[job][]=vet"
     end
+
+    it "doesn't tweak the actual search state" do
+      hide_me = Blacklight::Solr::Response::Facets::FacetItem.new(value: "vet", hits: 100, field: "job")
+      expect(search_state[:f].keys.sort).to eq %w(pet job num).sort
+      presenter.hide_facet_param(hide_me)
+      presenter.href
+      expect(search_state[:f].keys.sort).to eq %w(pet job num).sort
+      presenter.keep_in_params!
+      presenter.href
+      expect(search_state[:f].keys.sort).to eq %w(pet job num).sort
+    end
   end
 end


### PR DESCRIPTION
Blacklight::SearchState::to_h returns the actual param hash, so using it to render facet params causes bad side effects (deleting search params). So we can just utilize the existing remove and add functions, which return deep copies of that facet hash.