### PR TITLE
fix build and scan errors related to Rails upgrade

### DIFF
--- a/.docker/app/Dockerfile.prod
+++ b/.docker/app/Dockerfile.prod
@@ -30,8 +30,8 @@ RUN apk add -U --no-cache \
     bundle config set --local without "development test" && \
     bundle install --jobs=8 && \
     find "$GEM_HOME" -name yarn.lock -exec rm "{}" \; && \
-    touch config/alma.yml && \
-    touch config/bento.yml && \
+    cp config/alma.yml.example config/alma.yml && \
+    cp config/bento.yml.example config/bento.yml && \
     RAILS_ENV=production SECRET_KEY_BASE=$SECRET_KEY_BASE bundle exec rails assets:precompile && \
     rm -rf node_modules && \
     rm -rf tmp/* && \

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem "rails", "6.1.5"
+gem "rails", "6.1.6"
 gem "railties"
 # Use Puma as the app server
 gem "puma", "5.6.4"
@@ -87,7 +87,7 @@ gem "hashie", "~>4.1.0"
 gem "blacklight_alma", git: "https://github.com/tulibraries/blacklight_alma.git", branch: "main"
 gem "ezwadl"
 gem "awesome_print"
-gem "bento_search", git: "https://github.com/tulibraries/bento_search.git", branch: "allow-rails-6"
+gem "bento_search"
 gem "omniauth"
 gem "omniauth-rails_csrf_protection"
 gem "omniauth-shibboleth"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,22 +29,6 @@ GIT
       xml-simple
 
 GIT
-  remote: https://github.com/tulibraries/bento_search.git
-  revision: 27eb872141705b03a3aced16e371a4a9dbf70a49
-  branch: allow-rails-6
-  specs:
-    bento_search (1.8.0)
-      confstruct (~> 1.0)
-      htmlentities
-      httpclient (>= 2.2.5, < 3.0.0)
-      language_list (~> 1.0)
-      multi_json (>= 1.0.4, < 2.0)
-      nokogiri
-      openurl (>= 0.3.1, < 1.1)
-      rails (>= 3.2.3, < 7)
-      summon
-
-GIT
   remote: https://github.com/tulibraries/blacklight_alma.git
   revision: 2c45022e573e1f461dcfa8549fe5a1c5b186ae29
   branch: main
@@ -129,60 +113,60 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (6.1.5)
-      actionpack (= 6.1.5)
-      activesupport (= 6.1.5)
+    actioncable (6.1.6)
+      actionpack (= 6.1.6)
+      activesupport (= 6.1.6)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailbox (6.1.5)
-      actionpack (= 6.1.5)
-      activejob (= 6.1.5)
-      activerecord (= 6.1.5)
-      activestorage (= 6.1.5)
-      activesupport (= 6.1.5)
+    actionmailbox (6.1.6)
+      actionpack (= 6.1.6)
+      activejob (= 6.1.6)
+      activerecord (= 6.1.6)
+      activestorage (= 6.1.6)
+      activesupport (= 6.1.6)
       mail (>= 2.7.1)
-    actionmailer (6.1.5)
-      actionpack (= 6.1.5)
-      actionview (= 6.1.5)
-      activejob (= 6.1.5)
-      activesupport (= 6.1.5)
+    actionmailer (6.1.6)
+      actionpack (= 6.1.6)
+      actionview (= 6.1.6)
+      activejob (= 6.1.6)
+      activesupport (= 6.1.6)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (6.1.5)
-      actionview (= 6.1.5)
-      activesupport (= 6.1.5)
+    actionpack (6.1.6)
+      actionview (= 6.1.6)
+      activesupport (= 6.1.6)
       rack (~> 2.0, >= 2.0.9)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (6.1.5)
-      actionpack (= 6.1.5)
-      activerecord (= 6.1.5)
-      activestorage (= 6.1.5)
-      activesupport (= 6.1.5)
+    actiontext (6.1.6)
+      actionpack (= 6.1.6)
+      activerecord (= 6.1.6)
+      activestorage (= 6.1.6)
+      activesupport (= 6.1.6)
       nokogiri (>= 1.8.5)
-    actionview (6.1.5)
-      activesupport (= 6.1.5)
+    actionview (6.1.6)
+      activesupport (= 6.1.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (6.1.5)
-      activesupport (= 6.1.5)
+    activejob (6.1.6)
+      activesupport (= 6.1.6)
       globalid (>= 0.3.6)
-    activemodel (6.1.5)
-      activesupport (= 6.1.5)
-    activerecord (6.1.5)
-      activemodel (= 6.1.5)
-      activesupport (= 6.1.5)
-    activestorage (6.1.5)
-      actionpack (= 6.1.5)
-      activejob (= 6.1.5)
-      activerecord (= 6.1.5)
-      activesupport (= 6.1.5)
+    activemodel (6.1.6)
+      activesupport (= 6.1.6)
+    activerecord (6.1.6)
+      activemodel (= 6.1.6)
+      activesupport (= 6.1.6)
+    activestorage (6.1.6)
+      actionpack (= 6.1.6)
+      activejob (= 6.1.6)
+      activerecord (= 6.1.6)
+      activesupport (= 6.1.6)
       marcel (~> 1.0)
       mini_mime (>= 1.1.0)
-    activesupport (6.1.5)
+    activesupport (6.1.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -195,6 +179,16 @@ GEM
       execjs (~> 2)
     awesome_print (1.9.2)
     bcrypt (3.1.17)
+    bento_search (2.0.0.rc1)
+      confstruct (~> 1.0)
+      htmlentities
+      httpclient (>= 2.2.5, < 3.0.0)
+      language_list (~> 1.0)
+      multi_json (>= 1.0.4, < 2.0)
+      nokogiri
+      openurl (>= 0.3.1, < 1.1)
+      rails (>= 5.2, < 7)
+      summon
     bindex (0.8.1)
     blacklight (7.19.2)
       deprecation
@@ -330,7 +324,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.6.1)
+    json (2.6.2)
     jsonpath (1.1.0)
       multi_json
     jwt (1.5.6)
@@ -356,7 +350,7 @@ GEM
     llhttp-ffi (0.4.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    loofah (2.17.0)
+    loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -375,7 +369,7 @@ GEM
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.15.0)
+    minitest (5.16.0)
     msgpack (1.5.1)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -384,6 +378,10 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.13.6-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.13.6-arm64-darwin)
       racc (~> 1.4)
     okcomputer (1.18.4)
     omniauth (2.0.4)
@@ -417,7 +415,7 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
     rack-protection (2.2.0)
@@ -426,20 +424,20 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (6.1.5)
-      actioncable (= 6.1.5)
-      actionmailbox (= 6.1.5)
-      actionmailer (= 6.1.5)
-      actionpack (= 6.1.5)
-      actiontext (= 6.1.5)
-      actionview (= 6.1.5)
-      activejob (= 6.1.5)
-      activemodel (= 6.1.5)
-      activerecord (= 6.1.5)
-      activestorage (= 6.1.5)
-      activesupport (= 6.1.5)
+    rails (6.1.6)
+      actioncable (= 6.1.6)
+      actionmailbox (= 6.1.6)
+      actionmailer (= 6.1.6)
+      actionpack (= 6.1.6)
+      actiontext (= 6.1.6)
+      actionview (= 6.1.6)
+      activejob (= 6.1.6)
+      activemodel (= 6.1.6)
+      activerecord (= 6.1.6)
+      activestorage (= 6.1.6)
+      activesupport (= 6.1.6)
       bundler (>= 1.15.0)
-      railties (= 6.1.5)
+      railties (= 6.1.6)
       sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
@@ -448,11 +446,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
-    railties (6.1.5)
-      actionpack (= 6.1.5)
-      activesupport (= 6.1.5)
+    railties (6.1.6)
+      actionpack (= 6.1.6)
+      activesupport (= 6.1.6)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
@@ -584,7 +582,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.1)
+    unf_ext (0.0.8.2)
     unicode-display_width (2.1.0)
     vcr (6.1.0)
     view_component (2.52.0)
@@ -614,7 +612,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yell (2.2.2)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   aarch64-linux
@@ -626,7 +624,7 @@ DEPENDENCIES
   alma!
   autoprefixer-rails
   awesome_print
-  bento_search!
+  bento_search
   blacklight (~> 7.19.2)
   blacklight-marc
   blacklight-ris!
@@ -674,7 +672,7 @@ DEPENDENCIES
   pry-rails
   puma (= 5.6.4)
   rack-mini-profiler
-  rails (= 6.1.5)
+  rails (= 6.1.6)
   rails-controller-testing
   railties
   rsolr (~> 2.4)

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ VERSION ?= $(DOCKER_IMAGE_VERSION)
 HARBOR ?= harbor.k8s.temple.edu
 CLEAR_CACHES=no
 CI ?= false
-PLATFORM ?= linux/aarch64
+PLATFORM ?= linux/x86_64
 
 run:
 	@docker run --name=cob -p 127.0.0.1:3001:3000/tcp \


### PR DESCRIPTION
* Updates rails version to fix security scan
* Updates the way we pass in config for alma/bento 
* Updates bento_search gem to pull from ruby gems rather than an outdated branch