### PR TITLE
BL-1624 Notes mapping

### DIFF
--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -624,14 +624,6 @@ RSpec.feature "RecordPageFields" do
         expect(page).to have_text(item_586["note"])
       end
     end
-
-    let (:item_588) { fixtures.fetch("note_588") }
-    scenario "User visits a document with note" do
-      visit "catalog/#{item_588['doc_id']}"
-      within "dd.blacklight-note_display" do
-        expect(page).to have_text(item_588["note"])
-      end
-    end
   end
 
   feature "MARC Note With Fields" do

--- a/spec/fixtures/features.yml
+++ b/spec/fixtures/features.yml
@@ -218,9 +218,6 @@ note_550:
 note_586:
   doc_id: "991012132499760652"
   note: "Dictionary of American history: 586."
-note_588:
-  doc_id: "991012132499760653"
-  note: "Dictionary of American history: 588."
 note_with_501:
   doc_id: "991012132499760654"
   note_with: "Dictionary of American history: 501."


### PR DESCRIPTION
- Mapping for 588a is being removed from cob_index, so the related tests also need to be removed.