### PR TITLE
BL-1579 Update EZBorrow integration for new system

### DIFF
--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -15,11 +15,13 @@ module RequestHelper
   def ez_borrow_link_with_updated_query(url)
     uri = URI.parse(url)
     params = CGI.parse(uri.query)
-    new_params = params.select { |key, value| ["group", "LS", "dest", "PI", "RK", "rft.title"].include? key }
+    new_params = params.select { |key, value| ["rft.title"].include? key }
+    new_params["lookfor"] = new_params.delete("rft.title")
+    new_params["type"] = "Title"
 
     URI::HTTPS.build(
       host: uri.host,
-      path: uri.path,
+      path: "/Search/Results",
       query: URI.encode_www_form(new_params)).to_s
   end
 

--- a/app/views/almaws/_resource_sharing_broker_allowed.html.erb
+++ b/app/views/almaws/_resource_sharing_broker_allowed.html.erb
@@ -7,7 +7,7 @@
 </div>
 
 <div id="collapseFour-<%= @mms_id %>" class="collapse <%= 'show' if only_one_option_allowed(request_options, @books, document)%>">
-  <div class="card-body pb-0">
+  <div class="card-body">
     <p><%= t("requests.resource_sharing_broker_text") %></p>
       <%= link_to(t("requests.resource_sharing_broker_link"), ez_borrow_link_with_updated_query(request_options.ez_borrow_link), id: "ez-borrow-button", class: "btn btn-primary request-button search-results-request-btn text-white", target: "_blank") %>
   </div>

--- a/spec/helpers/request_helper_spec.rb
+++ b/spec/helpers/request_helper_spec.rb
@@ -4,10 +4,10 @@ require "rails_helper"
 
 RSpec.describe RequestHelper, type: :helper do
   describe "#ez_borrow_link_with_updated_query(url)" do
-    let(:url) { "https://e-zborrow.relais-host.com/user/login.html?group=patron&LS=TEMPLE&dest=discovery&PI=12345&RK=12345&rft.stitle=A+thin+bright+line+%2F&rft.pub=The+University+of+Wisconsin+Press%2C&rft.place=Madison%2C+Wisconsin+%3A&rft.isbn=0299309304&rft.btitle=A+thin+bright+line+%2F&rft.genre=book&rft.normalized_isbn=9780299309305&rft.oclcnum=946770187&rft.mms_id=991028550499703811&rft.object_type=BOOK&rft.publisher=The+University+of+Wisconsin+Press%2C&rft.au=Bledsoe%2C+Lucy+Jane%2C+author.&rft.pubdate=%5B2016%5D&rft.title=A+thin+bright+line+%2F" }
+    let(:url) { "https://ezborrow.reshare.indexdata.com/?group=patron&LS=TEMPLE&dest=discovery&PI=12345&RK=12345&rft.stitle=A+thin+bright+line+%2F&rft.pub=The+University+of+Wisconsin+Press%2C&rft.place=Madison%2C+Wisconsin+%3A&rft.isbn=0299309304&rft.btitle=A+thin+bright+line+%2F&rft.genre=book&rft.normalized_isbn=9780299309305&rft.oclcnum=946770187&rft.mms_id=991028550499703811&rft.object_type=BOOK&rft.publisher=The+University+of+Wisconsin+Press%2C&rft.au=Bledsoe%2C+Lucy+Jane%2C+author.&rft.pubdate=%5B2016%5D&rft.title=A+thin+bright+line+%2F" }
 
     it "has correct link to resource" do
-      expect(ez_borrow_link_with_updated_query(url)).to eq("https://e-zborrow.relais-host.com/user/login.html?group=patron&LS=TEMPLE&dest=discovery&PI=12345&RK=12345&rft.title=A+thin+bright+line+%2F")
+      expect(ez_borrow_link_with_updated_query(url)).to eq("https://ezborrow.reshare.indexdata.com/Search/Results?lookfor=A+thin+bright+line+%2F&type=Title")
     end
   end
 


### PR DESCRIPTION
This would be repurpose the Resource Sharing link to map the OpenURL field to a non-OpenURL parameter and leave us the option to pull in any of the other parameters later on if needed. Happy to discuss if this isn't the right approach (see Jira ticket for details). 