### PR TITLE
Fix passing format=json throws error.

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -24,12 +24,7 @@ class SearchController < CatalogController
     respond_to do |format|
       format.html { store_preferred_view }
       format.json do
-        @response ||= Blacklight::PrimoCentral::Response.new({})
-        @results ||= []
-        @presenter = Blacklight::JsonPresenter.new(@response,
-                                                   @results,
-                                                   [],
-                                                   blacklight_config)
+        render plain: @results.to_json, status: 200, content_type: "application/json"
       end
     end
   end


### PR DESCRIPTION
Passing format=json as an argument to /everything? query will throw an error instead of loading results in JSON format.