### PR TITLE
DEVO-396 Fix deprecation warnings part 3

### DIFF
--- a/app/assets/stylesheets/partials/_record_pages.scss
+++ b/app/assets/stylesheets/partials/_record_pages.scss
@@ -80,3 +80,12 @@ dd.blacklight-format {
 a.search-subject:visited  {
   text-decoration: none
 }
+
+.pagination-search-widgets {
+  align-self: center;
+  margin-left: auto;
+
+  @media(max-width: 768px) {
+    padding-bottom: 1rem;
+  }
+}

--- a/app/helpers/render_constraints_helper.rb
+++ b/app/helpers/render_constraints_helper.rb
@@ -33,7 +33,7 @@ module RenderConstraintsHelper
       # Hide library_facet if matching location facet already selected.
       hidden_class = []
       if facet == "library_facet" &&
-          search_state.dig(:f, :location_facet)&.any? { |l| l.match?(/#{val}/) }
+          search_state.to_h.dig(:f, :location_facet)&.any? { |l| l.match?(/#{val}/) }
         hidden_class << "hidden"
       end
 

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -6,15 +6,9 @@
       <%= link_to t("blacklight.search.start_over"), bento_search_engine_path, id: "start_over", class: "btn bg-dark-blue text-white" %>
     </div>
   <% end %>
-  <div class="pagination-search-widgets ml-auto align-self-center pb-md-3">
-  <% if @search_context[:prev] || @search_context[:next] %>
-    <div class="page-links">
-      <%= link_to_previous_document @search_context[:prev] %> |
-      <%= item_page_entry_info %> |
-      <%= link_to_next_document @search_context[:next] %>
-    </div>
-  <% end %>
-  </div>
+  
+  <%= render(Blacklight::SearchContextComponent.new(search_context: @search_context, search_session: search_session)) %>
+
   <div id="nav-tools" class="nav-tools pr-4">
     <%= render partial: "show_tools_navbar" %>
   </div>

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -1,5 +1,5 @@
 
-<% doc_presenter = show_presenter(document) %>
+<% doc_presenter = document_presenter(document) %>
 
 <%# partial to display availability details in catalog show view -%>
 

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -1,4 +1,4 @@
-<% doc_presenter = show_presenter(document) %>
+<% doc_presenter = document_presenter(document) %>
 <%# default partial to display solr document fields in catalog show view %>
 <div class="record-page-wrapper clearfix">
   <% unless controller_name == "databases" %>

--- a/app/views/catalog/_show_primary_fields.html.erb
+++ b/app/views/catalog/_show_primary_fields.html.erb
@@ -1,4 +1,4 @@
-<% doc_presenter = show_presenter(document) %>
+<% doc_presenter = document_presenter(document) %>
 <dl class="row document-metadata mb-0 show-page-list mb-3">
   <% doc_presenter.each_primary_field do |field_name, field, field_presenter| %>
     <%= render "show_fields", document: document, field: field, field_name: field_name, field_presenter: field_presenter %>

--- a/app/views/catalog/_show_secondary_fields.html.erb
+++ b/app/views/catalog/_show_secondary_fields.html.erb
@@ -1,4 +1,4 @@
-<% doc_presenter = show_presenter(document) %>
+<% doc_presenter = document_presenter(document) %>
 <div class="no-gutters pl-1 secondary-fields-header mt-4">
   <h2>Details</h2>
   <hr />

--- a/spec/controllers/lib_guides_controller_spec.rb
+++ b/spec/controllers/lib_guides_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe LibGuidesController do
 
       get :index, params: { q: "query terms" }
 
-      expect(response).to be_success
+      expect(response).to be_successful
       expect(controller.instance_variable_get(:@guides)).to eq([
         { "name" => "Guide 1", "url" => "https://example.com/1" },
         { "name" => "Guide 2", "url" => "https://example.com/2" }

--- a/spec/views/catalog/_show_availability_section.html.erb_spec.rb
+++ b/spec/views/catalog/_show_availability_section.html.erb_spec.rb
@@ -8,16 +8,16 @@ RSpec.describe "catalog/_show_availability_section.html.erb", type: :view do
   include CatalogHelper
 
   let(:user_signed_in?) { false }
-  let(:config) { Blacklight::Configuration.new }
 
   before(:each) do
-    config.show.document_presenter_class = ShowPresenter
+    allow(controller).to receive(:action_name).and_return("show")
+    @config = Blacklight::Configuration.new {}
 
     allow(view).to receive(:user_signed_in?) { user_signed_in? }
     allow(view).to receive(:item_url).and_return "https://example.com/foo"
 
     without_partial_double_verification do
-      allow(view).to receive(:blacklight_config).and_return config
+      allow(view).to receive(:blacklight_config).and_return(@config)
     end
   end
 

--- a/spec/views/catalog/_show_default.html.erb._spec.rb
+++ b/spec/views/catalog/_show_default.html.erb._spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "catalog/_show_default.html.erb", type: :view do
   before(:each) do
     allow(controller).to receive(:action_name).and_return("show")
     @config = Blacklight::Configuration.new {}
-    @config.show.document_presenter_class = ShowPresenter
     @context = Blacklight::Configuration::Context.new(controller)
     @document = SolrDocument.new(id: 1)
     @document[:format] = []
@@ -20,6 +19,8 @@ RSpec.describe "catalog/_show_default.html.erb", type: :view do
       allow(view).to receive(:staff_view_path).and_return("/catalog/1/staff_view")
     end
     stub_template "catalog/_show_availability_section.html.erb" => ""
+    stub_template "catalog/_show_primary_fields.html.erb" => ""
+    stub_template "catalog/_show_secondary_fields.html.erb" => ""
     stub_template "catalog/_aeon_request.html.erb" => ""
     @rendered = view.render_document_partial @document, :show
   end


### PR DESCRIPTION
- Use to_h instead of dig drectly on search_state
- Use search context component
- Use document presenter instead of show presenter
- Use successful instead of success