### PR TITLE
Set ci docker bundle path to /app/vendor

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -13,6 +13,7 @@ services:
       SOLR_WEB_CONTENT_URL: "http://solr:8983/solr/web-content"
       DO_INGEST: "${DO_INGEST}"
       LC_ALL: "C.UTF-8"
+      BUNDLE_PATH: /app/vendor/bundle
     entrypoint:
       - "tail"
       - "-f"


### PR DESCRIPTION
This is not set by default.