### PR TITLE
Fix stimulus-3 deprecation warnings

### DIFF
--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -4,7 +4,7 @@ module RequestHelper
   include Blacklight::CatalogHelperBehavior
 
   def request_modal(mms_id, pickup_locations, request_level)
-    link_to(t("requests.request_button"), "#", id: "request-btn-#{mms_id}", class: "btn btn-sm btn-primary request-button search-results-request-btn float-right", data: { "blacklight-modal": "trigger", "action": "availability#modal show#loading", "target": "availability.href show.href" })
+    link_to(t("requests.request_button"), "#", id: "request-btn-#{mms_id}", class: "btn btn-sm btn-primary request-button search-results-request-btn float-right", data: { "blacklight-modal": "trigger", "action": "availability#modal show#loading", "availability-target": "href", "show-target": "href" })
   end
 
   def request_redirect_url(mms_id)

--- a/app/views/catalog/_explanation_div.html.erb
+++ b/app/views/catalog/_explanation_div.html.erb
@@ -1,5 +1,5 @@
 <% if !cookies.fetch("#{controller_name}Once", false) %>
-<div class="row bg-background-grey rounded explanation-div mx-1" data-controller="explanation" data-exploration-target="<%= controller_name %>">
+<div class="row bg-background-grey rounded explanation-div mx-1" data-controller="explanation" data-explanation-target="<%= controller_name %>">
   <div class="explantion-wrapper col-sm-12 col-lg-10 mt-4 pl-5 pr-5 mx-auto" >
     <p class="explanation">
       <%= explanation_translations(controller_name) %>

--- a/app/views/catalog/_explanation_div.html.erb
+++ b/app/views/catalog/_explanation_div.html.erb
@@ -1,5 +1,5 @@
 <% if !cookies.fetch("#{controller_name}Once", false) %>
-<div class="row bg-background-grey rounded explanation-div mx-1" data-controller="explanation" data-target="<%= "explanation.#{controller_name}" %>">
+<div class="row bg-background-grey rounded explanation-div mx-1" data-controller="explanation" data-exploration-target="<%= controller_name %>">
   <div class="explantion-wrapper col-sm-12 col-lg-10 mt-4 pl-5 pr-5 mx-auto" >
     <p class="explanation">
       <%= explanation_translations(controller_name) %>

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -7,12 +7,12 @@
     <div class="row button-break pt-md-3"></div>
     <div data-controller="availability" data-availability-url="<%= item_url(document.alma_availability_mms_ids.first, params.merge(doc_id: document.id, redirect_to: request.url).except(:page)) %>">
         <div class="controls">
-          <button data-action="availability#item" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" class="btn btn-sm btn-default availability-toggle-details" data-toggle="collapse" data-target="#physical-document-<%=  document.id %>, availability.button" id="available_button-<%=  document.id %>" aria-expanded="false" aria-controls="physical-document-<%= document.id %>">
+          <button data-action="availability#item" data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" class="btn btn-sm btn-default availability-toggle-details" data-toggle="collapse" data-target="#physical-document-<%=  document.id %>" data-availability-target="button" id="available_button-<%=  document.id %>" aria-expanded="false" aria-controls="physical-document-<%= document.id %>">
             <i class="fa fa-spinner" aria-busy="true" aria-live="polite"></i>
             <span>Loading...</span>
           </button>
 
-          <div id="requests-container-<%= document.id %>" class="hidden requests-container float-right" data-controller="requests" data-target="show.request, availability.request">
+          <div id="requests-container-<%= document.id %>" class="hidden requests-container float-right" data-controller="requests" data-target="show.request" data-availability-target="request">
             <% if user_signed_in? %>
               <%= request_modal(document.id, @pickup_locations, @request_level) %>
             <% else %>
@@ -22,7 +22,7 @@
         </div>
 
         <div data-availability-ids="<%= document.alma_availability_mms_ids.join(',') %>" id="physical-document-<%= document.id %>" class="collapse panel-content avail-container index-avail-container mt-1">
