### PR TITLE
BL-1365 Digital copy bug

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -214,7 +214,8 @@ module CatalogHelper
       .exclude?("Archival Material") &&
     document.fetch("format", [])
       .exclude?("Object") &&
-    !document["electronic_resource_display"]
+    !document["electronic_resource_display"] &&
+    !hathitrust_link_allowed?(document)
   end
 
   def open_shelves_allowed?(document)
@@ -245,13 +246,18 @@ module CatalogHelper
     render "hathitrust_link", ht_bib_key_field: ht_bib_key_field
   end
 
+  def hathitrust_link_allowed?(document)
+    ht_bib_key_field = document.fetch("hathi_trust_bib_key_display", []).first rescue nil
+    ht_bib_key_field.fetch("access", "deny") == "allow" rescue nil
+  end
+
   def render_hathitrust_display(document)
     ht_bib_key_field = document.fetch("hathi_trust_bib_key_display", []).first rescue nil
     return if ht_bib_key_field.nil?
     online_resources = []
     online_resources << render_hathitrust_link(ht_bib_key_field)
 
-    if (campus_closed? || ht_bib_key_field.fetch("access", "deny") == "allow")
+    if (campus_closed? || hathitrust_link_allowed?(document))
       render "online_availability", online_resources: online_resources
     end
   end
@@ -261,7 +267,7 @@ module CatalogHelper
     return if ht_bib_key_field.nil?
     link = render_hathitrust_link(ht_bib_key_field)
 
-    if (campus_closed? || ht_bib_key_field.fetch("access", "deny") == "allow")
+    if (campus_closed? || hathitrust_link_allowed?(document))
       render "hathitrust_button", document: document, links: link
     end
   end

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -728,12 +728,27 @@ RSpec.describe CatalogHelper, type: :helper do
         expect(digital_help_allowed?(document)).to be true
       end
     end
+    context "is a physical item with hathitrust access denied" do
+      let(:document) { {
+         "availability_facet" => "At the Library",
+         "hathi_trust_bib_key_display" => "foo"
+          } }
+      it "returns true" do
+        expect(digital_help_allowed?(document)).to be true
+      end
+    end
     context "is an object" do
       let(:document) { { "format" => "Object" } }
       it "returns false" do
         expect(digital_help_allowed?(document)).to be false
       end
     end
+    context "has a hathitrust link" do
+      let(:document) { { "hathi_trust_bib_key_display" => [ { "bib_key" => "000005117", "access" => "allow" } ].first } }
+       it "returns false" do
+         expect(digital_help_allowed?(document)).to be false
+       end
+     end
     context "is a physical item and an online item" do
       let(:document) { {
         "availability_facet" => "At the Library",
@@ -838,6 +853,26 @@ RSpec.describe CatalogHelper, type: :helper do
 
     it "returns a correctly formed url" do
       expect(constructed_url).to eq base_url
+    end
+  end
+
+  describe "#hathitrust_link_allowed?(document))" do
+    context "record has a hathi_trust_bib_key_display field" do
+      context "with allow access" do
+        let(:document) { { "hathi_trust_bib_key_display" => [ { "bib_key" => "000005117", "access" => "allow" } ] } }
+
+        it "returns true" do
+          expect(hathitrust_link_allowed?(document)).to be(true)
+        end
+      end
+
+      context "with deny access" do
+        let(:document) { { "hathi_trust_bib_key_display" => [ { "bib_key" => "000005117", "access" => "deny" }] } }
+
+        it "does not render the online partial" do
+          expect(hathitrust_link_allowed?(document)).to be(false)
+        end
+      end
     end
   end
 

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -744,7 +744,7 @@ RSpec.describe CatalogHelper, type: :helper do
       end
     end
     context "has a hathitrust link" do
-      let(:document) { { "hathi_trust_bib_key_display" => [ { "bib_key" => "000005117", "access" => "allow" } ].first } }
+       let(:document) { { "hathi_trust_bib_key_display" => [ { "bib_key" => "000005117", "access" => "allow" } ].first } }
        it "returns false" do
          expect(digital_help_allowed?(document)).to be false
        end


### PR DESCRIPTION
- We still provide hathitrust links for open source materials, so they should not display the "get help finding a digital copy" tab