### PR TITLE
DEVO-260 Update cob_az_index branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ gem "cob_web_index", git: "https://github.com/tulibraries/cob_web_index.git",
   branch: "main"
 
 gem "cob_az_index", git: "https://github.com/tulibraries/cob_az_index.git",
-  branch: "qa"
+  branch: "main"
 
 gem "cob_index",
   git: "https://github.com/tulibraries/cob_index.git",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,8 +39,8 @@ GIT
 
 GIT
   remote: https://github.com/tulibraries/cob_az_index.git
-  revision: 2bfea9fa971408a180be4a651fc9a7f8aae56a2a
-  branch: qa
+  revision: e777602b43a5e08c10a950c3f0677781c214d927
+  branch: main
   specs:
     cob_az_index (0.1.0)
       gli (~> 2.18)


### PR DESCRIPTION
- cob_az_index is now a main only repo, so we need to point to that branch