### PR TITLE
DEVO-296 Deprecation warnings part 2

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,21 +39,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  ##
-  # Overrides Blacklight::BlacklightHelperBehavior::should_show_spellcheck_suggestions?.
-  #
-  # Overridden because the spelling field is not always available.
-  #
-  # @see: https://github.com/projectblacklight/blacklight/pull/1845
-  #
-  # @param [Blacklight::Solr::Response] response
-  # @return [Boolean]
-  def should_show_spellcheck_suggestions?(response)
-    response.total <= spell_check_max &&
-      !response.spelling.nil? &&
-      response.spelling.words.any?
-  end
-
   def redirect_to_referer
     flash[:notice] = "Your search results page had to be reloaded. Please try again."
     redirect_to request.referer

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -25,6 +25,6 @@ module BlacklightHelper
               field_or_opts
     end
 
-    link_to label, url_for_document(doc), document_link_params(doc, opts)
+    link_to label, search_state.url_for_document(doc), document_link_params(doc, opts)
   end
 end

--- a/app/presenters/classification_field_presenter.rb
+++ b/app/presenters/classification_field_presenter.rb
@@ -2,8 +2,8 @@
 
 class ClassificationFieldPresenter < PivotFacetFieldPresenter
   def active?
-    lc_begin = search_state.dig("range", "lc_classification", "begin")
-    lc_end = search_state.dig("range", "lc_classification", "end")
+    lc_begin = search_state.to_h.dig("range", "lc_classification", "begin")
+    lc_end = search_state.to_h.dig("range", "lc_classification", "end")
 
     lc_begin.present? || lc_end.present? || super
   end

--- a/app/presenters/facet_item_presenter.rb
+++ b/app/presenters/facet_item_presenter.rb
@@ -14,7 +14,7 @@ class FacetItemPresenter < Blacklight::FacetItemPresenter
 
   def has_selected_child?
     return false if facet_item.is_a?(String) || @parent_facet_item || facet_config.pivot.nil?
-    items && items.size > 0 && items.any? { |item| search_state.filter_params[item.field] && search_state.filter_params[item.field].include?(item.value) }
+    items && items.size > 0 && items.any? { |item| search_state.filter([item.field]) && search_state&.filter(item.field).include?(item.value) }
   end
 
   def remove_href(path = search_state)
@@ -49,7 +49,7 @@ class FacetItemPresenter < Blacklight::FacetItemPresenter
     return true if super
     if facet_config.pivot
       field = facet_item.respond_to?(:field) ? facet_item.field : facet_field
-      return search_state.has_facet? view_context.facet_configuration_for_field(field), value: value
+      return search_state&.filter(field).include?(value)
     end
     return false
   end

--- a/app/presenters/facet_item_presenter.rb
+++ b/app/presenters/facet_item_presenter.rb
@@ -23,7 +23,7 @@ class FacetItemPresenter < Blacklight::FacetItemPresenter
       path_hash["f"]&.delete(items[0].field)
       search_path(path_hash)
     else
-      path_hash = path.remove_facet_params(facet_config.key, facet_item)
+      path_hash = path.filter(facet_config.key).remove(facet_item)
       if @parent_facet_item && path_hash.dig("f", @parent_facet_item.field)
         path_hash["f"][@parent_facet_item.field] = path_hash["f"][@parent_facet_item.field].reject { |value|
           value == @parent_facet_item.value


### PR DESCRIPTION
- Removes spellcheck method we are no longer using
- Updates facet_item presenter - this one fixes hundreds of dep. warnings but needs to be tested thoroughly to make sure it is still working as expected
- Adds search state to url_for method