### PR TITLE
BL-1335 Fix advanced article searches skipped.

### DIFF
--- a/app/models/blacklight/primo_central/search_builder.rb
+++ b/app/models/blacklight/primo_central/search_builder.rb
@@ -17,7 +17,10 @@ module Blacklight::PrimoCentral
 
     def skip_search?(params)
       # Skip useless searches
-      params[:skip_search?] = ["*", "", nil].include?(blacklight_params["q"])
+      params[:skip_search?] =  [ "q", "q_1", "q_2", "q_3"].all? do |key|
+        next true if blacklight_params[key].nil?
+        ["*", "", nil].include?(blacklight_params[key])
+      end
     end
   end
 end

--- a/spec/models/primo_search_builder_spec.rb
+++ b/spec/models/primo_search_builder_spec.rb
@@ -323,5 +323,37 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
         expect(primo_central_parameters["skip_search?"]).to eq(false)
       end
     end
+
+    context "query is advanced q_1" do
+      let(:params) { ActionController::Parameters.new(q_1: "foo") }
+
+      it "sets skip_search? false" do
+        expect(primo_central_parameters["skip_search?"]).to eq(false)
+      end
+    end
+
+    context "query is advanced q_2" do
+      let(:params) { ActionController::Parameters.new(q_1: "foo") }
+
+      it "sets skip_search? false" do
+        expect(primo_central_parameters["skip_search?"]).to eq(false)
+      end
+    end
+
+    context "query is advanced q_3" do
+      let(:params) { ActionController::Parameters.new(q_1: "foo") }
+
+      it "sets skip_search? false" do
+        expect(primo_central_parameters["skip_search?"]).to eq(false)
+      end
+    end
+
+    context "query is advanced q_1 empty" do
+      let(:params) { ActionController::Parameters.new(q_1: "") }
+
+      it "sets skip_search? true" do
+        expect(primo_central_parameters["skip_search?"]).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
Skip search only when no queries (including advanced ones) are set.