### PR TITLE
BL-1323 Do not hit alma on database page.

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -121,6 +121,8 @@ module CatalogHelper
 
   def render_online_availability(doc_presenter)
     field = blacklight_config.show_fields["electronic_resource_display"]
+    return if field.nil?
+
     online_resources = [doc_presenter.field_value(field)]
       .select { |r| !r.empty? }.compact
 

--- a/app/models/solr_database_document.rb
+++ b/app/models/solr_database_document.rb
@@ -3,4 +3,10 @@
 class SolrDatabaseDocument < SolrDocument
   use_extension(Blacklight::Document::Email)
   use_extension(Blacklight::Document::Sms)
+
+
+  # Databases do not have any alma availability to report
+  def alma_availability_mms_ids
+    []
+  end
 end

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -1,7 +1,13 @@
+
 <% doc_presenter = show_presenter(document) %>
+
 <%# partial to display availability details in catalog show view -%>
 
+<% if document.alma_availability_mms_ids.present? %>
 <div data-controller="show" data-show-url="<%= item_url(document.alma_availability_mms_ids.first, params.merge(doc_id: document.id, redirect_to: request.url)) %>">
+<% else %>
+<div>
+<% end %>
   <div id="record-view-iframe" data-availability-id="<%= document.alma_availability_mms_ids.first %>" class="card availability-card d-flex mx-auto border-0">
     <div class="availability-card-heading float-right">
       <div id="heading-request ml-auto">

--- a/spec/views/catalog/_show_availability_section.html.erb_spec.rb
+++ b/spec/views/catalog/_show_availability_section.html.erb_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "catalog/_show_availability_section.html.erb", type: :view do
+
+  include BlacklightHelper
+  include CatalogHelper
+
+  let(:user_signed_in?) { false }
+  let(:config) { Blacklight::Configuration.new }
+
+  before(:each) do
+    config.show.document_presenter_class = ShowPresenter
+
+    allow(view).to receive(:user_signed_in?) { user_signed_in? }
+    allow(view).to receive(:item_url).and_return "https://example.com/foo"
+
+    without_partial_double_verification do
+      allow(view).to receive(:blacklight_config).and_return config
+    end
+  end
+
+  context "viewing a SolrDocument" do
+    let (:document) { SolrDocument.new(id: "foo") }
+
+    it "adds stimulus show controller stuff" do
+      render "catalog/show_availability_section", document: document
+      expect(rendered).to match(/<div data-controller="show"/)
+    end
+  end
+
+  context "viewing a SolrDatabaseDocument" do
+    let(:document) { SolrDatabaseDocument.new(id: 1) }
+
+    it "does not add stimulus show controller stuff" do
+      render "catalog/show_availability_section", document: document
+      expect(rendered).not_to match(/<div data-controller="show"/)
+    end
+  end
+end


### PR DESCRIPTION
Skips adding stimulus controller to document show page when viewing
databases as databases have not alma availability information that needs
to be loaded.