### PR TITLE
BL-614: Add coverband as code coverage analyzer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ gem "browser"
 gem "blacklight-ris", git: "https://github.com/upenn-libraries/blacklight-ris.git"
 gem "httparty"
 gem "dotenv-rails"
+gem "coverband"
 
 group :production do
   gem "mysql2", "~> 0.5.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,8 @@ GEM
     concurrent-ruby (1.1.9)
     confstruct (1.1.0)
       hashie (>= 3.3, < 5)
+    coverband (5.1.1)
+      redis
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -445,6 +447,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.5.1)
     regexp_parser (2.1.1)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -629,6 +632,7 @@ DEPENDENCIES
   cob_index!
   cob_web_index!
   coffee-rails (~> 5.0)
+  coverband
   dalli
   database_cleaner
   devise!
@@ -687,4 +691,4 @@ DEPENDENCIES
   webpacker (= 6.0.0.rc.6)
 
 BUNDLED WITH
-   2.2.17
+   2.2.30

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -2,7 +2,7 @@
 
 #config/coverband.rb
 Coverband.configure do |config|
-	# TODO: Use redis or memcached store.
+  # TODO: Use redis or memcached store.
   config.store = Coverband::Adapters::FileStore.new("log/coverband.log")
   config.logger = Rails.logger
 

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -1,0 +1,22 @@
+#frozen_string_literal: true
+
+#config/coverband.rb
+Coverband.configure do |config|
+	# TODO: Use redis or memcached store.
+  config.store = Coverband::Adapters::FileStore.new("log/coverband.log")
+  config.logger = Rails.logger
+
+  # config options false, true. (defaults to false)
+  # true and debug can give helpful and interesting code usage information
+  # and is safe to use if one is investigating issues in production, but it will slightly
+  # hit perf.
+  config.verbose = false
+
+  # default false. button at the top of the web interface which clears all data
+  config.web_enable_clear = true
+
+  # default false. Experimental support for tracking view layer tracking.
+  # Does not track line-level usage, only indicates if an entire file
+  # is used or not.
+  config.track_views = true
+end

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -3,6 +3,7 @@
 #config/coverband.rb
 Coverband.configure do |config|
   # TODO: Use redis or memcached store.
+  # A Redis will allow us to also track views.
   config.store = Coverband::Adapters::FileStore.new("log/coverband.log")
   config.logger = Rails.logger
 
@@ -18,5 +19,6 @@ Coverband.configure do |config|
   # default false. Experimental support for tracking view layer tracking.
   # Does not track line-level usage, only indicates if an entire file
   # is used or not.
-  config.track_views = true
+  config.track_views = false
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,7 +166,7 @@ Rails.application.routes.draw do
   get "*anything", to: "errors#not_found"
 
   authenticate :user, lambda { |u| u.admin? } do
-    mount Coverband::Reporters::Web.new, at: '/coverage'
+    mount Coverband::Reporters::Web.new, at: "/coverage"
   end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,10 @@ Rails.application.routes.draw do
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get "*anything", to: "errors#not_found"
+
+  authenticate :user, lambda { |u| u.admin? } do
+    mount Coverband::Reporters::Web.new, at: '/coverage'
+  end
 end
 
 OkComputer::Engine.routes.draw do


### PR DESCRIPTION
* We'll need to manually make whoever wants to view the coverage analysis and
admin in the production server.