### PR TITLE
Fix lose precision when convert from dollars to cents.

### DIFF
--- a/app/controllers/concerns/quik_pay.rb
+++ b/app/controllers/concerns/quik_pay.rb
@@ -12,7 +12,7 @@ module QuikPay
     raise AccessDenied.new("This user does not have access to this feature.") unless session["can_pay_online?"]
 
     # Fines needs to be converted to cents
-    total_fines_cents = 100 * session[:total_fines].to_i
+    total_fines_cents = (100 * session[:total_fines].to_f).to_i
 
     params = { amountDue: total_fines_cents,  orderNumber: session[:alma_sso_user] }
     redirect_to quik_pay_url(params, Rails.configuration.quik_pay["secret"])

--- a/spec/controllers/quik_pay_spec.rb
+++ b/spec/controllers/quik_pay_spec.rb
@@ -191,6 +191,16 @@ RSpec.describe UsersController, type: "controller"  do
         end
       end
 
+      context "the fine has cent amounts" do
+        it "does not lose precision when coverting total_fines to cents" do
+          session["can_pay_online?"] = true;
+          session["total_fines"] = "25.11"
+
+          get :quik_pay
+          expect(response.location).to match(/quikpay.*?orderNumber=.*&orderType=Temple%20Library&amountDue=2511.*&redirectUrl=.*&redirectUrlParameters=.*&timestamp=.*&hash=.*$/)
+        end
+      end
+
       context "user cannot pay online" do
         it "raises an exception" do
           session["can_pay_online?"] = false;


### PR DESCRIPTION
We need to convert alma values to a float in order not to lose
precision.