### PR TITLE
BL-251 Collection Name facet

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GIT
 
 GIT
   remote: https://github.com/tulibraries/cob_index.git
-  revision: f28d962c2c635607e7cb935719b7b76544e987aa
+  revision: d7b316867de727259e988cf394ead055f907c54b
   branch: main
   specs:
     cob_index (0.1.0)
@@ -215,7 +215,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     confstruct (1.1.0)
       hashie (>= 3.3, < 5)
     crack (0.4.5)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -153,6 +153,7 @@ class CatalogController < ApplicationController
     config.add_facet_field "subject_topic_facet", label: "Topic" , limit: true, show: true, component: true
     config.add_facet_field "subject_era_facet", label: "Era", limit: true, show: true, component: true
     config.add_facet_field "subject_region_facet", label: "Region", limit: true, show: true, component: true
+    config.add_facet_field "collection_ms", label: "Collection Name"
     config.add_facet_field "date_added_facet", label: "Newly Added", query: {
           week_1: { label: "Within Last Week", fq: "date_added_facet:[#{(Date.current - 2.weeks).strftime('%Y%m%d').to_i} TO #{(Date.current - 1.week).strftime('%Y%m%d').to_i}]" },
           months_1: { label: "Within Last Month", fq: "date_added_facet:[#{(Date.current - 1.month).strftime('%Y%m%d').to_i} TO #{(Date.current - 1.week).strftime('%Y%m%d').to_i}]" },
@@ -243,7 +244,7 @@ class CatalogController < ApplicationController
     config.add_show_field "donor_info_ms", label: "Donor bookplate", helper_method: :donor_links, multi: true
     config.add_show_field "subject_display", label: "Subject", helper_method: :subject_links, multi: true
     config.add_show_field "genre_ms", label: "Genre", helper_method: :genre_links, multi: true
-    config.add_show_field "collection_display", label: "Collection"
+    config.add_show_field "collection_ms", label: "Collection"
     config.add_show_field "collection_area_display", label: "SCRC Collecting Area"
 
     # Preceeding Entry fields

--- a/spec/features/indices_spec.rb
+++ b/spec/features/indices_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature "Indices" do
         "Topic",
         "Era",
         "Region",
+        "Collection Name"
         ]
     }
     context "searching shows all facets" do

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -921,7 +921,7 @@ RSpec.feature "RecordPageFields" do
     let (:item_973a) { fixtures.fetch("collection_973_a") }
     scenario "User visits a document with collection 973a" do
       visit "catalog/#{item_973a['doc_id']}"
-      within "dd.blacklight-collection_display" do
+      within "dd.blacklight-collection_ms" do
         expect(page).to have_text(item_973a["collection"])
       end
     end
@@ -929,7 +929,7 @@ RSpec.feature "RecordPageFields" do
     let (:item_973t) { fixtures.fetch("collection_973_t") }
     scenario "User visits a document with collection 973t" do
       visit "catalog/#{item_973t['doc_id']}"
-      within "dd.blacklight-collection_display" do
+      within "dd.blacklight-collection_ms" do
         expect(page).to have_text(item_973t["collection"])
       end
     end


### PR DESCRIPTION
- Adds a facet for collections
- Updates the mapping for both the facet and display field to use collection_ms so that we can create a searchable link on the record page.