### PR TITLE
Bl 1402 Include export options when directly accessing record page

### DIFF
--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -223,24 +223,11 @@ a#bookmarks_nav {
 }
 
 #record-page-nav-tools {
-	padding-top: 1.25rem;
 
 	@media(max-width: 485px) {
 		padding: 0 0.3125rem;
    	text-align: center;
   }
-}
-
-.pagination-search-widgets {
-	border-bottom: none !important;
-}
-
-.pagination-search-widgets .page-links {
-	padding-top: 0;
-
-	@media(max-width: 485px) {
-		padding-top: 0.5rem;
-	}
 }
 
 .search-widgets {
@@ -263,7 +250,6 @@ a#bookmarks_nav {
 
 .page-links {
 	display: inline-block;
-	padding-top: 0.625rem;
 }
 
 #sort-dropdown .dropdown-item,

--- a/app/assets/stylesheets/partials/_pagination.scss
+++ b/app/assets/stylesheets/partials/_pagination.scss
@@ -65,6 +65,7 @@ nav .pagination {
   white-space: nowrap;
 }
 
-div .page_links {
-  padding: 0.625rem;
+.pagination-search-widgets {
+	border-bottom: none !important;
+  margin-bottom: 0 !important;
 }

--- a/app/assets/stylesheets/partials/_record_pages.scss
+++ b/app/assets/stylesheets/partials/_record_pages.scss
@@ -80,12 +80,3 @@ dd.blacklight-format {
 a.search-subject:visited  {
   text-decoration: none
 }
-
-.pagination-search-widgets {
-  align-self: center;
-  margin-left: auto;
-
-  @media(max-width: 768px) {
-    padding-bottom: 1rem;
-  }
-}

--- a/app/assets/stylesheets/partials/_record_tools.scss
+++ b/app/assets/stylesheets/partials/_record_tools.scss
@@ -4,6 +4,8 @@
 
 #nav-tools {
 	vertical-align: middle;
+	margin-left: auto;
+
 	@media (max-width: 768px) {
 		margin-top: 0.875rem;
 	}

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -1,17 +1,21 @@
 <% #Using the Bootstrap Pagination class  -%>
 <div id="record-page-nav-tools" class="d-md-flex align-items-start">
+
   <% if current_search_session %>
     <div class="search-widgets d-flex">
       <%= link_back_to_catalog class: "btn btn-back-to-search text-red", id: "back_to_search" %>
       <%= link_to t("blacklight.search.start_over"), bento_search_engine_path, id: "start_over", class: "btn bg-dark-blue text-white" %>
     </div>
   <% end %>
-  
+
+  <% if @search_context && search_session['document_id'] == @document.id %>
   <%= render(Blacklight::SearchContextComponent.new(search_context: @search_context, search_session: search_session)) %>
+  <% end %>
 
   <div id="nav-tools" class="nav-tools pr-4">
     <%= render partial: "show_tools_navbar" %>
   </div>
+
 </div>
 
 <hr class="m-0 p-0 border-bottom border-grey" />

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,0 +1,23 @@
+<% @page_title = t('blacklight.search.show.title', document_title: Deprecation.silence(Blacklight::BlacklightHelperBehavior) { document_show_html_title }, application_name: application_name).html_safe %>
+<% content_for(:head) { render_link_rel_alternates } %>
+
+<%= render (blacklight_config.view_config(:show).document_component || Blacklight::DocumentComponent).new(presenter: document_presenter(@document), component: :div, title_component: :h1, show: true) do |component| %>
+  <% component.footer do %>
+    <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
+      <!--
+           // COinS, for Zotero among others.
+           // This document_partial_name(@document) business is not quite right,
+           // but has been there for a while.
+      -->
+      <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(Deprecation.silence(Blacklight::RenderPartialsHelperBehavior) { document_partial_name(@document) }) %>"></span>
+    <% end %>
+  <%  end %>
+
+  <%# Use :body for complete backwards compatibility (overriding the component body markup),
+        but if the app explicitly  opted-in to components, make the partials data available as :partials to ease migrations pain %>
+  <% component.public_send(blacklight_config.view_config(:show).document_component.blank? && blacklight_config.view_config(:show).partials.any? ? :body : :partial) do %>
+    <div id="doc_<%= @document.id.to_s.parameterize %>">
+      <%= render_document_partials @document, blacklight_config.view_config(:show).partials, component: component %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -2,9 +2,9 @@
 <%# This allows the user to see the back/start over buttons and send to options on record pages %>
 
 <% @search_context ||= current_search_session %>
-
 <div id="record-page-container">
   <div id="record-page-content" class="col-12 px-0">
+    <%= render 'previous_next_doc' %>
     <%= render_document_main_content_partial %>
   </div>
 </div>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -52,7 +52,7 @@
         <%= link_to "Chat", "https://v2.libanswers.com/chati.php?hash=6af1e63c96b3b7ee77f712a13babdc61&referer=https%3A%2F%2Flibrarysearch.temple.edu&referer_title=Temple%20University%20Libraries", target: "_blank" %>
       </div>
 
-      <div class="p-md-3">
+      <div class="p-md-2">
         <%= render :partial=>'/shared/flash_msg' %>
       </div>
 


### PR DESCRIPTION
So I was looking at BL-1402 to evaluate our options. I _think_ I may have found a solution that does not require a complete redesign, but I'm not sure if the choices that I made are consistent with our best practices. 

What I did: 
- Overrode the default Blacklight view _show_main_content.html.erb: This is the part that I'm most unsure of. Is there a reason why we should not customize this view (vs. others)? Here's the [Blacklight view](https://github.com/projectblacklight/blacklight/blob/master/app/views/catalog/_show_main_content.html.erb). By creating a custom view, we can remove `<%= render 'previous_next_doc' if @search_context && search_session['document_id'] == @document.id %>` and change the conditional logic for the rendering of 'previous_next_doc'. 
- Updated app/views/catalog/show.html.erb and app/views/catalog/_previous_next_doc.html.erb based on the change above
- Cleaned up the styling for .pagination-search-widgets and flexbox in record nav bar