-            <div class="border border-header-grey mt-0" data-target="availability.panel">
+            <div class="border border-header-grey mt-0" data-availability-target="panel">
               <%= render "physical_availability_card", document: document, document_counter: document.id %>
             </div>
         </div>

--- a/app/views/catalog/_lib_guide_recommender_catalog.html.erb
+++ b/app/views/catalog/_lib_guide_recommender_catalog.html.erb
@@ -1,12 +1,12 @@
 <div class="lib-guides-recommender-catalog w-100 my-3 px-3">
   <div class="lib-guides-recommender-catalog-body rounded-top">
     <h2 class="lib-guides-recommender-catalog-heading text-red mb-0">Help &amp; Guides</h2>
-    <div class="d-flex justify-content-between pt-md-1 pb-md-4 px-md-4 catalog-guides" data-target="lib-guides.card">
-      <div class="lib-guides-recommender-librarians flex-fill p-4 rounded" data-target="lib-guides.flex">
+    <div class="d-flex justify-content-between pt-md-1 pb-md-4 px-md-4 catalog-guides" data-libg-guides-target="card">
+      <div class="lib-guides-recommender-librarians flex-fill p-4 rounded" data-lib-guides-target="flex">
         <h3 class="lib-guides-recommender-heading lib-guides-recommender-catalog-heading">Subject Librarians</h3>
       </div>
 
-      <div class="lib-guides-recommender-guides flex-fill p-4 rounded ml-md-4" data-target="lib-guides.flex">
+      <div class="lib-guides-recommender-guides flex-fill p-4 rounded ml-md-4" data-lib-guides-target="flex">
         <h3 class="lib-guides-recommender-heading">Research Guides</h3>
       </div>
     </div>

--- a/app/views/catalog/_lib_guide_recommender_catalog.html.erb
+++ b/app/views/catalog/_lib_guide_recommender_catalog.html.erb
@@ -1,7 +1,7 @@
 <div class="lib-guides-recommender-catalog w-100 my-3 px-3">
   <div class="lib-guides-recommender-catalog-body rounded-top">
     <h2 class="lib-guides-recommender-catalog-heading text-red mb-0">Help &amp; Guides</h2>
-    <div class="d-flex justify-content-between pt-md-1 pb-md-4 px-md-4 catalog-guides" data-libg-guides-target="card">
+    <div class="d-flex justify-content-between pt-md-1 pb-md-4 px-md-4 catalog-guides" data-lib-guides-target="card">
       <div class="lib-guides-recommender-librarians flex-fill p-4 rounded" data-lib-guides-target="flex">
         <h3 class="lib-guides-recommender-heading lib-guides-recommender-catalog-heading">Subject Librarians</h3>
       </div>

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -29,7 +29,7 @@
   <% if document.fetch("availability_facet", []).include?("At the Library") %>
     <div class="physical-holding-panel border-0 mt-2">
       <div class="border border-header-grey mb-3">
-        <div data-target="show.panel">
+        <div data-show-target="panel">
           <%= render "physical_availability_card", document: document, document_counter: document.id %>
         </div>
       </div>

--- a/app/views/lib_guides/index.html.erb
+++ b/app/views/lib_guides/index.html.erb
@@ -1,18 +1,18 @@
-  <div class="lib-guides-recommender-librarians border p-3" data-target="lib-guides.flex">
-    <h3 class="lib-guides-recommender-heading" data-target="lib-guides.heading">Subject Librarians</h3>
+  <div class="lib-guides-recommender-librarians border p-3" data-lib-guides-target="flex">
+    <h3 class="lib-guides-recommender-heading" data-libg-guides-target="heading">Subject Librarians</h3>
     <% if @guides.present? %>
       <%= link_to(@guides.first.dig("owner", "first_name") + " " + @guides.first.dig("owner", "last_name"), "https://guides.temple.edu/prf.php?account_id=" + @guides.first.dig("owner", "id")) %>
       <p class="pt-2"><%= @guides.first.dig("owner", "email") %></p>
     <% else %>
