### PR TITLE
BL-1424: Do not propagate URL params in bento links.

### DIFF
--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -57,7 +57,7 @@ module BentoSearch
     end
 
     def url(helper)
-      params = helper.params.except(:action, :controller)
+      params = helper.params.slice(:q)
       helper.search_catalog_path(params)
     end
 

--- a/app/search_engines/bento_search/databases_engine.rb
+++ b/app/search_engines/bento_search/databases_engine.rb
@@ -9,7 +9,7 @@ module BentoSearch
     end
 
     def url(helper)
-      params = helper.params.except(:action, :controller)
+      params = helper.params.slice(:q)
       helper.search_databases_path(params)
     end
 

--- a/app/search_engines/bento_search/journals_engine.rb
+++ b/app/search_engines/bento_search/journals_engine.rb
@@ -9,7 +9,7 @@ module BentoSearch
     end
 
     def url(helper)
-      params = helper.params.except(:action, :controller)
+      params = helper.params.slice(:q)
       helper.search_journals_path(params)
     end
 

--- a/app/search_engines/bento_search/primo_engine.rb
+++ b/app/search_engines/bento_search/primo_engine.rb
@@ -30,7 +30,7 @@ module BentoSearch
     end
 
     def url(helper)
-      params = helper.params
+      params = helper.params.slice(:q)
         .merge(action: :index, controller: :primo_central)
       helper.url_for(params)
     end

--- a/app/search_engines/bento_search/web_content_engine.rb
+++ b/app/search_engines/bento_search/web_content_engine.rb
@@ -18,7 +18,7 @@ module BentoSearch
     end
 
     def url(helper)
-      params = helper.params.except(:action, :controller)
+      params = helper.params.except(:q)
       helper.search_web_content_path(params)
     end
 


### PR DESCRIPTION
Prevents params from being propagated via bento_links.