### PR TITLE
BL-1358: Prevents the blacklight_range_gem from making efficient queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "blacklight", "~> 7.15.2"
 gem "blacklight_advanced_search", git: "https://github.com/projectblacklight/blacklight_advanced_search.git"
 gem "blacklight-marc"
-gem "blacklight_range_limit", git: "https://github.com/dkinzer/blacklight_range_limit.git", branch: "issue-168-use-blackligh-config-for-constraints"
+gem "blacklight_range_limit", git: "https://github.com/tulibraries/blacklight_range_limit.git", branch: "bl-1431-bl-1358"
 
 group :development, :test do
   gem "byebug", platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/dkinzer/blacklight_range_limit.git
-  revision: 202a837311fa7f33b3fe64512a486453fc92232d
-  branch: issue-168-use-blackligh-config-for-constraints
-  specs:
-    blacklight_range_limit (8.0.0)
-      blacklight (~> 7.0)
-
-GIT
   remote: https://github.com/heartcombo/devise.git
   revision: e16d60d0fedc5f5e6f541b2b9e901a2d53f8ceda
   branch: ca-omniauth-2
@@ -47,6 +39,14 @@ GIT
       ezwadl (= 0.0.1)
       jwt (= 1.5.6)
       rails (>= 4.2, < 6)
+
+GIT
+  remote: https://github.com/tulibraries/blacklight_range_limit.git
+  revision: 7552146fc2f61dc8750f8c9a6c54217530d48bac
+  branch: bl-1431-bl-1358
+  specs:
+    blacklight_range_limit (8.0.0)
+      blacklight (~> 7.0)
 
 GIT
   remote: https://github.com/tulibraries/cdm_rb.git
@@ -359,7 +359,7 @@ GEM
     mysql2 (0.5.3)
     nenv (0.3.0)
     nio4r (2.5.7)
-    nokogiri (1.11.5)
+    nokogiri (1.11.6)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -571,7 +571,7 @@ GEM
     unf_ext (0.0.7.7)
     unicode-display_width (2.0.0)
     vcr (6.0.0)
-    view_component (2.28.0)
+    view_component (2.32.0)
       activesupport (>= 5.0.0, < 7.0)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -589,7 +589,7 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xml-simple (1.1.8)


### PR DESCRIPTION
Updates blacklight_range_limit_gem in order to prevent it from making
inefficient queries.

REF: projectblacklight/blacklight_range_limit#170