### PR TITLE
respond with not found for all random requests

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -11,6 +11,6 @@ class ErrorsController < ApplicationController
 
   private
     def layout(options)
-      request.env["REQUEST_PATH"].match?(/^\/almaws/) ? options.merge(layout: false) : options
+      request.env["REQUEST_PATH"]&.match?(/^\/almaws/) ? options.merge(layout: false) : options
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,7 @@ Rails.application.routes.draw do
   match "/articles", to: "primo_central#index", as: "search", via: [:get, :post]
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get "*anything", to: "errors#not_found"
 end
 
 OkComputer::Engine.routes.draw do

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "random 404", type: :request do
+
+  it "should redirect /errors/:not_found" do
+    get "/foobar"
+    expect(response).to have_http_status 404
+  end
+end


### PR DESCRIPTION
See:
https://app.honeybadger.io/projects/56250/faults/71188759

What happened:
The app raised a routing error, and because it was in the production environment, tried to render an error page while recovering and then errored while rendering due to an environment variable that wasn't there being expected by the template. I have fixed both issues (I hope!).

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/1626547/101067227-4a553800-3565-11eb-8f5b-7034d72dad09.png">
