### PR TITLE
BL-1438: Make manifold alerts more robust.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,8 @@
 class SessionsController < Devise::SessionsController
   include Sessions::SocialLogin
 
+  before_action :get_manifold_alerts, only: [ :new ]
+
   layout proc { |controller| false if request.xhr? }
 
   # Overrides Devise::SessionsController#new.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -231,10 +231,8 @@ module ApplicationHelper
   end
 
   def manifold_alerts
-    alert_url = "https://library.temple.edu/alerts.json"
-    alert = HTTParty.get(alert_url, timeout: 2)
-
-    alert["data"].select { |a| a if a.dig("attributes", "for_header") == false }
+    # @manifold_alerts_thread is set in the application controller via a before_action.
+    @manifold_alerts_thread.value.select { |a| a if a.dig("attributes", "for_header") == false }
   end
 
   def emergency_alert_message

--- a/spec/controllers/catalog_controller_errors_spec.rb
+++ b/spec/controllers/catalog_controller_errors_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe CatalogController, type: :controller do
   end
 
   before :each do
+    controller.get_manifold_alerts
+
     routes.draw do
       get "test_basic_exception" => "catalog#test_basic_exception"
       get "test_primo_error" => "catalog#test_primo_error"

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -278,4 +278,20 @@ RSpec.describe CatalogController, type: :controller do
       expect(response.body).to include "blacklight-lc_call_number_display"
     end
   end
+
+  describe "before_action get_manifold_alerts" do
+    context ":show action" do
+      it "sets @manifold_alerts_thread" do
+        get :show, params: { id: doc_id }
+        expect(controller.instance_variable_get("@manifold_alerts_thread")).to be_kind_of(Thread)
+      end
+    end
+
+    context ":index action" do
+      it "sets @manifold_alerts_thread" do
+        get :index, params: { q: "art" }
+        expect(controller.instance_variable_get("@manifold_alerts_thread")).to be_kind_of(Thread)
+      end
+    end
+  end
 end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -18,4 +18,20 @@ RSpec.describe ErrorsController, type: :controller do
     expect(response).to have_http_status 500
     expect(response.body).to include "DOCTYPE html"
   end
+
+  describe "before_action get_manifold_alerts" do
+    context ":internal_server_error" do
+      it "sets @manifold_alerts_thread" do
+        get :internal_server_error
+        expect(controller.instance_variable_get("@manifold_alerts_thread")).to be_kind_of(Thread)
+      end
+    end
+
+    context ":not_found" do
+      it "sets @manifold_alerts_thread" do
+        get :not_found
+        expect(controller.instance_variable_get("@manifold_alerts_thread")).to be_kind_of(Thread)
+      end
+    end
+  end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -25,4 +25,13 @@ RSpec.describe SessionsController, type: :controller do
       expect(response.headers["Pragma"]).to be_nil
     end
   end
+
+  describe "before_action get_manifold_alerts" do
+    context ":new action" do
+      it "sets @manifold_alerts_thread" do
+        get :new
+        expect(controller.instance_variable_get("@manifold_alerts_thread")).to be_kind_of(Thread)
+      end
+    end
+  end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -87,7 +87,15 @@ RSpec.describe UsersController, type: :controller do
           expect(response.headers["Pragma"]).to eq("no-cache")
           expect(response.headers["Expires"]).to eq("Fri, 01 Jan 1990 00:00:00 GMT")
         end
+
+        describe "before_action get_manifold_alerts" do
+          it "sets @manifold_alerts_thread" do
+            get :account
+            expect(controller.instance_variable_get("@manifold_alerts_thread")).to be_kind_of(Thread)
+          end
+        end
       end
+
     end
 
     context "User has no transactions" do
@@ -123,4 +131,5 @@ RSpec.describe UsersController, type: :controller do
       expect(response).to have_http_status(:success)
     end
   end
+
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe "#emergency_alert_message" do
     context "for_header is false" do
       it "does return the scroll_text" do
+        helper.instance_variable_set("@manifold_alerts_thread", get_manifold_alerts)
         expect(helper.emergency_alert_message).to eq("Test banner message")
       end
     end
@@ -175,8 +176,31 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe "#emergency_alert_link" do
     context "link field is present" do
       it "does return the link" do
+        helper.instance_variable_set("@manifold_alerts_thread", get_manifold_alerts)
         expect(helper.emergency_alert_link).to have_text("Click here to see full details.")
       end
     end
+  end
+
+  describe "#manifold_alerts" do
+    context "[] value" do
+      it "returns empty array []" do
+        helper.instance_variable_set("@manifold_alerts_thread", Thread.new { [] })
+        expect(helper.manifold_alerts).to eq([])
+      end
+    end
+
+    context "spec/fixtures/emergency_alert.json" do
+      it "filters out for_header alerts" do
+        helper.instance_variable_set("@manifold_alerts_thread", get_manifold_alerts)
+
+        expect(helper.manifold_alerts.count).to eq(1)
+        expect(helper.manifold_alerts.first.dig("attributes", "for_header")).to eq(false)
+      end
+    end
+  end
+
+  def get_manifold_alerts
+    ApplicationController.new.get_manifold_alerts
   end
 end


### PR DESCRIPTION
* Add threading for concurrent http calls.
* Add caching to avoid making expensive HTTP calls.
* Add default behavior when network times out.
* Reduce network timeout to 1 second (should always be less than 1 second)