### PR TITLE
BL-1587: Fix regression, no redirect for SAML auth.

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -23,11 +23,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def saml
     auth = request.env["omniauth.auth"]
-
-    # Debugging code
-    # TODO: Remove once we fix k8 authentication
-    doc = Nokogiri::XML auth.extra.response_object.response
-    logger.info(doc.to_xml.pretty_inspect)
+    omniauth_params = request.env["omniauth.params"]
 
     auth.uid = auth.extra.raw_info["urn:oid:2.16.840.1.113730.3.1.3"]
     @user = User.from_omniauth(auth)
@@ -37,7 +33,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     session[:alma_sso_user] = @user.uid
     session[:alma_sso_token] = SecureRandom.hex(10)
     set_flash_message(:success, :success, kind: "Temple Single Sign On") if is_navigational_format?
-    redirect_to params[:target] || helpers.users_account_path
+    redirect_to omniauth_params["target"] || helpers.users_account_path
   end
 
   def failure

--- a/spec/controllers/users/omniauth_callback_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callback_controller_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Users::OmniauthCallbacksController, type: :controller do
+  describe "SAML Auth" do
+    before(:each) do
+      request.env["devise.mapping"] = Devise.mappings[:user]
+      auth = OmniAuth.config.mock_auth[:default]
+      auth.extra = OpenStruct.new(raw_info: { "urn:oid:2.16.840.1.113730.3.1.3": "foo" })
+      request.env["omniauth.auth"] = auth
+    end
+
+
+    context "A target redirect is defined" do
+      it "redirects to the target" do
+        request.env["omniauth.params"] = { "target" => "foobar" }
+        get :saml
+        expect(response.status).to redirect_to("foobar")
+      end
+    end
+
+    context "A target redirect is not defined" do
+      it "redirects to account page" do
+        request.env["omniauth.params"] = {}
+        get :saml
+        expect(response.status).to redirect_to("/users/account")
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
* Fixes redirects back to searched document after authentication via
  SAML.
* Remove debugging code.
* Adds controller spec for SAML auth.