### PR TITLE
BL-1540: Fix lc_classification constraint broken

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -163,6 +163,7 @@ class CatalogController < ApplicationController
     config.add_facet_field "location_facet", show: false
     config.add_facet_field "lc_inner_facet", show: false
     config.add_facet_field "lc_outer_facet", show: false
+    config.add_facet_field "lc_classification", show: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -145,6 +145,9 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def add_lc_range_search_to_solr(solr_params)
+    # Solr throws exceptions when trying to facet unnknown fields.
+    solr_params["facet.field"].delete("lc_classification")
+
     return unless blacklight_params["range"] && blacklight_params["range"]["lc_classification"]
 
     lc_range = blacklight_params["range"]["lc_classification"]

--- a/spec/features/call_number_facet_spec.rb
+++ b/spec/features/call_number_facet_spec.rb
@@ -16,5 +16,14 @@ RSpec.feature "Call Number Facet" do
         expect(page.all(".filter .constraint-value .filterValue").last).to have_text("G - Geography, Anthropology, Recreation | GF - Human Ecology, Anthropogeography")
       end
     end
+
+    context "Advanced Search Library Of Congress Classification Range search." do
+      let(:path) { "http://localhost:3000/catalog?utf8=%E2%9C%93&f_1=all_fields&operator%5Bq_1%5D=contains&q_1=test&op_1=AND&f_2=all_fields&operator%5Bq_2%5D=contains&q_2=&op_2=AND&f_3=all_fields&operator%5Bq_3%5D=contains&q_3=&range%5Bpub_date_sort%5D%5Bbegin%5D=&range%5Bpub_date_sort%5D%5Bend%5D=&range%5Blc_classification%5D%5Bbegin%5D=NA&range%5Blc_classification%5D%5Bend%5D=NB&sort=score+desc%2C+pub_date_sort+desc%2C+title_sort+asc&search_field=advanced&commit=Search" }
+
+      it "should add the lc classification constraints" do
+        expect(page).to have_css(".constraint-value", text: "Library of Congress Classification")
+        expect(page).to have_css(".constraint-value", text: "NA to NB")
+      end
+    end
   end
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe SearchBuilder , type: :model do
             end: "1950"
           }
         })
-      builder = subject.with(params)
+      subject.with(params)
       expect(subject.to_h["fq"]).to include("pub_date_sort: [1900 TO 1950]")
       expect(subject.to_h["fq"]).to include("lc_call_number_sort: [Zaaaaaaaaa TO Zkaaaaaaaa]")
     end
@@ -399,9 +399,14 @@ RSpec.describe SearchBuilder , type: :model do
             end: "1950"
           }
         })
-      builder = subject.with(params)
+      subject.with(params)
       has_lc_call_number_sort_field = subject.to_h["fq"].any? { |f| f.match(/lc_call_number_sort/) }
       expect(has_lc_call_number_sort_field).to be(false)
+    end
+
+    it "removes lc_classification from solr_params[facet.field]" do
+      subject.with({})
+      expect(subject["facet.field"]).not_to include("lc_classification")
     end
   end
 


### PR DESCRIPTION
A bug in the blacklight_range_limit gem was allowing the
lc_classification facet constraint to show up even though it wasn't being
configured as a facet field in the controller.

When this bug was fixed it caused the lc_classification constraint to
disappear.

This commit configures the lc_classification constraint but then removes
it from the search so that Solr does not throw an error since
"lc_classification" is not a field that our Solr config knows about.

This commit also adds a feature test for these constraint to avoid
a regression bug.