### PR TITLE
BL-1557 Make Ambler items unavailable

### DIFF
--- a/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
+++ b/app/assets/javascripts/blacklight_alma/blacklight_alma_lib.js
@@ -21,7 +21,11 @@ var BlacklightAlma = function (options) {
  availabilityButton = function(id, holding) {
    var availButton = $("button[data-availability-ids='" + id + "']");
    if (!$(availButton).hasClass("btn-success")) {
-     if (holding['availability'] == 'available') {
+
+     if (holding['library_code'] == 'AMBLER') {
+       unavailableItems(id);
+     }
+     else if (holding['availability'] == 'available') {
        $(availButton).html("<span class='avail-label available'>Available</span>");
        $(availButton).removeClass("btn-default");
        $(availButton).addClass("btn-success collapsed collapse-button available availability-btn");

--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -7,12 +7,15 @@ module AvailabilityHelper
   PHYSICAL_TYPE_EXCLUSIONS = /BOOK|ISSUE|SCORE|KIT|MAP|ISSBD|GOVRECORD|OTHER/i
 
   def availability_status(item)
-    unavailable_libraries = []
+    # Temporary change for Ambler items
+    unavailable_libraries = ["AMBLER"]
     # Temporary change for items that don't currently fit in the ASRS bins
     unavailable_locations = ["storage"]
 
-    if unavailable_libraries.include?(item.library) ||
-        unavailable_locations.include?(item.location)
+    if unavailable_libraries.include?(item.library)
+      content_tag(:span, "", class: "close-icon") + "Temporarily unavailable"
+
+    elsif unavailable_locations.include?(item.location)
 
       label = "In temporary storage"
 

--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -24,11 +24,11 @@ module CobAlma
 
     def self.possible_pickup_locations
       #Make an array on only items that can request items
-      ["MAIN", "AMBLER", "GINSBURG", "PODIATRY", "HARRISBURG"]
+      ["MAIN", "GINSBURG", "PODIATRY", "HARRISBURG"]
     end
 
     def self.asrs_pickup_locations
-      ["MAIN", "AMBLER", "GINSBURG", "PODIATRY", "HARRISBURG"]
+      ["MAIN", "GINSBURG", "PODIATRY", "HARRISBURG"]
     end
 
     def self.remove_by_campus(campus)

--- a/spec/controllers/almaws_controller_spec.rb
+++ b/spec/controllers/almaws_controller_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe AlmawsController, type: :controller do
       expect(search_service).to receive(:fetch).and_return([:foo, document])
       allow(controller).to receive(:search_service).and_return(search_service)
       get(:item, { params: { mms_id: "merge_document_and_api", doc_id: 456 } })
-      expect(document["items_json_display"][0]["availability"]).to eq "<span class=\"check\"></span>Available"
+      # Shows Temporarily unavailable due to short-term Ambler availability change
+      expect(document["items_json_display"][0]["availability"]).to eq "<span class=\"close-icon\"></span>Temporarily unavailable"
     end
 
     it "does nothing if the pids don't match" do
@@ -53,7 +54,8 @@ RSpec.describe AlmawsController, type: :controller do
       allow(controller).to receive(:search_service).and_return(search_service)
       get(:item, { params: { mms_id: "merge_document_and_api", doc_id: 456 } })
       availability = controller.instance_variable_get(:@document_availability)
-      expect(availability.values.flatten.first["availability"]).to eq("<span class=\"check\"></span>Available")
+      # Shows Temporarily unavailable due to short-term Ambler availability change
+      expect(availability.values.flatten.first["availability"]).to eq("<span class=\"close-icon\"></span>Temporarily unavailable")
     end
 
     it "does not include missing or lost items" do

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe AvailabilityHelper, type: :helper do
       allow(helper).to receive(:campus_closed?) { campus_closed? }
     end
 
+    context "item is in Ambler" do
+      let(:item) do
+        Alma::BibItem.new("item_data" => { "current_library" => "AMBLER" })
+      end
+
+      it "displays Temporarily unavailable" do
+        label = "<span class=\"close-icon\"></span>Temporarily unavailable"
+      end
+    end
+
     context "item is in storage and campus is closed" do
       let(:item) do
         Alma::BibItem.new("item_data" => { "location" => { "value" => "storage" } })

--- a/spec/lib/cob_alma/requests_spec.rb
+++ b/spec/lib/cob_alma/requests_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe CobAlma::Requests do
       let(:items_list) { Alma::BibItem.find("desc_with_no_libraries") }
 
       it "returns a hash with all the campuses" do
-        expect(subject).to eq("v.2 (1974)" => ["MAIN", "AMBLER", "GINSBURG", "PODIATRY", "HARRISBURG"])
+        expect(subject).to eq("v.2 (1974)" => ["MAIN", "GINSBURG", "PODIATRY", "HARRISBURG"])
       end
     end
 
@@ -83,8 +83,8 @@ RSpec.describe CobAlma::Requests do
       let(:items_list) { Alma::BibItem.find("paley_reserves_and_remote_storage") }
 
       it "returns a hash with all the campuses" do
-        expect(subject).to eq("v.4 (1976)" => ["MAIN", "AMBLER", "GINSBURG", "PODIATRY", "HARRISBURG"],
-                              "v.5 (1977)" => ["MAIN", "AMBLER", "GINSBURG", "PODIATRY", "HARRISBURG"])
+        expect(subject).to eq("v.4 (1976)" => ["MAIN", "GINSBURG", "PODIATRY", "HARRISBURG"],
+                              "v.5 (1977)" => ["MAIN", "GINSBURG", "PODIATRY", "HARRISBURG"])
       end
     end
 
@@ -175,7 +175,7 @@ RSpec.describe CobAlma::Requests do
 
   describe "#asrs_pickup_locations" do
     it "displays MAIN as the pickup_location" do
-      expect(described_class.asrs_pickup_locations).to eq(["MAIN", "AMBLER", "GINSBURG", "PODIATRY", "HARRISBURG"])
+      expect(described_class.asrs_pickup_locations).to eq(["MAIN", "GINSBURG", "PODIATRY", "HARRISBURG"])
     end
   end
 


### PR DESCRIPTION
1) Remove Ambler from the list of pickup locations
2) Set masked availability status as "Temporarily unavailable" for all Ambler items

Note -- one of the spec/controllers/almaws_controller_spec.rb tests uses a Ambler item, so this needed to temporarily updated as well. 