### PR TITLE
BL-1052: Remove location translation step.

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-CATALOG_COLLECTION="tul_cob-catalog-5.1.0.v0.6.3-2020-09-11_19-05-07"
+CATALOG_COLLECTION="tul_cob-catalog-5.1.0.v0.6.4-2020-09-23_15-11-01"
 AZ_COLLECTION="tul_cob-az-3-prod"
 WEB_CONTENT_COLLECTION="tul_cob-web-2-prod"
 

--- a/app/helpers/facets_helper.rb
+++ b/app/helpers/facets_helper.rb
@@ -33,35 +33,22 @@ module FacetsHelper
     end + " (#{item.hits})"
   end
 
+  ##
+  # Overrides Blacklight::FacetsHelperBehavior.facet_field_presenter.
+  #
+  # Overridden to use PivotFacetFieldPresenter for pivot fields.
   def facet_field_presenter(facet_config, display_facet)
     return PivotFacetFieldPresenter.new(facet_config, display_facet, self) if facet_config.pivot
     super(facet_config, display_facet)
-  end
-
-
-  def locations_map
-    @locations_map ||= Rails.configuration.locations.values.inject(&:merge)
-  end
-
-  def library_location_label(value, include_library = false)
-    library, label = value.split(" - ")
-    label = locations_map[label] || label
-
-    if include_library
-      [library, label].join(" - ")
-    else
-      label
-    end
   end
 
   def pre_process_library_facet!(item)
     # Filter out secondary facets that do not match library
     item.items.select! { |i| i.value.match?(/#{item.value}/) }
 
-    # Add propper secondary facet labels
-    item.items.each { |i| i.label = library_location_label(i.value) }
+    # Add proper secondary facet labels
+    item.items.each { |i| i.label = i.value.split(" - ", 2).last }
   end
-
 
   ##
   # Overridden to allow pivot sub fields to be rendered in 'selected' state

--- a/app/helpers/render_constraints_helper.rb
+++ b/app/helpers/render_constraints_helper.rb
@@ -11,12 +11,6 @@ module RenderConstraintsHelper
 
       presenter = facet_item_presenter(facet_config, val, facet)
 
-      # Map location label
-      label = presenter.label
-      if facet == "location_facet"
-        label = library_location_label(label, include_library = true)
-      end
-
       # Hide library_facet if matching location facet already selected.
       hidden_class = []
       if facet == "library_facet" &&
@@ -25,9 +19,9 @@ module RenderConstraintsHelper
       end
 
       acc << { facet_field_label: facet_field_label(facet_config.key),
-        label: label,
-        remove: presenter.remove_href(search_state),
-        classes: ["filter", "filter-" + facet.parameterize] + hidden_class }
+               label: presenter.label,
+               remove: presenter.remove_href(search_state),
+               classes: ["filter", "filter-" + facet.parameterize] + hidden_class }
     end
   end
 

--- a/spec/helpers/facets_helper_spec.rb
+++ b/spec/helpers/facets_helper_spec.rb
@@ -55,12 +55,6 @@ RSpec.describe FacetsHelper, type: :helper do
     end
   end
 
-  describe "#locations_map" do
-    it "maps locations coldes to labels" do
-      expect(locations_map["ASRS"]).to eq("BookBot")
-    end
-  end
-
   describe "#pre_process_library_facet!" do
     before do
       helper.pre_process_library_facet!(item)
@@ -85,23 +79,23 @@ RSpec.describe FacetsHelper, type: :helper do
       end
     end
 
-    context "sub item cannot be translated" do
+    context "sub item has 'foo - bar' value" do
       let(:sub_item_a) { Blacklight::Solr::Response::Facets::FacetItem.new(value: "foo - bar", hits: 5, items: []) }
       let(:item) { Blacklight::Solr::Response::Facets::FacetItem.new(value: "foo", hits: 5, items: [ sub_item_a ]) }
 
-      it "makes a label using sub item value but does not translate it" do
+      it "transforms label to just be 'bar'" do
         label = item.items.first.label
         expect(label).to eq("bar")
       end
     end
 
-    context "sub item can be translated" do
-      let(:sub_item_a) { Blacklight::Solr::Response::Facets::FacetItem.new(value: "foo - ASRS", hits: 5, items: []) }
+    context "sub item has 'foo - bar - buzz' value" do
+      let(:sub_item_a) { Blacklight::Solr::Response::Facets::FacetItem.new(value: "foo - bar - buzz", hits: 5, items: []) }
       let(:item) { Blacklight::Solr::Response::Facets::FacetItem.new(value: "foo", hits: 5, items: [ sub_item_a ]) }
 
-      it "makes a label using sub item value and translates it" do
+      it "transforms label to just be 'bar - buzz'" do
         label = item.items.first.label
-        expect(label).to eq("BookBot")
+        expect(label).to eq("bar - buzz")
       end
     end
   end

--- a/spec/helpers/render_constraints_helper_spec.rb
+++ b/spec/helpers/render_constraints_helper_spec.rb
@@ -41,15 +41,6 @@ RSpec.describe RenderConstraintsHelper, type: :helper do
       end
     end
 
-    context "is field location_facet" do
-      let(:facet) { "location_facet" }
-      let(:values) { "foo - ASRS" }
-
-      it "maps the location facet to the location label" do
-        expect(subject).to match(/foo - BookBot/)
-      end
-    end
-
     context "library_facet field and matching library_location" do
       let(:facet) { "library_facet" }
       let(:params) { ActionController::Parameters.new({ f: { location_facet: [ "foo - ASRS"] } }) }


### PR DESCRIPTION
- [x] Depends on tulibraries/cob_index#141

REQUIRES FULL_REINDEX

Move location translation step to indexing time because doing that
handles collapsing items that should be treated as coming from the same
location.  Otherwise they appear as duplicates or have the wrong facet
count.