### PR TITLE
Fix for request bug

### DIFF
--- a/app/views/almaws/_asrs_request_form.html.erb
+++ b/app/views/almaws/_asrs_request_form.html.erb
@@ -42,7 +42,7 @@
           <%= select_tag(:asrs_description, grouped_options_for_select(@asrs_description), { data: { "action": "form#select", "target": "form.descriptions" }, class: "request-form form-control", include_blank: true }) %>
         </div>
       <% else %>
-        <%= form.hidden_field :asrs_description, value: @asrs_description %>
+        <%= form.hidden_field :asrs_description, value: @asrs_description.flatten.last%>
       <% end %>
 
       <div class="hold-form form-group row">


### PR DESCRIPTION
We recently updated the way descriptions are handled in the request forms, basing them on material type.  The asrs_descriptions instance variable now returns [["DVD", [""]]] in order for the dropdown menus to work.  This works when there are multiple descriptions present and the user is selecting one.

When items only have 1 description, we pass the params["description] through a hidden field. But, this is adding the material_type key("DVD") as a description in the hidden_field.  This updates the form to return the last description instead of the nested array that includes the material type value.