### PR TITLE
Allow local development using m1 mac.

### DIFF
--- a/.docker/app/Dockerfile.prod
+++ b/.docker/app/Dockerfile.prod
@@ -1,4 +1,8 @@
-FROM harbor.k8s.temple.edu/library/ruby:2.7-alpine
+# Allow base image override
+ARG BASE_IMAGE="harbor.k8s.temple.edu/library/ruby:2.7-alpine"
+
+# hadolint ignore=DL3006,DL3026
+FROM "${BASE_IMAGE}"
 
 WORKDIR /app
 
@@ -9,18 +13,18 @@ USER root
 ARG SECRET_KEY_BASE
 
 RUN apk add -U --no-cache \
-      bash=5.1.16-r0 \
+      bash=5.1.16-r2 \
       tzdata=2022a-r0 \
-      mariadb-connector-c=3.1.13-r2 \
+      mariadb-connector-c=3.1.13-r4 \
       libxslt=1.1.35-r0 \
-      shared-mime-info=2.1-r0 && \
+      shared-mime-info=2.2-r0 && \
     apk add -U --no-cache --virtual build-dependencies \
       build-base=0.5-r2 \
-      git=2.34.2-r0 \
-      mariadb-dev=10.6.7-r0 \
+      git=2.36.1-r0 \
+      mariadb-dev=10.6.8-r0 \
       libxslt-dev=1.1.35-r0 \
-      nodejs=16.14.2-r0 \
-      yarn=1.22.17-r0 && \
+      nodejs=16.15.0-r1 \
+      yarn=1.22.19-r0 && \
     gem install bundler:2.3.7 && \
     bundle config build.nokogiri --use-system-libraries && \
     bundle config set --local without "development test" && \

--- a/.docker/app/Dockerfile.prod
+++ b/.docker/app/Dockerfile.prod
@@ -21,7 +21,7 @@ RUN apk add -U --no-cache \
       shared-mime-info=2.2-r0  \
       tzdata=2022a-r0 && \
     apk add -U --no-cache --virtual build-dependencies \
-      build-base=0.5-r2 \
+      build-base=0.5-r3 \
       git=2.36.1-r0 \
       libxslt-dev=1.1.35-r0 \
       mariadb-dev=10.6.8-r0 \

--- a/.docker/app/Dockerfile.prod
+++ b/.docker/app/Dockerfile.prod
@@ -12,21 +12,21 @@ USER root
 
 ARG SECRET_KEY_BASE
 
+# libc6-compat is required for m1 build.
 RUN apk add -U --no-cache \
       bash=5.1.16-r2 \
-      tzdata=2022a-r0 \
-      mariadb-connector-c=3.1.13-r4 \
+      libc6-compat \
       libxslt=1.1.35-r0 \
-      shared-mime-info=2.2-r0 && \
+      mariadb-connector-c=3.1.13-r4 \
+      shared-mime-info=2.2-r0  \
+      tzdata=2022a-r0 && \
     apk add -U --no-cache --virtual build-dependencies \
       build-base=0.5-r2 \
       git=2.36.1-r0 \
-      mariadb-dev=10.6.8-r0 \
       libxslt-dev=1.1.35-r0 \
+      mariadb-dev=10.6.8-r0 \
       nodejs=16.15.0-r1 \
       yarn=1.22.19-r0 && \
-    gem install bundler:2.3.7 && \
-    bundle config build.nokogiri --use-system-libraries && \
     bundle config set --local without "development test" && \
     bundle install --jobs=8 && \
     find "$GEM_HOME" -name yarn.lock -exec rm "{}" \; && \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,7 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     ffi (1.15.5)
+    ffi (1.15.5-x64-unknown)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -619,7 +620,9 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
+  arm64-darwin
   ruby
+  unknown
 
 DEPENDENCIES
   alma!
@@ -704,4 +707,4 @@ DEPENDENCIES
   webpacker (= 6.0.0.rc.6)
 
 BUNDLED WITH
-   2.3.7
+   2.3.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -620,6 +620,7 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin
   ruby
   unknown

--- a/Makefile
+++ b/Makefile
@@ -67,16 +67,17 @@ ci-bundle-install:
 ci-yarn-install:
 	$(DOCKER) exec app yarn install --frozen-lockfile
 
