### PR TITLE
Only request published, handled types of guides

### DIFF
--- a/app/models/lib_guides_api.rb
+++ b/app/models/lib_guides_api.rb
@@ -69,6 +69,8 @@ class LibGuidesApi
         key: api_key,
         sort_by: "relevance",
         expand: "owner",
+        guide_types: "1,2,3,4", # we don't want internal guides or templates
+        status: 1, # we only want published guides
         search_terms: "#{query}"
       }
 

--- a/spec/models/lib_guides_api_spec.rb
+++ b/spec/models/lib_guides_api_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe LibGuidesApi do
         expect(api.as_json.map { |o| o["id"] }).to eq([1, 5, 3])
       end
     end
+
+    context "when there are no results" do
+      it "returns an empty array" do
+        allow(HTTParty).to receive(:get).and_return(
+          double(success?: true, body: [].to_json))
+        expect(api.as_json.map { |o| o["id"] }).to eq([])
+      end
+    end
   end
 
   context "when the API fails to respond successfully" do


### PR DESCRIPTION
We don't want to recommend internal or private guides, so limit the types returned in the API call.
