### PR TITLE
Set rack-mini-profiler to require: false in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ group :development, :test do
   gem "launchy"
   gem "foreman"
   gem "vcr"
-  gem "rack-mini-profiler"
+  gem "rack-mini-profiler", require: false
   gem "rails-controller-testing"
   gem "rubocop"
   gem "rubocop-rails"


### PR DESCRIPTION
- The omniauth security update is throwing this error: RuntimeError:
  MiniProfilerRails initialized twice. Set `require: false' for rack-mini-profiler in your Gemfile