### PR TITLE
Cleanup fixtures

### DIFF
--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -250,12 +250,15 @@ note_copyright_540:
   note_copyright: "Dictionary of American history: 540."
 note_copyright_542:
   doc_id: "991012132499760710"
+  title: "note_copyright_542 title"
   note_copyright: "Dictionary of American history: 542. Subfield B. Subfield C. Subfield D. Subfield E. Subfield F. Subfield G. Subfield H. Subfield I. Subfield J. Subfield K. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield 3."
 note_copyright_542_0:
   doc_id: "991012132499760711"
+  title: "note_copyright_542_0 title"
   note_copyright: "Dictionary of American history: 542. Subfield B. Subfield C. Subfield D. Subfield E. Subfield F. Subfield G. Subfield H. Subfield I. Subfield J. Subfield K. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield 3."
 note_copyright_542_1:
   doc_id: "991012132499760712"
+  title: "note_copyright_542_1 title"
   note_copyright: "Dictionary of American history: 542. Subfield B. Subfield C. Subfield D. Subfield E. Subfield F. Subfield G. Subfield H. Subfield I. Subfield J. Subfield K. Subfield L. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield 3."
 note_bio_545:
   doc_id: "991012132499760663"
@@ -355,42 +358,55 @@ entry_preced_780_07:
   separated_from: "Dictionary of American history: 780. Subfield I. Subfield B. Subfield D. Subfield G. Subfield H. Subfield K. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield S. Annales scientifiques de l'Université de Besançon$w(OCoLC)6179013 Subfield U. Subfield X. Subfield Y. Subfield Z. Subfield 3."
 entry_succeed_785_00:
   doc_id: "991012132499760690"
+  title: "785_00 title"
   continued_by: "Dictionary of American history: 785. Subfield I. Subfield B. Subfield D. Subfield G. Subfield H. Subfield K. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield S. Subfield T. Subfield U. Subfield X. Subfield Y. Subfield Z. Subfield 3."
 entry_succeed_785_03:
   doc_id: "991012132499760704"
+  title: "785_03 title"
   continued_in_part_by: "Dictionary of American history: 785. Subfield I. Subfield B. Subfield D. Subfield G. Subfield H. Subfield K. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield S. Subfield T. Subfield U. Subfield X. Subfield Y. Subfield Z. Subfield 3."
 entry_succeed_785_04:
   doc_id: "991012132499760705"
+  title: "785_04 title"
   absorbed_by: "Dictionary of American history: 785. Subfield I. Subfield B. Subfield D. Subfield G. Subfield H. Subfield K. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield S. Subfield T. Subfield U. Subfield X. Subfield Y. Subfield Z. Subfield 3."
 entry_succeed_785_05:
   doc_id: "991012132499760706"
+  title: "785_05 title"
   absorbed_in_part_by: "Dictionary of American history: 785. Subfield I. Subfield B. Subfield D. Subfield G. Subfield H. Subfield K. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield S. Subfield T. Subfield U. Subfield X. Subfield Y. Subfield Z. Subfield 3."
 entry_succeed_785_06:
   doc_id: "991012132499760707"
+  title: "785_06 title"
   split_into: "Dictionary of American history: 785. Subfield I. Subfield B. Subfield D. Subfield G. Subfield H. Subfield K. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield S. Subfield T. Subfield U. Subfield X. Subfield Y. Subfield Z. Subfield 3."
 entry_succeed_785_07:
   doc_id: "991012132499760708"
+  title: "785_07 title"
   merged_to_form: "Dictionary of American history: 785. Subfield I. Subfield B. Subfield D. Subfield G. Subfield H. Subfield K. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield S. Subfield T. Subfield U. Subfield X. Subfield Y. Subfield Z. Subfield 3."
 entry_succeed_785_08:
   doc_id: "991012132499760709"
+  title: "785_08 title"
   changed_back_to: "Dictionary of American history: 785. Subfield I. Subfield B. Subfield D. Subfield G. Subfield H. Subfield K. Subfield M. Subfield N. Subfield O. Subfield P. Subfield Q. Subfield R. Subfield S. Subfield T. Subfield U. Subfield X. Subfield Y. Subfield Z. Subfield 3."
 lccn_010:
   doc_id: "991012132499760713"
+  title: "lccn_010 title"
   lccn: "lccn number Subfield B"
 gpo_074:
   doc_id: "991012132499760714"
+  title: "gpo_074 title"
   gpo: "gpo number"
 alma_mms_001:
   doc_id: "991012132499760715"
+  title: "alma_mms_001 title"
   alma_mms: "991012132499760715"
 sudoc_086:
   doc_id: "991012132499760718"
+  title: "sudoc_086 title"
   sudoc: "test"
 sudoc_086_0:
   doc_id: "991012132499760716"
+  title: "sudoc_086_0 title"
   sudoc: "Y 4.C 73/7:S.HRG.109-174"
 sudoc_086_1:
   doc_id: "991012132499760717"
+  title: "sudoc_086_1 title"
   sudoc: "test"
 url_856_0:
   doc_id: "991012065429703811"

--- a/spec/fixtures/marc_fixture_4_marc.xml
+++ b/spec/fixtures/marc_fixture_4_marc.xml
@@ -4087,6 +4087,9 @@
 		<leader>01120cam a22003610  4500</leader>
 		<controlfield tag='001'>991012132499760690</controlfield>
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">785_00 title</subfield>
+		</datafield>
 		<datafield ind1='0' ind2='0' tag='264'>
 			<subfield code='c'>2017.</subfield>
 		</datafield>
