### PR TITLE
BL-1621 Fix Google Analytics event tracking for search results request button

### DIFF
--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -3,8 +3,8 @@
 module RequestHelper
   include Blacklight::CatalogHelperBehavior
 
-  def request_modal(mms_id, pickup_locations, request_level)
-    link_to(t("requests.request_button"), "#", id: "request-btn-#{mms_id}", class: "btn request-btn record-page-request-btn", data: { "blacklight-modal": "trigger", "action": "availability#modal show#loading", "availability-target": "href", "show-target": "href" })
+  def request_modal(mms_id, pickup_locations, request_level, request_page_type)
+    link_to(t("requests.request_button"), "#", id: "request-btn-#{mms_id}", class: "btn request-btn #{request_page_type}-request-btn", data: { "blacklight-modal": "trigger", "action": "availability#modal show#loading", "availability-target": "href", "show-target": "href" })
   end
 
   def request_redirect_url(mms_id)

--- a/app/views/catalog/_index_availability_section.html.erb
+++ b/app/views/catalog/_index_availability_section.html.erb
@@ -14,7 +14,7 @@
 
           <div id="requests-container-<%= document.id %>" class="hidden requests-container" data-availability-target="request">
             <% if user_signed_in? %>
-              <%= request_modal(document.id, @pickup_locations, @request_level) %>
+              <%= request_modal(document.id, @pickup_locations, @request_level, "search-results") %>
             <% else %>
               <%= link_to(t("requests.request_button"), doc_redirect_url(document.id),  data: {"blacklight-modal": "trigger"}, class: "btn search-results-request-btn") %>
             <% end %>

--- a/app/views/catalog/_show_availability_section.html.erb
+++ b/app/views/catalog/_show_availability_section.html.erb
@@ -15,7 +15,7 @@
         <h2 class="sr-only availability-section"><%= "Availability" %></h2>
         <div id="requests-container" class="hidden">
           <% if user_signed_in? %>
-            <%= request_modal(document.id, @pickup_locations, @request_level) %>
+            <%= request_modal(document.id, @pickup_locations, @request_level, "record-page") %>
           <% else %>
           <%= link_to(t("requests.request_button"), doc_redirect_url(document.id),  data: {"blacklight-modal": "trigger"}, class: "btn record-page-request-btn request-btn") %>
           <% end %>


### PR DESCRIPTION
When logged in, the search results request button still had the class "record-page-request-btn" due to dual use of request_modal helper method. I've updated this method so that it can have different classes on record page and search results view pages. 