### PR TITLE
always render error pages as html

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,11 +2,11 @@
 
 class ErrorsController < ApplicationController
   def not_found
-    render(layout(status: 404))
+    render(layout(status: 404, formats: :html))
   end
 
   def internal_server_error
-    render(layout(status: 500))
+    render(layout(status: 500, formats: :html))
   end
 
   private

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ErrorsController, type: :controller do
+  render_views
+
+  let (:sign_out_url) { Rails.configuration.devise[:sign_out_redirect_url] }
+
+  it "ignores file extensions in url when a resource is not found" do
+    get :not_found, params: { format: "txt" }
+    expect(response).to have_http_status 404
+    expect(response.body).to include "DOCTYPE html"
+  end
+
+  it "ignores file extensions in url when a server error arises" do
+    get :internal_server_error, params: { format: "txt" }
+    expect(response).to have_http_status 500
+    expect(response.body).to include "DOCTYPE html"
+  end
+end


### PR DESCRIPTION
Application faulted when a request contained a file extension, e.g., http://librarysearch/foo/bar.txt

https://app.honeybadger.io/projects/54521/faults/71255924