### PR TITLE
Remove unnecessary configuration.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,13 +37,6 @@ module Tulcob
     config.time_zone = "Eastern Time (US & Canada)"
     config.active_record.default_timezone = :local
 
-    # TODO: do we still need this?
-    begin
-      config.relative_url_root = config_for(:deploy_to)["path"]
-    rescue StandardError => error
-      error
-    end
-
     config.generators do |g|
       g.test_framework :rspec, spec: true
       g.fixture_replacement :factory_bot

--- a/config/deploy_to.yml.example
+++ b/config/deploy_to.yml.example
@@ -1,4 +1,0 @@
----
-
-production:
-    path: "/catalog"


### PR DESCRIPTION
* The relative URL root is set to the default ("/") for all our
environments. Therefore this configuration is no longer needed.