### PR TITLE
BL-1559: Disable faceting for opensearch queries.

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -61,6 +61,9 @@ class SearchBuilder < Blacklight::SearchBuilder
       solr_parameters["facet.field"] = [ "availability_facet", "library_facet", "format" ]
     elsif path == "catalog/range_limit" || path == "catalog/advanced"
       solr_parameters["facet.field"] = []
+    elsif path.match?(/\/opensearch/) || path.match?(/\/query_list/)
+      solr_parameters["facet"] = "off"
+      solr_parameters["facet.field"] = []
     end
   end
 

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -61,6 +61,28 @@ RSpec.describe SearchBuilder , type: :model do
         expect(solr_parameters["facet.field"]).to eq([])
       end
     end
+
+    context "when doing a query_list query" do
+      let(:params) { ActionController::Parameters.new(
+        controller: "catalog",
+        action: "query_list",
+      ) }
+
+      it "disables faceting" do
+        expect(solr_parameters["facet"]).to eq("off")
+      end
+    end
+
+    context "when doing a opensearch query" do
+      let(:params) { ActionController::Parameters.new(
+        controller: "catalog",
+        action: "opensearch",
+      ) }
+
+      it "disables faceting" do
+        expect(solr_parameters["facet"]).to eq("off")
+      end
+    end
   end
 
   describe "#tweak_query" do


### PR DESCRIPTION
Opensearch queries just return titles so facetings are not required.

Also disabled faceting for query_list queries because we do not neet facets on those either.