### PR TITLE
Update libguides search terms and response handling for better relevance

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -9,6 +9,7 @@ class SearchController < CatalogController
 
     config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :index_translate_resource_type_code, no_label: true
     config.add_facet_field "format", label: "Resource Type", url_method: :path_for_books_and_media_facet, helper_method: :translate_resource_type_code, show: true, limit: -1
+    config.add_facet_field "subject_topic_facet", limit: true
   end
 
   def index

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -555,7 +555,18 @@ module CatalogHelper
     ::FeatureFlags.campus_closed?(params)
   end
 
-  def derived_libguides_search_term
-    params.fetch("q", "")
+  def derived_lib_guides_search_term(solr_response)
+    query =  [params.fetch("q", "")]
+    query += _subject_topic_facet_terms(solr_response)
+    query.map { |s| "(#{s})" }.join(" OR ")
+  end
+
+  def _subject_topic_facet_terms(response)
+    return [] if (response.nil? || !response.respond_to?(:facet_fields))
+    (response.facet_fields || {})
+    .fetch("subject_topic_facet", [])
+      .to_a
+      .each_slice(2)
+      .map(&:first)
   end
 end

--- a/app/models/lib_guides_api.rb
+++ b/app/models/lib_guides_api.rb
@@ -30,7 +30,15 @@ class LibGuidesApi
   private
 
     def guides
-      json.take(3)
+      ranked_by_type.take(3)
+    end
+
+    def ranked_by_type
+      # The Libguides API has no way to express preference for certain types of guides, the equivalent
+      # of a solr boost (^10 ), so we take the original response, sort it by guide type, then do
+      # a secondary sort by original order. That way the most relevant subject guides appear at the top
+      ranker = { "Subject Guide" => 1, "Topic Guide" => 2, "General Purpose Guide" => 3, "Course Guide" => 4 }
+      json.sort_by { |o| [ranker[o["type_label"]], json.index(o) ] }
     end
 
     def json

--- a/app/views/catalog/_lib_guide_recommender_catalog.html.erb
+++ b/app/views/catalog/_lib_guide_recommender_catalog.html.erb
@@ -1,4 +1,4 @@
-<div class="lib-guides-recommender-catalog w-100 my-3" data-lib-guides-api-url="<%= lib_guides_path(q: params[:q]) %>" data-controller="lib-guides">
+<div class="lib-guides-recommender-catalog w-100 my-3" data-lib-guides-api-url="<%= lib_guides_path(q: derived_lib_guides_search_term(@response)) %>" data-controller="lib-guides">
   <div class="lib-guides-recommender-catalog-body rounded-top">
     <h4 class="lib-guides-recommender-catalog-heading text-red px-4 mb-0">Help &amp; Guides</h4>
     <div class="d-flex justify-content-between pt-md-1 pb-md-4 px-md-4">

--- a/app/views/search/_lib_guide_recommender_bento.html.erb
+++ b/app/views/search/_lib_guide_recommender_bento.html.erb
@@ -1,4 +1,4 @@
-<div class="card lib-guides-recommender-bento border bg-header-grey" data-lib-guides-api-url="<%= lib_guides_path(q: params[:q]) %>" data-controller="lib-guides">
+<div class="card lib-guides-recommender-bento border bg-header-grey" data-lib-guides-api-url="<%= lib_guides_path(q: derived_lib_guides_search_term(@response)) %>" data-controller="lib-guides">
   <button class="d-lg-none collapsed w-100 p-0 border-0 m-0" data-toggle="collapse" data-target="#lib-guide-collapse">
     <h2 class="text-left pl-3 lib-guides-recommender-bento-heading text-white bg-red mb-0 rounded-top">Help &amp; Guides
       <i class="fa float-right pr-3" aria-hidden="true"></i>

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SearchController, type: :controller do
 
       it "adds content-dm totals to facet" do
         facet_fields = controller.instance_variable_get(:@response).facet_fields
