### PR TITLE
set permissions on docker host socket so osx can run circlci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,10 +55,12 @@ jobs:
             - gem-cache-v6-{{ arch }}
             - yarn-cache-v6-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
 
-      
+
       - setup_remote_docker:
           docker_layer_caching: false
           version: 19.03.13
+
+      - run: if [ -e /var/run/docker.sock ]; then sudo chown circleci:circleci /var/run/docker.sock; fi
 
       - run:
           name: Build app
@@ -75,7 +77,7 @@ jobs:
       - run:
           name: Copy the vendor/bundle from the container to local
           command: make ci-copy-bundle-files-to-local
-      
+
       - run:
           name: Copy the node_modules from the container to local
           command: make ci-copy-node-modules-to-local
@@ -84,7 +86,7 @@ jobs:
           key: gem-cache-v6-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
               - vendor/bundle
-      - save_cache:    
+      - save_cache:
           key: yarn-cache-v6-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
               - node_modules


### PR DESCRIPTION
Presuming this doesn't break the actual CircleCI build, this change should enable CI jobs to run locally on OSX - example:

`circleci local execute --job run_tests`
