### PR TITLE
Allow primo and alma apikey config using environment variable.

### DIFF
--- a/config/initializers/alma.rb
+++ b/config/initializers/alma.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-Alma.configure do |config|
-  # You have to set te apikey
-  config.apikey = Rails.configuration.alma[:apikey]
-  config.enable_loggable = true
-  config.timeout = Rails.configuration.alma[:timeout] || 30
-end
 ENV["ALMA_API_KEY"] ||= Rails.configuration.alma[:apikey]
 ENV["ALMA_DELIVERY_DOMAIN"] ||= Rails.configuration.alma[:delivery_domain]
 ENV["ALMA_INSTITUTION_CODE"] ||= Rails.configuration.alma[:institution_code]
 ENV["ALMA_AUTH_SECRET"] ||= Rails.configuration.alma[:auth_secret]
+
+Alma.configure do |config|
+  # You have to set te apikey
+  config.apikey = ENV["ALMA_API_KEY"]
+  config.enable_loggable = true
+  config.timeout = Rails.configuration.alma[:timeout] || 30
+end

--- a/config/initializers/primo.rb
+++ b/config/initializers/primo.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Primo.configure do |config|
-  config.apikey  = Rails.configuration.bento[:primo][:apikey]
+  config.apikey  = ENV["PRIMO_API_KEY"] || Rails.configuration.bento[:primo][:apikey]
   config.context = :PC
   config.vid     = "TULI"
   config.scope   = "pci_scope"


### PR DESCRIPTION
We already do this for Alma requests.  We should do it for Primo
requests too.  In K8 we will be setting secret configs via environment
variables.