-        expect(facet_fields).to eq("format" => [ "digital_collections", "415" ])
+        expect(facet_fields).to include("format" => [ "digital_collections", "415" ])
       end
     end
 

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -907,14 +907,58 @@ RSpec.describe CatalogHelper, type: :helper do
     end
   end
 
-  describe "#derived_libguides_search_term" do
+  describe "#derived_lib_guides_search_term(solr_response)" do
     before do
       allow(helper).to receive(:params) { params }
+      allow(self).to receive(:_subject_topic_facet_terms).and_return(["wu tang", "clan aint"])
     end
     let(:params) { { "q" => "thing" } }
 
-    it "returns the origial search term as term to search in libguides" do
-      expect(derived_libguides_search_term).to eq("thing")
+    it "returns the origial search term and subject topics in parenthesis and combined with OR " do
+      expect(derived_lib_guides_search_term(nil)).to eq("(thing) OR (wu tang) OR (clan aint)")
+    end
+  end
+
+  describe "#_subject_topic_facet_terms(response)" do
+    let(:subject) { _subject_topic_facet_terms(response) }
+    let(:solr_response) { Blacklight::Solr::Response.new({ responseHeader: {}, facet_counts: { facet_fields: [facet_field] } }, {}) }
+    let(:facet_field) { ["wrong", []] }
+
+    context "nil response" do
+      let(:response) { nil }
+      it "returns an empty array" do
+        expect(subject).to eq([])
+      end
+    end
+
+    context "empty solr response" do
+      let(:response) { solr_response }
+      it "returns an empty array" do
+        expect(subject).to eq([])
+      end
+    end
+
+    context "solr_response without subject_topic_facet" do
+      let(:response) { solr_response }
+      it "returns an empty array" do
+        expect(subject).to eq([])
+      end
+    end
+
+    context "solr_response with subject_topic_facet" do
+      let(:facet_field) { ["subject_topic_facet", ["foo", 1]] }
+      let(:response) { solr_response }
+      it "returns an empty array" do
+        expect(subject).to eq(["foo"])
+      end
+    end
+
+    context "solr_response with subject_topic_facet multiple values" do
+      let(:facet_field) { ["subject_topic_facet", ["foo", 1, "boo", 2]] }
+      let(:response) { solr_response }
+      it "returns an empty array" do
+        expect(subject).to eq(["foo", "boo"])
+      end
     end
   end
 end

--- a/spec/models/lib_guides_api_spec.rb
+++ b/spec/models/lib_guides_api_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe LibGuidesApi do
       allow(HTTParty).to receive(:get).and_return(double(success?: true, body: json))
       expect(api.as_json.length).to be 3
     end
+
+    context "when there are many results" do
+      it "sorts Subject -> Topic -> General Purpose -> Course, then by original order" do
+        allow(HTTParty).to receive(:get).and_return(
+          double(success?: true, body: [
+            { id: 1, "type_label" => "Subject Guide" },
+            { id: 2, "type_label" => "General Purpose Guide" },
+            { id: 3, "type_label" => "Topic Guide" },
+            { id: 4, "type_label" => "Course Guide" },
+            { id: 5, "type_label" => "Subject Guide" },
+          ].to_json))
+        expect(api.as_json.map { |o| o["id"] }).to eq([1, 5, 3])
+      end
+    end
   end
 
   context "when the API fails to respond successfully" do


### PR DESCRIPTION
This pull requests updates the way we generate search queries to send to the libguides API and changs how we handle the API response before generating html.

Instead of sending only the original search term to the libguides API, we now grab the orginal search term plus the top 10 subject_facet_topic terms, wrap each term (which can be multiple words) in parenthesis and then join all of the terms with a boolean `OR`. This allows for a much broader search than the possibly very narrow original search query.

Additionally, we also process the response from the libguides API to boost Subject Guides and Topic Guides over Course Guides and General Purpose guides.