### PR TITLE
BL-818 Non-circulating items

### DIFF
--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -27,13 +27,10 @@ module AvailabilityHelper
     elsif item.item_data["awaiting_reshelving"]
       content_tag(:span, "", class: "close-icon") + "Awaiting Reshelving"
     elsif item.in_place? && item.item_data["requested"] == false
-      if item.non_circulating? || item.location == "reserve" ||
-          item.circulation_policy == "Bound Journal"
+      if non_circulating_items(item)
         content_tag(:span, "", class: "check") + "Available" +
         content_tag(:p, "", class: "mt-1") +
-        content_tag(:div, data: { toggle: "tooltip", placement: "bottom", container: "body" }, title: "#{t('tooltip.online_only')}", tabindex: "0", class: "info-tooltip") do
-          content_tag(:span, "", class: "information-icon") + "Onsite only"
-        end
+        content_tag(:span, "", data: { toggle: "tooltip", placement: "bottom", container: "body" }, title: "#{t('tooltip.online_only')}", tabindex: "0", class: "information-icon") + "Onsite only"
       else
         content_tag(:span, "", class: "check") + "Available"
       end
@@ -42,6 +39,14 @@ module AvailabilityHelper
     else
       unavailable_items(item)
     end
+  end
+
+  def non_circulating_items(item)
+    item.non_circulating? ||
+    item.location == "reserve" ||
+    item.circulation_policy == "Bound Journal" ||
+    item.circulation_policy == "Music Restricted" ||
+    item.physical_material_type["desc"] == "Issue" && item.holding_library == "KARDON"
   end
 
   def unavailable_items(item)

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
       end
 
       it "displays library use only" do
-        expect(availability_status(item)).to include("<span class=\"information-icon\"></span>Onsite only")
+        expect(availability_status(item)).to include("Onsite only")
       end
     end
 
@@ -79,7 +79,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
       end
 
       it "displays library use only" do
-        expect(availability_status(item)).to include("<span class=\"information-icon\"></span>Onsite only")
+        expect(availability_status(item)).to include("Onsite only")
       end
     end
 
@@ -97,7 +97,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
       end
 
       it "displays library use only" do
-        expect(availability_status(item)).to include("<span class=\"information-icon\"></span>Onsite only")
+        expect(availability_status(item)).to include("Onsite only")
       end
     end
 
@@ -115,7 +115,7 @@ RSpec.describe AvailabilityHelper, type: :helper do
       end
 
       it "displays as available" do
-        expect(availability_status(item)).to eq "<span class=\"check\"></span>Available"
+        expect(availability_status(item)).to include("Onsite only")
       end
     end
 
@@ -193,6 +193,38 @@ RSpec.describe AvailabilityHelper, type: :helper do
 
       it "displays 'Awaiting Reshelving' status" do
         expect(availability_status(item)).to eq "<span class=\"close-icon\"></span>Awaiting Reshelving"
+      end
+    end
+  end
+
+  describe "#non_circulating_items(item)" do
+    context "item is an issue in KARDON" do
+      let(:item) do
+        Alma::BibItem.new("item_data" =>
+           { "physical_material_type" =>
+             { "value" => "ISSUE", "desc" => "Issue" },
+             "library" =>
+             { "value" => "KARDON", "desc" => "Remote Storage" }
+           }
+         )
+      end
+      it "returns true" do
+        expect(non_circulating_items(item)).to eq true
+      end
+    end
+
+    context "item is an issue in MAIN" do
+      let(:item) do
+        Alma::BibItem.new("item_data" =>
+           { "physical_material_type" =>
+             { "value" => "ISSUE", "desc" => "Issue" },
+             "library" =>
+             { "value" => "MAIN", "desc" => "Charles Library" }
+           }
+         )
+      end
+      it "returns true" do
+        expect(non_circulating_items(item)).to eq false
       end
     end
   end


### PR DESCRIPTION
- Adds a few more items to the non-circulations status.  As a result of this, I broke this out into a new method and added some specs
- Cleaned up the display for non-circulating items