### PR TITLE
BL-1615 Collection display field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -208,6 +208,7 @@ class CatalogController < ApplicationController
     config.add_show_field "edition_display", label: "Edition", type: :primary
     config.add_show_field "date_copyright_display", label: "Copyright Notice", type: :primary
     config.add_show_field "phys_desc_display", label: "Physical Description", type: :primary
+    config.add_show_field "collection_ms", label: "Collection", type: :primary, helper_method: :record_page_ms_links, multi: true
     config.add_show_field "title_series_display", label: "Series Title"
     config.add_show_field "title_series_vern_display", label: "Series Title"
     config.add_show_field "volume_series_display", label: "Volume"
@@ -241,10 +242,9 @@ class CatalogController < ApplicationController
     config.add_show_field "note_related_display", label: "Related Materials"
     config.add_show_field "note_accruals_display", label: "Additions to Collection"
     config.add_show_field "note_local_display", label: "Local Note"
-    config.add_show_field "donor_info_ms", label: "Donor bookplate", helper_method: :donor_links, multi: true
+    config.add_show_field "donor_info_ms", label: "Donor bookplate", helper_method: :record_page_ms_links, multi: true
     config.add_show_field "subject_display", label: "Subject", helper_method: :subject_links, multi: true
-    config.add_show_field "genre_ms", label: "Genre", helper_method: :genre_links, multi: true
-    config.add_show_field "collection_ms", label: "Collection"
+    config.add_show_field "genre_ms", label: "Genre", helper_method: :record_page_ms_links, multi: true
     config.add_show_field "collection_area_display", label: "SCRC Collecting Area"
 
     # Preceeding Entry fields

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -434,9 +434,10 @@ module CatalogHelper
     end
   end
 
-  def donor_links(args)
-    args[:document][args[:field]].uniq.map do |donor|
-      link_to(donor, "#{search_catalog_path}?f[donor_info_ms][]=#{CGI.escape donor}")
+  def record_page_ms_links(args)
+    linked_field = [args[:field]].first
+    args[:document][args[:field]].uniq.map do |field|
+      link_to(field, "#{search_catalog_path}?f[#{linked_field}][]=#{CGI.escape field}")
     end
   end
 

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -428,12 +428,6 @@ module CatalogHelper
       .map { |h_subjs| h_subjs.map(&method(:hierarchical_subject_link)).join(separator).html_safe }
   end
 
-  def genre_links(args)
-    args[:document][args[:field]].uniq.map do |genre|
-      link_to(genre, "#{search_catalog_path}?f[genre_ms][]=#{CGI.escape genre}")
-    end
-  end
-
   def record_page_ms_links(args)
     linked_field = [args[:field]].first
     args[:document][args[:field]].uniq.map do |field|

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -461,23 +461,55 @@ RSpec.describe CatalogHelper, type: :helper do
     end
   end
 
-  describe "#genre_links" do
-    context "duplicate genres" do
-      let(:args) {
+  describe "#record_page_ms_links" do
+  context "duplicate genres" do
+    let(:args) {
+        {
+          document:
           {
-            document:
-            {
-              genre_ms: [ "foo", "foo", "bar" ]
-            },
-            field: :genre_ms
-          }
+            genre_ms: [ "foo", "foo", "bar" ]
+          },
+          field: :genre_ms
         }
+      }
 
-      it "filters out duplicate genres" do
-        expect(genre_links(args).count).to eq(2)
-      end
+    it "filters out duplicate genres" do
+      expect(record_page_ms_links(args).count).to eq(2)
     end
   end
+
+  context "donor_info_ms" do
+    let(:args) {
+        {
+          document:
+          {
+            donor_info_ms: ["Lois G. Brodsky"]
+          },
+          field: :donor_info_ms
+        }
+      }
+
+    it "displays donor link" do
+      expect(record_page_ms_links(args)).to have_text("Lois G. Brodsky")
+    end
+  end
+
+  context "collection_ms" do
+    let(:args) {
+        {
+          document:
+          {
+            collection_ms: ["Russell Conwell Book Collection"]
+          },
+          field: :collection_ms
+        }
+      }
+
+    it "displays donor link" do
+      expect(record_page_ms_links(args)).to have_text("Russell Conwell Book Collection")
+    end
+  end
+end
 
   describe "#subject_links(args)" do
     let(:base_path) { "foo" }


### PR DESCRIPTION
- Moves the collection field to the primary field section of the record page
- Adds a new generic method for all _ms fields on record pages (collection, donor_info, genre)