### PR TITLE
BL-1617 Update availability display layout to table for physical items

### DIFF
--- a/app/assets/javascripts/availability.js
+++ b/app/assets/javascripts/availability.js
@@ -8,7 +8,7 @@ $(document).on('turbolinks:load', function() {
 
 	    return this.each(function(){
 	      var $list = $(this),
-	      $children = $list.children().css("display", "flex").filter(function(i){
+	      $children = $list.children().filter(function(i){
 	        return $(this);
 	      }),
 	      type = $list.data("list-type"),

--- a/app/assets/stylesheets/partials/_availability.scss
+++ b/app/assets/stylesheets/partials/_availability.scss
@@ -20,6 +20,41 @@
   font-weight: bold;
 }
 
+.availability-table {
+  width: 100%;
+}
+
+.call-number-col, .description-col {
+  width: 30%;
+}
+
+.material-type-col {
+  width: 15%;
+}
+
+.availability-col {
+  width: 25%;
+}
+
+.availability-table thead {
+  @media(max-width: 768px) {
+  display: none;
+  }
+}
+
+.availability-table td {
+  @media(max-width: 768px) {
+  display: block;
+  padding-top: 0;
+  padding-bottom: 0;
+  border: 0;
+
+  :last-child {
+    padding-bottom: 1rem;
+  }
+  }
+}
+
 /* === RECORD PAGE AVAILABILITY === */
 #availability-heading {
   color: $red;

--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -86,7 +86,7 @@ module AvailabilityHelper
   end
 
   def description(item)
-    item["description"] ? "Description: #{item['description']}" : ""
+    item["description"] ? "#{item['description']}" : ""
   end
 
   def material_type(item)
@@ -100,6 +100,7 @@ module AvailabilityHelper
   end
 
   def public_note(item)
+    item["description"] ? "; " : ""
     item["public_note"] ? "Note: #{item['public_note']}" : ""
   end
 
@@ -162,13 +163,13 @@ module AvailabilityHelper
     }.uniq
      .join(", ")
 
-    summary_list.present? ? "Description: #{summary_list}" : ""
+    summary_list.present? ? "Summary: #{summary_list}" : ""
   end
 
   def render_holdings_summary(items)
     items.collect { |item|
       if item["summary"].present?
-        "Description: " + item["summary"]
+        "Summary: " + item["summary"]
       else
         "We are unable to find availability information for this record. Please contact the library for more information."
       end

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -13,29 +13,37 @@
 <% unless @document_availability.all?(&:empty?) %>
 <% sort_order_for_holdings(@document_availability).each do |key, locations| %>
   <% locations.each do |location, items| %>
-    <div data-long-list class="m-0" data-controller="availability">
-      <div class="d-lg-flex table-heading ml-0 mb-0 border-bottom border-top border-header-grey bg-header-grey justify-content-lg-between avail-list">
-        <h3 class="library-name card-title row-sm col-md"><%= library_name_from_short_code(key) %> - <%= location_name_from_short_codes(location, key) %></h3>
-        <div class="holdings-summary row-sm col-md"><%= summary_list(items) %></div>
+    <div class="m-0" data-controller="availability">
+      <div class="table-heading ml-0 mb-0 border-bottom border-top border-header-grey bg-header-grey">
+        <h3 class="library-name card-title"><%= library_name_from_short_code(key) %> - <%= location_name_from_short_codes(location, key) %></h3>
+        <div class="holdings-summary"><p><%= summary_list(items) %></p></div>
       </div>
 
       <%= library_specific_instructions(key, @document) %>
 
+      <table class="table availability-table border-0 px-2">
+        <thead>
+        <tr>
+          <th class="call-number-col">Call Number</th>
+          <th class="description-col">Description</th>
+          <th class="material-type-col">Type</th>
+          <th class="availability-col">Availability</th>
+        </tr>
+        </thead>
+      <tbody data-long-list>
       <% items.each do |item| %>
-        <div class="item-info row avail-info-rows border-bottom border-header-grey p-sm-0 m-0 p-md-2">
-          <div class="row-md col-lg"><%= alternative_call_number(item) %></div>
-          <div class="row-md col-lg">
-            <span><%= description(item) %></span>
-            <span><%= public_note(item) %></span>
-            <span><%= material_type(item) %></span>
-          </div>
-
-          <div class="d-sm-flex flex-md-column avail_status-container">
+        <tr>
+          <td><%= alternative_call_number(item) %></td>
+          <td><%= description(item) %><%= public_note(item) %></td>
+          <td><%= material_type(item) %></td>
+          <td>
             <div class="avail_status"><%= item.fetch("availability", "") %></div>
-          </div>
-        </div>
+          </td>
+        </tr>
       <% end %>
-    </div>
+      </tbody>
+      </table>
+
   <% end %>
   <% end %>
 

--- a/app/views/catalog/_physical_availability_card.html.erb
+++ b/app/views/catalog/_physical_availability_card.html.erb
@@ -6,31 +6,40 @@
 <% unless @document_availability.all?(&:empty?) %>
   <% sort_order_for_holdings(@document_availability).each do |key, locations| %>
   <% locations.each do |location, items| %>
-    <div data-long-list class="m-0" data-controller="availability">
-      <div class="d-lg-flex table-heading ml-0 mb-0 border-bottom border-top border-header-grey bg-header-grey justify-content-lg-between avail-list">
-        <h3 class="library-name card-title row-sm col-md"><%= library_name_from_short_code(key) %> - <%= location_name_from_short_codes(location, key) %></h3>
-        <div class="holdings-summary row-sm col-md"><%= summary_list(items) %></div>
+    <div class="m-0" data-controller="availability">
+      <div class="table-heading ml-0 mb-0 border-bottom border-top border-header-grey bg-header-grey">
+        <h3 class="library-name card-title"><%= library_name_from_short_code(key) %> - <%= location_name_from_short_codes(location, key) %></h3>
+        <div class="holdings-summary"><p><%= summary_list(items) %></p></div>
       </div>
 
       <%= library_specific_instructions(key, document) %>
 
+      <table class="table availability-table border-0 px-2"">
+        <thead>
+        <tr>
+          <th class="call-number-col">Call Number</th>
+          <th class="description-col">Description</th>
+          <th class="material-type-col">Type</th>
+          <th class="availability-col">Availability</th>
+        </tr>
+        </thead>
+        <tbody data-long-list>
       <% items.each do |item| %>
-        <div class="item-info row avail-info-rows border-bottom border-header-grey p-sm-0 m-0">
-          <div class="row-md col-lg"><%= alternative_call_number(item) %></div>
-          <div class="row-md col-lg">
-            <span><%= description(item) %></span>
-            <span><%= public_note(item) %></span>
-            <span><%= material_type(item) %></span>
-          </div>
-
-          <div class="d-sm-flex flex-md-column align-self-start avail-spinner-container">
-            <div class="spinner mr-2">
+        <tr>
+          <td><%= alternative_call_number(item) %></td>
+          <td><%= description(item) %><%= public_note(item) %></td>
+          <td><%= material_type(item) %></td>
+          <td>
+            <div class="spinner">
               <span class="fa fa-spinner" aria-busy="true" aria-live="polite"></span>
               <span>Loading Availability</span>
             </div>
-          </div>
-        </div>
+          </td>
+        </tr>
       <% end %>
+      </tbody>
+      </table>
+
     </div>
   <% end %>
   <% end %>

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -32,8 +32,8 @@ RSpec.feature "RecordPageFields" do
 
     scenario "items with more than 5 locations should be truncated with a more link" do
       visit  "catalog/#{item["doc_id"]}"
-      expect(page).to have_css("div", text: "Description: 1960, pt.1", visible: true)
-      expect(page).to have_css("div", text: "Description: 1965, pt.4", visible: false)
+      expect(page).to have_css("td", text: "1960, pt.1", visible: true)
+      expect(page).to have_css("td", text: "1965, pt.4", visible: false)
     end
   end
 

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
       let(:item) { { "description" => "v. 1" } }
 
       it "displays description" do
-        expect(description(item)).to eq "Description: v. 1"
+        expect(description(item)).to eq "v. 1"
       end
     end
 
@@ -860,7 +860,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
 
       it "returns copies for each library by description" do
         sorted_descriptions = sort_order_for_holdings(grouped_items)["MAIN"]["stacks"].map { |item| description(item) }
-        expect(sorted_descriptions).to eq(["Description: v.42 (2004)", "Description: v.53 (2016)", "Description: v.55, no.5 (Nov. 2017)"])
+        expect(sorted_descriptions).to eq(["v.42 (2004)", "v.53 (2016)", "v.55, no.5 (Nov. 2017)"])
       end
     end
   end

--- a/spec/javascript/packs/controllers/availability_controller.spec.js
+++ b/spec/javascript/packs/controllers/availability_controller.spec.js
@@ -7,7 +7,7 @@ describe('AvailabilityController', () => {
 
   	    return this.each(function(){
   	      var $list = $(this),
-  	      $children = $list.children().css("display", "flex").filter(function(i){
+  	      $children = $list.children().filter(function(i){
   	        return $(this);
   	      }),
   	      type = $list.data("list-type"),


### PR DESCRIPTION
Updates in this PR include: 
- Moving the placement of the holdings summary to appear under library/location rather than to the right
- Adding table structure and labels for column sections: “Call Number,” “Description,” “Type”, and “Availability”
- Removing prepended labels from item data (ex. "Description: ")
- Modifying JS long list truncation to work with new structure
- Adding some CSS to flatten table structure in mobile view 

This changes do not include broader styling updates (ex. color, fonts) yet. 