### PR TITLE
Refactor lc_call_number_ender_on_index?

### DIFF
--- a/app/controllers/concerns/lc_classifications.rb
+++ b/app/controllers/concerns/lc_classifications.rb
@@ -8,6 +8,6 @@ module LCClassifications
       params.dig("range", "lc_classification", "end").present? ||
       params.dig("f", "lc_outer_facet").present? ||
       params.dig("f", "lc_inner_facet").present? ||
-      !!(params.dig("sort").&include?("lc_call_number_sort"))
+      !!(params.dig("sort")&.include?("lc_call_number_sort"))
   end
 end

--- a/app/controllers/concerns/lc_classifications.rb
+++ b/app/controllers/concerns/lc_classifications.rb
@@ -4,11 +4,10 @@ module LCClassifications
   extend ActiveSupport::Concern
 
   def render_lc_call_number_on_index?
-    return true unless params.dig("range", "lc_classification", "begin").blank?
-    return true unless params.dig("range", "lc_classification", "end").blank?
-    return true unless params.dig("f", "lc_outer_facet").blank?
-    return true unless params.dig("f", "lc_inner_facet").blank?
-    return true if params.dig("sort").present? && params["sort"].include?("lc_call_number_sort")
-    false
+    params.dig("range", "lc_classification", "begin").present? ||
+      params.dig("range", "lc_classification", "end").present? ||
+      params.dig("f", "lc_outer_facet").present? ||
+      params.dig("f", "lc_inner_facet").present? ||
+      !!(params.dig("sort").&include?("lc_call_number_sort"))
   end
 end


### PR DESCRIPTION
Refactor to use present and only no returns.