-      <div data-target="lib-guides.noresults">
+      <div data-lib-guides-target="noresults">
         <p><%= t("lib_guides.librarian_no_results") %></p>
         <%= link_to(t("lib_guides.librarian_no_results_text"), t("lib_guides.librarian_no_results_link")) %>
       </div>
     <% end %>
   </div>
 
-  <div class="lib-guides-recommender-guides border-top border-red p-3" data-target="lib-guides.flex">
-    <h3 class="lib-guides-recommender-heading" data-target="lib-guides.heading">Research Guides</h3>
+  <div class="lib-guides-recommender-guides border-top border-red p-3" data-lib-guides-target="flex">
+    <h3 class="lib-guides-recommender-heading" data-lib-guides-target="heading">Research Guides</h3>
     <ul class="list-unstyled">
     <% if @guides.present? %>
       <% @guides.each do |guide| %>
@@ -21,7 +21,7 @@
         </li>
       <% end %>
     <% else %>
-      <div data-target="lib-guides.noresults">
+      <div data-lib-guides-target="noresults">
         <li class="pb-2">
           <%= link_to(t("lib_guides.guides_no_results_text"), t("lib_guides.guides_no_results_link")) %>
         </li>

--- a/app/views/query_list/_results.html.erb
+++ b/app/views/query_list/_results.html.erb
@@ -5,7 +5,7 @@
   </div>
 
   <hr class="query-hr" />
-  <div class="query-list-preload" data-target="query-list.results">
+  <div class="query-list-preload" data-query-list-target="results">
     <span class="fa fa-spinner" aria-busy="true" aria-live="polite"></span>
     <span>Loading...</span>
   </div>

--- a/app/views/users/_user_fines.html.erb
+++ b/app/views/users/_user_fines.html.erb
@@ -15,9 +15,9 @@
         <%= render partial: "fines_details", locals: {fines: current_user.fines} %>
       </tbody>
       <% else %>
-      <tbody data-target="fines.table">
+      <tbody data-fines-target="table">
         <tr>
-          <td class="text-center" data-target="fines.spinner">
+          <td class="text-center" data-fines-target="spinner">
             <i class="fa fa-spinner" aria-busy="true" aria-live="polite"></i>
             <span class="loading-message"> Loading Fines...</span>
           </td>

--- a/app/views/users/_user_holds.html.erb
+++ b/app/views/users/_user_holds.html.erb
@@ -15,9 +15,9 @@
       <%= render partial: "holds_details", locals: {holds: current_user.holds} %>
     </tbody>
     <% else %>
-    <tbody data-target="holds.table">
+    <tbody data-holds-target="table">
       <tr>
-        <td colspan="4" class="text-center" data-target="holds.spinner">
+        <td colspan="4" class="text-center" data-holds-target="spinner">
           <i class="fa fa-spinner" aria-busy="true" aria-live="polite"></i>
           <span class="loading-message"> Loading Holds...</span>
         </td>

--- a/app/views/users/_user_loans.html.erb
+++ b/app/views/users/_user_loans.html.erb
@@ -20,9 +20,9 @@
         <%= render partial: "loans_details", locals: {loans: current_user.loans} %>
       </tbody>
       <% else %>
-      <tbody data-target="loans.table">
+      <tbody data-loans-target="table">
         <tr>
-          <td colspan="9" data-target="loans.spinner">
+          <td colspan="9" data-loans-target="spinner">
             <i class="fa fa-spinner" aria-busy="true" aria-live="polite"></i>
             <span class="loading-message"> Loading Items...</span>
           </td>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       it "sets a target div called data-target=\"query-list.results\"" do
-        expect(helper.query_list("foo", "tooltip", "q=bar")).to match(/<div.*data-target="query-list\.results".*>/)
+        expect(helper.query_list("foo", "tooltip", "q=bar")).to match(/<div.*data-query-list-target="results".*>/)
       end
     end
 


### PR DESCRIPTION
Stimulus 3 has added a deprecation warning to data-target attributes because they are going away in future versions of stimulus.