### PR TITLE
Bl 1364 add email address

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,7 +2,12 @@
 
 class ErrorsController < ApplicationController
   def not_found
-    render(layout(status: 404, formats: :html))
+    respond_to do |format|
+      format.woff2 { render plain: "", status: 400, content_type: "text/plain" }
+      format.css { render plain: "", status: 400, content_type: "text/plain" }
+      format.js { render plain: "", status: 400, content_type: "text/plain" }
+      format.all { render(layout(status: 404, formats: :html)) }
+    end
   end
 
   def internal_server_error

--- a/app/models/concerns/blacklight/document/email.rb
+++ b/app/models/concerns/blacklight/document/email.rb
@@ -16,7 +16,11 @@ module Blacklight::Document::Email
         body << I18n.t(label, value: value.join("; ").gsub("|", "; "))
       end
     end
-    body << add_holdings_information
+    begin
+      body << add_holdings_information
+    rescue Alma::BibItemSet::ResponseError => exception
+      Honeybadger.notify(exception.message)
+    end
     return body.join("\n") unless body.empty?
   end
 

--- a/app/models/purchase_order_mailer.rb
+++ b/app/models/purchase_order_mailer.rb
@@ -13,7 +13,7 @@ class PurchaseOrderMailer < RecordMailer
     @message        = details[:message]
     @url_gen_params = url_gen_params
     @from           = details[:from]
-
-    mail(bcc: "orders@temple.edu", to: @from[:email], subject: subject)
+    @bcc            = Rails.configuration.email_groups["RAPID_REQUEST"]
+    mail(bcc: @bcc, to: @from[:email], subject: subject)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,7 @@ module Tulcob
     config.material_types = config_for(:material_types).with_indifferent_access
     config.alma = config_for(:alma).with_indifferent_access
     config.bento = config_for(:bento).with_indifferent_access
+    config.email_groups = config_for(:email_groups).with_indifferent_access
     config.oclc = config_for(:oclc).with_indifferent_access
     config.lib_guides = config_for(:lib_guides).with_indifferent_access
     config.devise = config_for(:devise).with_indifferent_access

--- a/config/email_groups.yml
+++ b/config/email_groups.yml
@@ -1,0 +1,16 @@
+default: &default
+
+test:
+  <<: *default
+
+development:
+  <<: *default
+  RAPID_REQUEST:
+    - librarystaff1@mailinator.com
+    - librarystaff2@mailinator.com
+
+production:
+  <<: *default
+  RAPID_REQUEST:
+    - orders@temple.edu
+    - brian@temple.edu


### PR DESCRIPTION
Pulls the rapid request email addressee into a config file.
Also wraps a line in the mail constructor in a begin / rescue to protect against errors arising in the alma gem when the item has no holdings.
Unrelated change to prevent serving an html page for missing asset files.