### PR TITLE
allow controller errors to raise by default in tests

### DIFF
--- a/spec/controllers/almaws_controller_spec.rb
+++ b/spec/controllers/almaws_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe AlmawsController, type: :controller do
         sign_in @user, scope: :user
       end
 
-      it "doesn't render the layout, even when there's an error" do
+      it "doesn't render the layout, even when there's an error", with_rescue: true do
         allow(Alma::BibItem).to receive(:find).and_raise("oof")
         get :item, params
         expect(response).not_to render_template("layouts/blacklight")
@@ -177,13 +177,13 @@ RSpec.describe AlmawsController, type: :controller do
         get(:request_options, params)
       end
 
-      it "sends a 502 error with a layout-less error message in the body" do
+      it "sends a 502 error with a layout-less error message in the body", with_rescue: true do
         expect(response).to have_http_status 502
         expect(response.body).to include "The item request service did not respond or encountered a problem"
         expect(response).not_to render_template("layouts/blacklight")
       end
 
-      it "forwards the alma error to honeybadger" do
+      it "forwards the alma error to honeybadger", with_rescue: true do
         expect(Honeybadger::Backend::Test.notifications[:notices].last.error_message).to eq(JSON.dump({ error: "phhhht" }))
       end
     end
@@ -383,7 +383,7 @@ RSpec.describe AlmawsController, type: :controller do
   describe "handling Alma::BibItemSet::ResponseError exceptions" do
     let(:params) { { params: { mms_id: "991026719119703811" } } }
 
-    it "renders the html response" do
+    it "renders the html response", with_rescue: true do
       allow(controller).to receive(:item) { raise Alma::BibItemSet::ResponseError.new("test") }
       get :item, params
       expect(response.body).to eq("<p class='m-2'>Please contact the library service desk for additional assistance.</p>")

--- a/spec/controllers/catalog_controller_errors_spec.rb
+++ b/spec/controllers/catalog_controller_errors_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe CatalogController, type: :controller do
     end
   end
 
-  it "handles its own errors gracefully" do
+  it "handles its own errors gracefully", with_rescue: true do
     get :test_basic_exception
     expect(response).to have_http_status 500
     expect(response.body).to include "We're sorry, but something went wrong"
   end
 
-  it "handles primo's errors  gracefully" do
+  it "handles primo's errors  gracefully", with_rescue: true do
     get :test_primo_error
     expect(response).to have_http_status 502
     expect(response.body).to include "We're sorry, but something went wrong"

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CatalogController, type: :controller do
 
     context "when the record is suppressed" do
       let(:document) { SolrDocument.new(id: doc_id, suppress_items_b: true) }
-      it "raises a record not found error if the record is suppressed" do
+      it "raises a record not found error if the record is suppressed", with_rescue: true do
         allow(search_service).to receive(:fetch).with(doc_id).and_return([mock_response, document])
         allow(controller).to receive(:search_service).and_return(search_service)
 

--- a/spec/controllers/primo_central_controller_spec.rb
+++ b/spec/controllers/primo_central_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe PrimoCentralController, type: :controller do
       expect(response).to be_successful
     end
 
-    it "handles a record not found exception" do
+    it "handles a record not found exception", with_rescue: true do
       allow(search_service).to receive(:fetch).and_raise(Primo::Search::ArticleNotFound, "glub glub glub")
       get :show, params: { id: 1 }
       expect(response.code).to eq "404"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -367,6 +367,11 @@ RSpec.configure do |config|
   require "warden"
   config.include Warden::Test::Helpers
 
+  config.before :each do |example|
+    if example.metadata[:type] == :controller
+      bypass_rescue unless example.metadata[:with_rescue]
+    end
+  end
 end
 
 VCR.configure do |config|


### PR DESCRIPTION
Adds an option to use `rescue_from` when testing controllers, and turns it off by default so ci failures will be more informative.