### PR TITLE
BL-1638 Online Availability

### DIFF
--- a/app/assets/stylesheets/partials/_availability.scss
+++ b/app/assets/stylesheets/partials/_availability.scss
@@ -190,7 +190,7 @@ button.btn-warning:visited {
   text-align: center;
   width: 10rem;
   border-radius: 0;
-  padding: 0.375rem 0.5rem; 
+  padding: 0.375rem 0.5rem;
   span.avail-label.not-available {
   	font-size: 0.9375rem;
   }
@@ -225,6 +225,7 @@ button.available, button.available:focus, button.available:hover, button.availab
 }
 
 .bl_alma_iframe {
+  border: 0;
   width: 100%;
 }
 

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -278,7 +278,7 @@ module CatalogHelper
       render partial: "availability_panel", locals: { label: field.label, rows: rows }
 
     elsif current_user && !current_user.can_purchase_order?
-      content_tag :div, t("purchase_order.purchase_order_allowed"), class: "availability border border-header-grey"
+      content_tag :div, t("purchase_order.purchase_order_allowed"), class: "availability"
     else
       render_purchase_order_button(document: doc, config: field)
     end
@@ -481,8 +481,14 @@ module CatalogHelper
     title = field.fetch("title", "Find it online")
     electronic_notes = render_electronic_notes(field)
 
-    item_html = [render_alma_eresource_link(field["portfolio_id"], title), field["subtitle"]]
-      .select(&:present?).join(" - ")
+    item_html =
+      if field["subtitle"].present?
+        [render_alma_eresource_link(field["portfolio_id"], field["subtitle"]), title]
+          .select(&:present?).join(" - ")
+      else
+        [render_alma_eresource_link(field["portfolio_id"], title), field["subtitle"]]
+          .select(&:present?).join(" - ")
+      end
     item_html = [item_html, electronic_notes]
       .select(&:present?).join(" ").html_safe
 

--- a/app/views/catalog/_online_availability_button.html.erb
+++ b/app/views/catalog/_online_availability_button.html.erb
@@ -4,7 +4,7 @@
     <span class="avail-label" aria-expanded="false">Available online</span>
   </button>
   <div id="online-document-<%= document.id %>" class="collapse online_resources online-list">
-    <div class="list_elec_links search_results_table w-100 border border-dark-blue border-bottom-0">
+    <div class="list_elec_links search_results_table w-100">
       <%= links %>
       <span class="border-bottom"></span>
     </div>

--- a/app/views/primo_central/_direct_link.html.erb
+++ b/app/views/primo_central/_direct_link.html.erb
@@ -1,4 +1,4 @@
-<div class="record-page-online-list border border-bottom-0 direct-link">
+<div class="record-page-online-list direct-link">
   <div class="electronic_links online-list-item">
     <%= link_to document_link_label, document_link, class: "electronic_links"  %>
   </div>

--- a/app/views/primo_central/_show_availability_section.html.erb
+++ b/app/views/primo_central/_show_availability_section.html.erb
@@ -4,10 +4,9 @@
 
 <div class="col-sm-12 p-0">
   <div id="record-view-iframe"  class="card border-0">
-    <div class="online-border"></div>
     <div class="availability_iframe physical-holding-panel card-body p-0">
-      <h3 class="online-card-heading mb-0 border border-dark-blue">Online</h3>
-      <div class="primo-online-card-body">
+      <h3 class="online-card-heading mb-0">Online</h3>
+      <div class="primo-online-card-body ">
         <% availability_link_partials.each do |partial| %>
           <%= render(partial) %>
         <% end %>

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe CatalogHelper, type: :helper do
 
       it "should render purchase allow message" do
         expect(helper).to have_received(:content_tag).with(
-          :div, t("purchase_order.purchase_order_allowed"), class: "availability border border-header-grey"
+          :div, t("purchase_order.purchase_order_allowed"), class: "availability"
         )
       end
     end
@@ -400,8 +400,18 @@ RSpec.describe CatalogHelper, type: :helper do
       } }
 
       it "displays additional information as plain text" do
+        expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Text", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(electronic_resource_link_builder(field)).to have_text("Sample Name")
+      end
+    end
+
+    context "porfolio_id, title, and subtitle is not present present" do
+      let(:field) { {
+        "portfolio_id" => "77777", "title" => "Sample Name"
+      } }
+
+      it "displays additional information as plain text" do
         expect(electronic_resource_link_builder(field)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
-        expect(electronic_resource_link_builder(field)).to have_text("Sample Text")
       end
     end
 


### PR DESCRIPTION
- Removes borders from search results and record pages
- Coverage statement appears first and is the link for items that have it.