### PR TITLE
Update nokogiri to not use native extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ gem "blacklight-ris", git: "https://github.com/upenn-libraries/blacklight-ris.gi
 gem "httparty"
 gem "dotenv-rails"
 gem "faraday", "1.8.0"
+gem "nokogiri", "1.13.1"
 
 group :production do
   gem "mysql2", "~> 0.5.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,6 +369,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
+    mini_portile2 (2.7.1)
     minitest (5.15.0)
     msgpack (1.4.4)
     multi_json (1.15.0)
@@ -377,7 +378,8 @@ GEM
     mysql2 (0.5.3)
     nenv (0.3.0)
     nio4r (2.5.8)
-    nokogiri (1.13.1-x86_64-darwin)
+    nokogiri (1.13.1)
+      mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -474,7 +476,7 @@ GEM
     rspec-expectations (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+    rspec-mocks (3.10.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-rails (5.1.0)
@@ -617,7 +619,7 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
-  x86_64-darwin-20
+  ruby
 
 DEPENDENCIES
   alma!
@@ -663,6 +665,7 @@ DEPENDENCIES
   lc_solr_sortable!
   listen (~> 3.7.1)
   mysql2 (~> 0.5.3)
+  nokogiri (= 1.13.1)
   okcomputer
   omniauth
   omniauth-rails_csrf_protection


### PR DESCRIPTION
- Nokogiri was installing with  nokogiri (1.13.1-x86_64-darwin), this was causing the playbook to fail.  This updates it to just use nokogiri (1.13.1) because that is what the playbook is looking for.