### PR TITLE
BL-1418: Fix advanced search different than basic search.

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -137,7 +137,11 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   def add_lc_range_search_to_solr(solr_params)
     return unless blacklight_params["range"] && blacklight_params["range"]["lc_classification"]
+
     lc_range = blacklight_params["range"]["lc_classification"]
+
+    return if lc_range["begin"].blank? && lc_range["end"].blank?
+
     _begin = lc_range["begin"].blank? ? "*" : LcSolrSortable.convert(lc_range["begin"])
     _end = lc_range["end"].blank? ? "*" : LcSolrSortable.convert(lc_range["end"])
     solr_params[:fq] << "lc_call_number_sort: [#{_begin} TO #{_end}]"

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -356,5 +356,30 @@ RSpec.describe SearchBuilder , type: :model do
       expect(subject.to_h["fq"]).to include("pub_date_sort: [1900 TO 1950]")
       expect(subject.to_h["fq"]).to include("lc_call_number_sort: [Zaaaaaaaaa TO Zkaaaaaaaa]")
     end
+
+    it "skips when empty lc classification range" do
+      params = ActionController::Parameters.new(
+        f: {
+          unknown_facet_field: "foo",
+          format: "bar",
+          lc_outer_facet: ""
+        },
+        range: {
+          lc_classification: {
+            begin: "",
+            end: ""
+          },
+          pub_date_sort: {
+            begin: "1900",
+            end: "1950"
+          }
+        })
+      builder = subject.with(params)
+      has_lc_call_number_sort_field = subject.to_h["fq"].any? { |f| f.match(/lc_call_number_sort/) }
+      expect(has_lc_call_number_sort_field).to be(false)
+    end
   end
+
+
+
 end


### PR DESCRIPTION
Skips providing a defaut lc range when no range was given for both
begining and end of range.