### PR TITLE
Experiment with hidden headings

### DIFF
--- a/app/javascript/packs/controllers/query_list_controller.js
+++ b/app/javascript/packs/controllers/query_list_controller.js
@@ -16,6 +16,8 @@ import { Controller } from "stimulus"
       .then(response => response.text())
       .then(html => {
         this.resultsTarget.innerHTML = html
+        $(".query-heading").removeClass("hidden");
+        $(".query-feedback").removeClass("hidden");
       })
   }
 }

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -20,8 +20,8 @@
   </div>
 </div>
 
-<h3 class="query-heading">Related items</h3>
-<div class="query-feedback pt-1">
+<h3 class="query-heading hidden">Related items</h3>
+<div class="query-feedback pt-1 hidden">
   <p><%= t("query_list.query_feedback_html", href: link_to(t("query_list.query_feedback_href"), t("query_list.query_feedback_link"), target: "_blank")) %></p>
 </div>
 <%= render "record_page_query_lists", :document => document %>


### PR DESCRIPTION
Hide Related items heading info until we know there are actually related items.  This also removes it from non-catalog pages