### PR TITLE
Use https for git repo urls.

### DIFF
--- a/.circleci/update-airflow.sh
+++ b/.circleci/update-airflow.sh
@@ -6,7 +6,7 @@ source ./.env
 
 # Get Airflow Deployment Scripts.
 cd ..
-git clone --single-branch --branch main git@github.com:tulibraries/ansible-playbook-airflow.git
+git clone --single-branch --branch main https://github.com/tulibraries/ansible-playbook-airflow.git
 cd ansible-playbook-airflow
 
 # Install requirements


### PR DESCRIPTION
I missed this when I was updating git repo URLS for that issue that was causing our deployments to fail on QA.

This makes sure we don't run into that issue when we try to do a prod deployment at this step.