### PR TITLE
BL-1604: delete cache that results from a bad request.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,6 +53,7 @@ class ApplicationController < ActionController::Base
                  HTTParty.get(alert_url, timeout: 1)
                rescue => e
                  Honeybadger.notify(e)
+                 Thread.new { sleep 0.25; Rails.cache.delete("manifold_alerts") }
                  {}
                end
         resp["data"] || []


### PR DESCRIPTION
We'll want to dump cache that results from error recovery because it's not useful.