### PR TITLE
Ignore config/master.key for security.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -53,6 +53,7 @@ coverage
 config/alma.yml
 config/bento.yml
 config/deploy_to.yml
+config/master.key
 
 spec/examples.txt
 /public/packs-test

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ yarn-error.log
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+/config/master.key


### PR DESCRIPTION
Avoid committing or adding the rails docker image directly.