### PR TITLE
Allow any authenticated user to pay online.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,11 +80,6 @@ class User < ApplicationRecord
   end
 
   def can_pay_online?
-    # TODO: verify who can pay online
-    alma.total_fines > 0 && ({
-      "Undergraduate" => "2",
-      "Graduate/Professional" => "3",
-      "Faculty/Admin" => "4",
-    }.values.include? alma.user_group["value"] rescue false)
+    alma.total_fines > 0
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -305,7 +305,6 @@ en:
   account:
     renew_text_html: "Items marked with <i class='fas fa-exclamation-circle text-red'></i><span class='sr-only'>Unable to renew</span> icon are not eligible for renewal.  Please %{href} for more information."
     renew_text_href: "contact us"
-    fines_not_electronic: "Fines cannot be paid electronically."
     fines_text: "Learn more about late fines and replacement charges."
     fines_link: "https://library.temple.edu/services/12"
     update_name: "Update your preferred name via TUPortal"

--- a/spec/features/online_payment_spec.rb
+++ b/spec/features/online_payment_spec.rb
@@ -27,16 +27,16 @@ RSpec.feature "Online Payments" do
     end
   end
 
-  context "User has fines but is not part proper group" do
+  context "User has fine and is in some random unknown group" do
     let(:alma) { OpenStruct.new(
       total_fines: 1.0,
-      user_group: { "value" => "99" }
+      user_group: { "value" => "foobar" }
     ) }
 
     scenario "user goes to account page" do
       visit users_account_path
 
-      expect(page).to_not have_link "Pay Online"
+      expect(page).to have_link "Pay Online"
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -131,18 +131,16 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context "the user hass a fine but is not allowed group" do
+    context "the user hass a fine and is in any group" do
       let(:alma) { OpenStruct.new(
         total_fines: 1.0,
         user_group: { "value" => "99" }
       ) }
 
-      it "does not allow pay online" do
-        expect(user.can_pay_online?).to eq(false)
+      it "allows pay online" do
+        expect(user.can_pay_online?).to eq(true)
       end
-    end
 
-    context "the user hass a fine but and is in an allowed group" do
       let(:alma) { OpenStruct.new(
         total_fines: 1.0,
         user_group: { "value" => "2" }


### PR DESCRIPTION
Remove consideration of a user's group in deciding if they can pay
online.

Only consider that they have a fine and the they are authenticated.