@@ -4247,6 +4250,9 @@
 		<leader>01120cam a22003610  4500</leader>
 		<controlfield tag='001'>991012132499760704</controlfield>
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">785_03 title</subfield>
+		</datafield>
 		<datafield ind1='0' ind2='0' tag='264'>
 			<subfield code='c'>2017.</subfield>
 		</datafield>
@@ -4279,6 +4285,9 @@
 		<leader>01120cam a22003610  4500</leader>
 		<controlfield tag='001'>991012132499760705</controlfield>
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">785_04 title</subfield>
+		</datafield>
 		<datafield ind1='0' ind2='0' tag='264'>
 			<subfield code='c'>2017.</subfield>
 		</datafield>
@@ -4311,6 +4320,9 @@
 		<leader>01120cam a22003610  4500</leader>
 		<controlfield tag='001'>991012132499760706</controlfield>
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">785_05 title</subfield>
+		</datafield>
 		<datafield ind1='0' ind2='0' tag='264'>
 			<subfield code='c'>2017.</subfield>
 		</datafield>
@@ -4343,6 +4355,9 @@
 		<leader>01120cam a22003610  4500</leader>
 		<controlfield tag='001'>991012132499760707</controlfield>
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">785_06 title</subfield>
+		</datafield>
 		<datafield ind1='0' ind2='0' tag='264'>
 			<subfield code='c'>2017.</subfield>
 		</datafield>
@@ -4375,6 +4390,9 @@
 		<leader>01120cam a22003610  4500</leader>
 		<controlfield tag='001'>991012132499760708</controlfield>
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">785_07 title</subfield>
+		</datafield>
 		<datafield ind1='0' ind2='0' tag='264'>
 			<subfield code='c'>2017.</subfield>
 		</datafield>
@@ -4407,6 +4425,9 @@
 		<leader>01120cam a22003610  4500</leader>
 		<controlfield tag='001'>991012132499760709</controlfield>
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">785_08 title</subfield>
+		</datafield>
 		<datafield ind1='0' ind2='0' tag='264'>
 			<subfield code='c'>2017.</subfield>
 		</datafield>
@@ -4439,6 +4460,9 @@
 		<leader>01120cam a22003610  4500</leader>
 		<controlfield tag='001'>991012132499760710</controlfield>
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">note_copyright_542 title</subfield>
+		</datafield>
 		<datafield ind1='0' ind2='0' tag='264'>
 			<subfield code='c'>2017.</subfield>
 		</datafield>
@@ -4470,6 +4494,9 @@
 		<leader>01120cam a22003610  4500</leader>
 		<controlfield tag='001'>991012132499760711</controlfield>
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">note_copyright_542_0 title</subfield>
+		</datafield>
 		<datafield ind1='0' ind2='0' tag='264'>
 			<subfield code='c'>2017.</subfield>
 		</datafield>
@@ -4501,6 +4528,9 @@
 		<leader>01120cam a22003610  4500</leader>
 		<controlfield tag='001'>991012132499760712</controlfield>
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">note_copyright_542_1 title</subfield>
+		</datafield>
 		<datafield ind1='0' ind2='0' tag='264'>
 			<subfield code='c'>2017.</subfield>
 		</datafield>
@@ -4536,6 +4566,9 @@
 			<subfield code='a'>lccn number</subfield>
 			<subfield code='b'>Subfield B</subfield>
 		</datafield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">lccn_010 title</subfield>
+		</datafield>
 		<datafield ind1='0' ind2='0' tag='264'>
 			<subfield code='c'>2017.</subfield>
 		</datafield>
@@ -4549,6 +4582,9 @@
 		<datafield ind1=' ' ind2=' ' tag='074'>
 			<subfield code='a'>gpo number</subfield>
 		</datafield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">gpo_074 title</subfield>
+		</datafield>
 		<datafield tag='HLD' >
 		</datafield>
 	</record>
@@ -4557,6 +4593,9 @@
 		<controlfield tag='001'>991012132499760715</controlfield>
 		<controlfield tag='001'>991012132499760715</controlfield>
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">alma_mms_001 title</subfield>
+		</datafield>
 		<datafield tag='HLD'>
 		</datafield>
 	</record>
@@ -4566,6 +4605,9 @@
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
 		<datafield ind1='0' ind2=' ' tag='086'>
 			<subfield code='a'>Y 4.C 73/7:S.HRG.109-174</subfield>
+		</datafield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">sudoc_086_0</subfield>
 		</datafield>
 		<datafield tag='HLD' >
 		</datafield>
@@ -4577,6 +4619,9 @@
 		<datafield ind1='1' ind2=' ' tag='086'>
 			<subfield code='a'>test</subfield>
 		</datafield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">sudoc_086_1 title</subfield>
+		</datafield>
 		<datafield tag='HLD' >
 		</datafield>
 	</record>
@@ -4586,6 +4631,9 @@
 		<controlfield tag='008'>831003s1983    nyu      d    00010deng  </controlfield>
 		<datafield ind1=' ' ind2=' ' tag='086'>
 			<subfield code='a'>test</subfield>
+		</datafield>
+		<datafield ind1="0" ind2="0" tag="245">
+			<subfield code="a">sudoc_086 title</subfield>
 		</datafield>
 		<datafield tag='HLD' >
 		</datafield>


### PR DESCRIPTION
- Some of our test cases for record page feature tests did not include a title.  This throws an error during the cob_index ingest process.  
- This adds titles to the records throwing errors to avoid this when running tests