### PR TITLE
BL-1435 Remove subfield i from links

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -181,9 +181,9 @@ class CatalogController < ApplicationController
 
     config.add_show_field "title_statement_vern_display", label: "Title Statement", type: :primary
     config.add_show_field "url_finding_aid_display", label: "Finding Aid", helper_method: :check_for_full_http_link, type: :primary
-    config.add_show_field "title_uniform_display", label: "Uniform title", helper_method: :list_with_links, type: :primary
+    config.add_show_field "title_uniform_display", label: "Uniform title", helper_method: :additional_title_link, type: :primary
     config.add_show_field "title_uniform_vern_display", label: "Uniform title", type: :primary
-    config.add_show_field "title_addl_display", label: "Additional titles", helper_method: :list_with_links, type: :primary
+    config.add_show_field "title_addl_display", label: "Additional titles", helper_method: :additional_title_link, type: :primary
     config.add_show_field "title_addl_vern_display", label: "Additional titles", type: :primary
     config.add_show_field "creator_display", label: "Author/Creator", helper_method: :browse_creator, multi: true, type: :primary
     config.add_show_field "creator_vern_display", label: "Author/Creator", helper_method: :browse_creator, type: :primary

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -369,6 +369,27 @@ module CatalogHelper
     args[:document][args[:field]].map { |field| content_tag(:li,  fielded_search(field, args[:field]), class: "list_items") }.join("").html_safe
   end
 
+  def additional_title_link(args)
+    title = args[:document][args[:field]]
+
+    title.map do |title_data|
+      begin
+        title_data = JSON.parse(title_data)
+        linked_subfields = title_data["title"]
+        relation_to_work_prefix = title_data["relation"]
+      end
+      link = fielded_search(linked_subfields, args[:field])
+
+      content_tag(:li, class: "list_items") do
+        if relation_to_work_prefix.present?
+          link.prepend("#{relation_to_work_prefix} ")
+        else
+          link
+        end
+      end
+    end
+  end
+
   def creator_index_separator(args)
     creator = args[:document][args[:field]]
     creator.map do |name|

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "RecordPageFields" do
       scenario "User visits a document with field 730 only" do
         visit "catalog/#{item_730['doc_id']}"
         within "dd.blacklight-title_uniform_display" do
-          expect(page).to have_text(item_730["title_uniform"])
+          expect(page).to have_text("Subfield I.")
           expect(page).to have_link(item_730["title_uniform"])
         end
       end
@@ -103,7 +103,7 @@ RSpec.feature "RecordPageFields" do
     scenario "User visits a document with additional title " do
       visit "catalog/#{item_246['doc_id']}"
       within "dd.blacklight-title_addl_display" do
-        expect(page).to have_text(item_246["title_addl"])
+        expect(page).to have_text("Subfield I")
         expect(page).to have_link(item_246["title_addl"])
       end
     end

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -23,14 +23,14 @@ title_uniform_240:
   title_uniform: "Dictionary of American history: 240. Subfield D. Subfield F. Subfield K. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield R. Subfield S."
 title_uniform_730:
   doc_id: "991012132499760612"
-  title_uniform: "Dictionary of American history: 730. Subfield I. Subfield L."
+  title_uniform: "Dictionary of American history: 730. Subfield L."
 title_addl_210:
   doc_id: "991012132499760613"
   title_addl: "Dictionary of American history: 210. Subfield B."
   title_addl_vern: "Title Additional Vern."
 title_addl_246:
   doc_id: "991012132499760614"
-  title_addl: "Subfield I. Dictionary of American history: 246. Subfield B. Subfield F. Subfield G. Subfield N. Subfield P."
+  title_addl: "Dictionary of American history: 246. Subfield B. Subfield F. Subfield G. Subfield N. Subfield P."
 title_addl_247:
   doc_id: "991012132499760615"
   title_addl: "Dictionary of American history: 247. Subfield B. Subfield C. Subfield D. Subfield E. Subfield F. Subfield G. Subfield N. Subfield P."


### PR DESCRIPTION
- Subfield i should be displayed as plain text and not be included as part of the link for the title_uniform and title_addl display fields
- This is the front end part of this work, but it relies on a full reindex before it will display correctly on QA