### PR TITLE
BL-1638 Adjust online availability border styling to avoid double line in search results

### DIFF
--- a/app/assets/stylesheets/partials/_availability.scss
+++ b/app/assets/stylesheets/partials/_availability.scss
@@ -105,7 +105,7 @@ dd .online-list-items {
 }
 
 .online-list-items, .online-list-item {
-  border-bottom: 0.0625rem solid $gray-300;
+  border-top: 0.0625rem solid $gray-300;
   padding: .5rem;
 }
 

--- a/app/views/catalog/_hathitrust_button.html.erb
+++ b/app/views/catalog/_hathitrust_button.html.erb
@@ -4,8 +4,7 @@
 </button>
 <div id="online-document-<%= document.id %>" class="collapse online_resources online-list mt-1">
   <h3 class="online-card-heading card-title mb-0">Online</h3>
-  <div class="list_elec_links search_results_table w-100 border-bottom-0">
+  <div class="list_elec_links search_results_table w-100">
     <%= links %>
-    <span class="border-bottom"></span>
   </div>
 </div>

--- a/app/views/catalog/_online_availability.html.erb
+++ b/app/views/catalog/_online_availability.html.erb
@@ -2,7 +2,7 @@
   <div id="record-page-online" class="mb-0">
     <h3 class="online-card-heading card-title mb-0">Online</h3>
       <% online_resources.each do |value| %>
-        <div class="record-page-online-list border-bottom-0"><%= safe_join([value]) %></div>
+        <div class="record-page-online-list border-bottom"><%= safe_join([value]) %></div>
       <% end %>
   </div>
 </div>

--- a/app/views/catalog/_online_availability_button.html.erb
+++ b/app/views/catalog/_online_availability_button.html.erb
@@ -7,7 +7,6 @@
     <h3 class="online-card-heading card-title mb-0">Online</h3>
     <div class="list_elec_links search_results_table w-100">
       <%= links %>
-      <span class="border-bottom"></span>
     </div>
   </div>
 <% elsif has_one_electronic_resource?(document) %>


### PR DESCRIPTION
This PR fixes this double gray line issue: 
<img width="1211" alt="Screen Shot 2022-04-18 at 9 54 36 AM" src="https://user-images.githubusercontent.com/23346046/163863162-5ba1511a-16cf-494c-b12c-59fddae19beb.png">

