### PR TITLE
BL-1373 conditionally render lc classification metadata

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -9,6 +9,7 @@ class CatalogController < ApplicationController
   include BlacklightAlma::Availability
   include Blacklight::Marc::Catalog
   include ServerErrors
+  include LCClassifications
 
   before_action :authenticate_purchase_order!, only: [ :purchase_order, :purchase_order_action ]
   before_action :set_thread_request
@@ -73,6 +74,7 @@ class CatalogController < ApplicationController
     # solr field configuration for search results/index views
     config.index.title_field = "title_truncated_display"
     config.index.display_type_field = "format"
+    config.index.document_presenter_class = IndexPresenter
 
     # solr field configuration for document/show views
     config.show.title_field = "title_statement_display"
@@ -168,7 +170,7 @@ class CatalogController < ApplicationController
     config.add_index_field "imprint_man_display", label: "Manufacture"
     config.add_index_field "creator_display", label: "Author/Creator", helper_method: :creator_index_separator
     config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :separate_formats
-    config.add_index_field "lc_call_number_display"
+    config.add_index_field "lc_call_number_display", if: :render_lc_call_number_on_index?
     config.add_index_field "url_finding_aid_display", label: "Finding Aid", helper_method: :check_for_full_http_link
     config.add_index_field "availability"
     config.add_index_field "purchase_order_availability", field: "purchase_order", if: false, helper_method: :render_purchase_order_availability, with_po_link: true

--- a/app/controllers/concerns/lc_classifications.rb
+++ b/app/controllers/concerns/lc_classifications.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module LCClassifications
+  extend ActiveSupport::Concern
+
+  def render_lc_call_number_on_index?
+    return true unless params.dig("range", "lc_classification", "begin").blank?
+    return true unless params.dig("range", "lc_classification", "end").blank?
+    return true unless params.dig("f", "lc_outer_facet").blank?
+    return true unless params.dig("f", "lc_inner_facet").blank?
+    return true if params.dig("sort").present? && params["sort"].include?("lc_call_number_sort")
+    false
+  end
+end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -147,12 +147,10 @@ module CatalogHelper
     end
   end
 
-  def render_lc_display_field(doc_presenter, field_config)
-    if (params["sort"]&.include?("lc_call_number_sort") || params["f"]&.include?("lc_outer_facet") || params["range"]&.include?("lc_classification"))
-      content_tag :dl, nil, class: "row document-metadata my-0 mr-5 blacklight-lc_call_number_display" do
-        html = content_tag :dt, "LC Classification:", class: "py-2 index-label col-sm-12 col-md-4 col-lg-3 blacklight-lc_call_number_display"
-        html += content_tag :dd, doc_presenter.field_value(field_config), class: "py-2 col-sm-12 col-md-5 col-lg-4 blacklight-lc_call_number_display mb-0"
-      end
+  def render_lc_display_field(field_presenter)
+    content_tag :dl, nil, class: "row document-metadata my-0 mr-5 blacklight-lc_call_number_display" do
+      html = content_tag :dt, "LC Classification:", class: "py-2 index-label col-sm-12 col-md-4 col-lg-3 blacklight-lc_call_number_display"
+      html += content_tag :dd, field_presenter.render, class: "py-2 col-sm-12 col-md-5 col-lg-4 blacklight-lc_call_number_display mb-0"
     end
   end
 

--- a/app/presenters/index_presenter.rb
+++ b/app/presenters/index_presenter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class IndexPresenter < Blacklight::IndexPresenter
+  def fields_to_render
+    return super unless block_given?
+    super do |field_name, field_config, field_presenter|
+      yield field_name, field_config, field_presenter unless field_name == "lc_call_number_display"
+    end
+  end
+
+  def lc_call_number_field_to_render
+    return unless fields["lc_call_number_display"] && block_given?
+    field_presenter = field_presenter(fields["lc_call_number_display"])
+    yield "lc_call_number_display", fields["lc_call_number_display"], field_presenter if field_presenter.render_field?
+  end
+end

--- a/app/presenters/primo_central_presenter.rb
+++ b/app/presenters/primo_central_presenter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PrimoCentralPresenter < Blacklight::IndexPresenter
+class PrimoCentralPresenter < IndexPresenter
   def label(field, opts = {})
     with_subtitle(document[:title]).html_safe
   end

--- a/app/views/catalog/_fields.html.erb
+++ b/app/views/catalog/_fields.html.erb
@@ -1,9 +1,7 @@
-
 <% doc_presenter = index_presenter(document) %>
 
 <dl class="row document-metadata mb-0 mr-5">
 <% doc_presenter.fields_to_render do |field_name, field_config, field_presenter| -%>
-  <% if field_presenter.render_field? && field_name != "lc_call_number_display" %>
     <% unless field_config[:no_label] %>
     <dt class="index-label col-sm-12 col-md-4 col-lg-3 blacklight-<%= field_name.parameterize %>"><%= field_presenter.label %>: </dt>
     <dd class="col-sm-12 col-md-5 col-lg-7 blacklight-<%= field_name.parameterize %>">
@@ -15,12 +13,10 @@
       <% end -%>
     </dd>
   <% end -%>
-<% end -%>
 </dl>
 
 <%= render_alma_availability(document) %>
-<% doc_presenter.fields_to_render do |field_name, field_config, field_presenter| -%>
-  <% if field_name == "lc_call_number_display" %>
-    <%= render_lc_display_field(doc_presenter, field_config) %>
-  <% end -%>
+
+<% doc_presenter.lc_call_number_field_to_render do |field_name, field_config, field_presenter| -%>
+  <%= render_lc_display_field(field_presenter) %>
 <% end -%>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -254,4 +254,28 @@ RSpec.describe CatalogController, type: :controller do
       expect(response).not_to render_template("catalog/_search_results")
     end
   end
+
+  describe "deciding to render or not to render lc classification fields on index" do
+    render_views
+
+    it "does not show the lc classification field by default" do
+      get :index, params: { q: "art" }
+      expect(response.body).not_to include "blacklight-lc_call_number_display"
+    end
+
+    it "shows the lc classification field when the lc range param is present" do
+      get :index, params: { q: "art" , range: { lc_classification: { begin: "A", end: "Z" } } }
+      expect(response.body).to include "blacklight-lc_call_number_display"
+    end
+
+    it "shows the lc classification field when the lc facet param is present" do
+      get :index, params: { q: "art" , f: { lc_outer_facet: ["N - Fine Arts"] } }
+      expect(response.body).to include "blacklight-lc_call_number_display"
+    end
+
+    it "shows the lc classification field when the lc sort param is present" do
+      get :index, params: { q: "art" , sort: { lc_call_number_sort: true } }
+      expect(response.body).to include "blacklight-lc_call_number_display"
+    end
+  end
 end


### PR DESCRIPTION
Repost of: https://github.com/tulibraries/tul_cob/pull/2304

- abstracted logic for displaying lc classification to a controller concern
- created a local IndexPresenter class to customize fields_to_render so we only have to iterate through field presenter creation one time.