### PR TITLE
BL-1166: Add hierarchical linking to subjects.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -115,6 +115,16 @@ $(document).ready(function(){
 	    }
 	    else $(document).find(':input[id=renew_selected]').prop('disabled', true);
 	});
+
+  //link highlighting of hierarchy
+  $(".search-subject, .search-name-title").hover(
+    function() {
+      $(this).prevAll().addClass("field-hierarchy");
+    },
+    function() {
+      $(this).prevAll().removeClass("field-hierarchy");
+    }
+  );
 });
 
 

--- a/app/assets/stylesheets/partials/_record_pages.scss
+++ b/app/assets/stylesheets/partials/_record_pages.scss
@@ -72,3 +72,7 @@
 dd.blacklight-format {
   padding-left: 15px;
 }
+
+.field-hierarchy {
+  text-decoration: underline;
+}

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -1021,4 +1021,23 @@ RSpec.describe CatalogHelper, type: :helper do
       end
     end
   end
+
+  describe "#subject_links" do
+    let(:args) { {
+      document: SolrDocument.new(id: "foo", subject_display: subject),
+      field: "subject_display"
+    } }
+
+    before do
+      allow(helper).to receive(:base_path) { "foo/bar" }
+    end
+
+    context "subjet is hierarchical string" do
+      let(:subject) { ["Foo — Bar"] }
+
+      it "splits the subject into a hierarchical list of links" do
+        expect(helper.subject_links(args).first).to match(/<a.*href=".*Foo".*>Foo<\/a>.*href=".*Foo\+%E2%80%94\+Bar.*>Bar<\/a>/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
For subject_display fields with subdivisions (i.e. those that we have
concatenated together using an em dash), add link options for searching
each level of the subject heading using the subdivisions on the full
record page