### PR TITLE
Authenticate dockerhub pulls.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,9 @@ jobs:
   run_tests:
     docker:
       - image: cimg/base:2020.01
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
 
@@ -98,6 +101,9 @@ jobs:
   qa_deploy:
     docker:
       - image: circleci/python:3.6.6
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:
@@ -112,6 +118,9 @@ jobs:
   stage_deploy:
     docker:
       - image: circleci/python:3.6.6
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:
@@ -126,6 +135,9 @@ jobs:
   prod_deploy:
     docker:
       - image: circleci/python:3.6.6
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ifeq ($(CI), true)
 	DOCKER := docker-compose -p tul_cob -f docker-compose.ci.yml
 	LINT_CMD := ./bin/rubocop
 	TEST_CMD := ./bin/rake ci
+	DOCKERHUB_LOGIN := docker login -u ${DOCKERHUB_USER} -p ${DOCKERHUB_PASSWORD}
 else
 	DOCKER := docker-compose -f docker-compose.yml -f docker-compose.local.yml
 	LINT_CMD := rubocop
@@ -11,6 +12,7 @@ endif
 up:
 	git submodule init
 	git submodule update
+	@$(DOCKERHUB_LOGIN)
 	$(DOCKER) up -d
 down:
 	$(DOCKER) down


### PR DESCRIPTION
dockerhub will begin to throttle non anthenticated pulls so we need to
authenticate our pulls now.