-BASE_IMAGE ?= harbor.k8s.temple.edu/library/ruby:3.1.0-alpine
+BASE_IMAGE ?= harbor.k8s.temple.edu/library/ruby:2.7-alpine
 IMAGE ?= tulibraries/tul_cob
 VERSION ?= $(DOCKER_IMAGE_VERSION)
 HARBOR ?= harbor.k8s.temple.edu
 CLEAR_CACHES=no
 CI ?= false
-PLATFORM ?= x86_64
+PLATFORM ?= linux/aarch64
 
 run:
 	@docker run --name=cob -p 127.0.0.1:3001:3000/tcp \
+		--platform $(PLATFORM) \
 		-e "ALMA_API_KEY=$(ALMA_API_KEY)" \
 		-e "ALMA_AUTH_SECRET=$(ALMA_AUTH_SECRET)" \
 		-e "ALMA_DELIVERY_DOMAIN=$(ALMA_DELIVERY_DOMAIN)" \

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ci-bundle-install:
 ci-yarn-install:
 	$(DOCKER) exec app yarn install --frozen-lockfile
 
-BASE_IMAGE ?= "ruby:2.7-alpine"
+BASE_IMAGE ?= harbor.k8s.temple.edu/library/ruby:3.1.0-alpine
 IMAGE ?= tulibraries/tul_cob
 VERSION ?= $(DOCKER_IMAGE_VERSION)
 HARBOR ?= harbor.k8s.temple.edu

--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,13 @@ ci-bundle-install:
 ci-yarn-install:
 	$(DOCKER) exec app yarn install --frozen-lockfile
 
+BASE_IMAGE ?= "ruby:2.7-alpine"
 IMAGE ?= tulibraries/tul_cob
 VERSION ?= $(DOCKER_IMAGE_VERSION)
 HARBOR ?= harbor.k8s.temple.edu
 CLEAR_CACHES=no
 CI ?= false
+PLATFORM ?= x86_64
 
 run:
 	@docker run --name=cob -p 127.0.0.1:3001:3000/tcp \
@@ -104,6 +106,8 @@ run:
 
 build:
 	@docker build --build-arg SECRET_KEY_BASE=$(SECRET_KEY_BASE) \
+    --build-arg BASE_IMAGE=$(BASE_IMAGE) \
+		--platform $(PLATFORM) \
 		--tag $(HARBOR)/$(IMAGE):$(VERSION) \
 		--tag $(HARBOR)/$(IMAGE):latest \
 		--file .docker/app/Dockerfile.prod \

--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ If Docker is available, we defined a Makefile with many useful commands.
 * To load sample data, run ```DO_INGEST=yes make up``` or ```make load-data```
 * To reload solr configs, run ```make reload-configs```
 * To attatch to the running app container (good for debugging) ```make attach```
-* To build prod image: ```make build ASSETS_PRECOMPILE=yes```
+* To build prod image: ```make build ASSETS_PRECOMPILE=yes PLATFORM=arm64 BUILD_IMAGE=ruby:3.1.0-alpine```
   * `ASSETS_PRECOMPILE=no` by default
+  * `PLATFORM=x86_64` by default
+  * `BASE_IMAGE=harbor.k8s.temple.edu/library/ruby:3.1.0-alpine` by default
 * To deploy prod image: ```make deploy VERSION=x```  VERSION=latest by default
 * To run security check on image: ```make secure``` depends on trivy (brew install aquasecurity/trivy/trivy)
 * To run a shell with image: ```make shell```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ We need to run two commands in separate terminal windows in order to start the a
 bundle exec rake server
 ```
 
+#### Platform Considerations
+If building a docker image on m1/arm64 chip set PLATFORM env to PLATFORM=arm64 so that docker pulls an arm64 image compatible with your system.
+
 ### Start the Application with some sample data for Development
 
 You can also have it ingest a few thousand sample records by setting the


### PR DESCRIPTION
This adds m1 platform specific changes to allow local deevelopment using
m1 computer.  This does not change how application works for non m1 macs
etc.

This fixes m1 issues for building production image using
`make build` and `make run`

This also fixes issue for regular local dev using `bundle install`

This does not fix issue for docker-compose in local development.  That
is still a TODO.