### PR TITLE
BL-1328 Footer links

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -14,6 +14,8 @@
           <div class="region region-postscript-second">
             <div>
               <ul>
+                <li><%= link_to(t("no_results.ez_borrow_href"), t("no_results.ez_borrow_link"), target: "_blank") %></li>
+                <li><%= link_to(t("no_results.illiad_href"), t("no_results.illiad_link"), target: "_blank") %></li>
                 <li><a href="https://directory.temple.edu/">Cherry and White Directory</a></li>
                 <li><a href="https://library.temple.edu/libraries/2">Maps and Directions</a></li>
                 <li><a href="https://library.temple.edu/contact-us">Contact</a></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,7 +245,7 @@ en:
     ez_borrow_link: "https://ezb.relaisd2d.com/?LS=TEMPLE"
     illiad_html: "For <strong>journal articles, books not available through E-ZBorrow, and other</strong> materials not available at Temple, use %{href}."
     illiad_href: "ILLiad"
-    illiad_link: "http://libproxy.temple.edu/login?url=https://temple.illiad.oclc.org/illiad/charles/logon.html"
+    illiad_link: "https://temple.illiad.oclc.org/illiad/charles/logon.html"
     ginsburg_illiad_html: "The Health Sciences Libraries patrons should use %{href},"
     ginsburg_illiad_href: "ILLiad for Ginsburg (HSL) Library"
     ginsburg_illiad_link: "https://temple.illiad.oclc.org/illiad/HSC/logon.html"


### PR DESCRIPTION
- Adds EZBorrow and Illiad links to the footer
- Updates the link for Illiad to not use the proxy