### PR TITLE
Fix OCLC query error for Google Books

### DIFF
--- a/app/assets/javascripts/book_covers.js
+++ b/app/assets/javascripts/book_covers.js
@@ -15,7 +15,7 @@ $(document).on('turbolinks:load', function() {
       })
     } else if(oclc) {
       oclc.split(",").map(function(value){
-        queries.push("ISBN:" + value);
+        queries.push("OCLC:" + value);
       })
     } else {
       $("#book-cover-image").remove();


### PR DESCRIPTION
Noticed this when I was working on https://github.com/tulibraries/tul_cob/pull/3000