### PR TITLE
BL-1365 Digital help bug

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -214,8 +214,7 @@ module CatalogHelper
       .exclude?("Archival Material") &&
     document.fetch("format", [])
       .exclude?("Object") &&
-    !document["electronic_resource_display"] &&
-    !document["hathi_trust_bib_key_display"]
+    !document["electronic_resource_display"]
   end
 
   def open_shelves_allowed?(document)

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -743,15 +743,6 @@ RSpec.describe CatalogHelper, type: :helper do
         expect(digital_help_allowed?(document)).to be false
       end
     end
-    context "is a physical item with hathitrust link" do
-      let(:document) { {
-        "availability_facet" => "At the Library",
-        "hathi_trust_bib_key_display" => "foo"
-         } }
-      it "returns nil" do
-        expect(digital_help_allowed?(document)).to be false
-      end
-    end
   end
 
   describe "#open_shelves_allowed?(document)" do


### PR DESCRIPTION
- The original implementation excuded hathitrust items from the get help finding a digital copy method.  
- Now that we are open and not using hathitrust, we need to remove this exclusion so that the request panel displays.