### PR TITLE
Clean up lib guides work

### DIFF
--- a/app/assets/stylesheets/partials/_index_results.scss
+++ b/app/assets/stylesheets/partials/_index_results.scss
@@ -79,14 +79,16 @@ dd.blacklight-format {
 .lib-guides-recommender-catalog-body {
   background-color: #dddddd;
 
-  h4 {
+  h2 {
     font-weight: 800;
+    padding-left: 2.5rem;
+
     @media(max-width: 485px) {
       padding: 1rem !important;
       background-color: $red;
       color: $white !important;
-      border-top-right-radius: 0.25rem !important;
-      border-top-left-radius: 0.25rem !important;
+      border-top-right-radius: 0.25rem;
+      border-top-left-radius: 0.25rem;
     }
   }
 
@@ -108,7 +110,7 @@ dd.blacklight-format {
 .lib-guides-recommender-guides {
   background-color: #ebebe9;
 
-  h5 {
+  h3 {
     font-weight: 800;
   }
 
@@ -125,7 +127,7 @@ dd.blacklight-format {
 
   @media(max-width: 485px) {
     margin-right: 0;
-    border-bottom: 0.0625rem solid $red;
+    border-bottom: 0.0625rem solid $red !important;
     border-bottom-right-radius: 0 !important;
     border-bottom-left-radius: 0 !important;
   }

--- a/app/controllers/lib_guides_controller.rb
+++ b/app/controllers/lib_guides_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class LibGuidesController < CatalogController
+class LibGuidesController < ApplicationController
   def index
     @guides = LibGuidesApi.fetch(params[:q]).as_json
     render layout: false

--- a/app/javascript/packs/controllers/lib-guides_controller.js
+++ b/app/javascript/packs/controllers/lib-guides_controller.js
@@ -6,7 +6,7 @@ function getMetaValue(name) {
 }
 
 export default class extends Controller {
-  static targets = [ "card", "flex", "heading", "noresults", "panel" ];
+  static targets = [ "card", "flex", "heading", "noresults", "panel", "divider" ];
 
   initialize() {
     fetch(this.data.get("url"), {
@@ -17,9 +17,19 @@ export default class extends Controller {
     })
       .then(response => response.text())
       .then(html => {
-        this.cardTarget.innerHTML = html
+        let documents = $('#documents');
+        if (this.hasPanelTarget) {
+          let afterThird = documents.find('.document-position-2').after(this.panelTarget);
 
-        if (this.hasNoresultsTarget) {
+          // If there is no third document, just append to the end of #documents
+          if (afterThird.length === 0) {
+            documents.append(this.panelTarget);
+          }
+          this.panelTarget.classList.remove("hidden");
+        }
+
+        this.cardTarget.innerHTML = html
+        if (this.hasNoresultsTarget && this.cardTarget.classList.contains("catalog-guides")) {
           this.panelTarget.classList.add("hidden");
         }
 

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -16,14 +16,4 @@
 </div>
 
 <%= render_availability(document) %>
-
-<% if document_counter == 2 && controller_name == "catalog" %>
-  <hr class="document-divider" />
-  <div data-lib-guides-url="<%= lib_guides_path(q: derived_lib_guides_search_term(@response)) %>" data-controller="lib-guides">
-    <%= render :partial => "lib_guide_recommender_catalog" %>
-  </div>
-  <hr class="document-divider" />
-
-<% else %>
-  <hr class="document-divider" />
-<% end %>
+<hr class="document-divider" />

--- a/app/views/catalog/_lib_guide_recommender_catalog.html.erb
+++ b/app/views/catalog/_lib_guide_recommender_catalog.html.erb
@@ -1,6 +1,6 @@
-<div class="lib-guides-recommender-catalog w-100 my-3" data-target="lib-guides.panel">
+<div class="lib-guides-recommender-catalog w-100 my-3 px-3">
   <div class="lib-guides-recommender-catalog-body rounded-top">
-    <h2 class="lib-guides-recommender-catalog-heading text-red px-4 mb-0">Help &amp; Guides</h2>
+    <h2 class="lib-guides-recommender-catalog-heading text-red mb-0">Help &amp; Guides</h2>
     <div class="d-flex justify-content-between pt-md-1 pb-md-4 px-md-4 catalog-guides" data-target="lib-guides.card">
       <div class="lib-guides-recommender-librarians flex-fill p-4 rounded" data-target="lib-guides.flex">
         <h3 class="lib-guides-recommender-heading lib-guides-recommender-catalog-heading">Subject Librarians</h3>

--- a/app/views/catalog/_lib_guide_section.html.erb
+++ b/app/views/catalog/_lib_guide_section.html.erb
@@ -1,0 +1,6 @@
+<% if controller_name == "catalog" %>
+  <div class="hidden" data-lib-guides-url="<%= lib_guides_path(q: derived_lib_guides_search_term(@response)) %>" data-controller="lib-guides" data-target="lib-guides.panel">
+
+    <%= render :partial => "lib_guide_recommender_catalog" %>
+  </div>
+<% end %>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -23,4 +23,5 @@
 <%- else %>
   <%= render_document_index %>
 <%- end %>
+
 <%= render "results_pagination" %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -20,6 +20,7 @@
       <%= render "shared/sitelinks_search_box" %>
     <% else %>
       <%= render "search_results" %>
+      <%= render :partial => "lib_guide_section" %>
     <% end %>
   </div>
 

--- a/app/views/lib_guides/index.html.erb
+++ b/app/views/lib_guides/index.html.erb
@@ -1,12 +1,12 @@
   <div class="lib-guides-recommender-librarians border p-3" data-target="lib-guides.flex">
     <h3 class="lib-guides-recommender-heading" data-target="lib-guides.heading">Subject Librarians</h3>
     <% if @guides.present? %>
-      <%= link_to(@guides[0]["owner"]["first_name"] + " " + @guides[0]["owner"]["last_name"], "https://guides.temple.edu/prf.php?account_id=" + @guides[0]["owner"]["id"]) %>
-      <p class="pt-2"><%= @guides[0]["owner"]["email"] %></p>
+      <%= link_to(@guides.first.dig("owner", "first_name") + " " + @guides.first.dig("owner", "last_name"), "https://guides.temple.edu/prf.php?account_id=" + @guides.first.dig("owner", "id")) %>
+      <p class="pt-2"><%= @guides.first.dig("owner", "email") %></p>
     <% else %>
       <div data-target="lib-guides.noresults">
-        <p>Need research help?</p>
-        <%= link_to("Talk to a librarian or subject matter expert", "https://library.temple.edu/services/sme") %>
+        <p><%= t("lib_guides.librarian_no_results") %></p>
+        <%= link_to(t("lib_guides.librarian_no_results_text"), t("lib_guides.librarian_no_results_href")) %>
       </div>
     <% end %>
   </div>
@@ -23,7 +23,7 @@
     <% else %>
       <div data-target="lib-guides.noresults">
         <li class="pb-2">
-          <%= link_to("Browse our research guides by subject", "https://guides.temple.edu/?b=s") %>
+          <%= link_to(t("lib_guides.guides_no_results_text"), t("lib_guides.guides_no_results_link")) %>
         </li>
       </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -297,6 +297,13 @@ en:
     update_name_href: "https://tuportal.temple.edu"
     email_notice: "If you prefer not to receive email notices from us owing to privacy concerns, we offer an opt-out option. Please know that if you choose to opt out of receiving email notifications for due dates, late items, etc., you are still fully responsible for any and all related fines and other consequences resulting from late, long overdue or lost/missing items you have borrowed. If interested, please contact a staff member at the circulation desk."
 
+  lib_guides:
+    librarian_no_results: "Need research help?"
+    librarian_no_results_text: "Talk to a librarian or subject matter expert"
+    librarian_no_results_link: "https://library.temple.edu/services/sme"
+    guides_no_results_text: "Browse our research guides by subject"
+    guides_no_results_link: "https://guides.temple.edu/?b=s"
+
   resource_type_code:
     articles: "Journal Article"
     article: "Journal Article"


### PR DESCRIPTION
- Adds translations for default text
- Uses javascript to insert lib guides section into catalog results
- Adjusts styling that needed to be changed after editing the original files
- Moves where we call lib guides in the catalog so that it only gets called once