### PR TITLE
BL-1649 Remove link to recall items from Main Storage

### DIFF
--- a/app/helpers/availability_helper.rb
+++ b/app/helpers/availability_helper.rb
@@ -7,22 +7,13 @@ module AvailabilityHelper
   PHYSICAL_TYPE_EXCLUSIONS = /BOOK|ISSUE|SCORE|KIT|MAP|ISSBD|GOVRECORD|OTHER/i
 
   def availability_status(item)
-    # Temporary change for Ambler items
+    # Temporary change for Ambler locations, Main storage location
     unavailable_libraries = []
-    unavailable_locations = ["ambler", "amb_media"]
+    unavailable_locations = ["ambler", "amb_media", "storage"]
 
     if unavailable_libraries.include?(item.library) ||
       unavailable_locations.include?(item.location)
       content_tag(:span, "", class: "close-icon") + "Temporarily unavailable"
-
-    # Temporary change for items that don't currently fit in the ASRS bins
-    elsif item.location == "storage"
-      label = "In temporary storage"
-      if !campus_closed?
-        library_link = "#{Rails.configuration.library_link}forms/storage-request"
-        label += " — #{link_to("Recall item now", library_link)}"
-      end
-      content_tag(:span, "", class: "close-icon") + raw(label)
 
     elsif item.item_data["awaiting_reshelving"]
       content_tag(:span, "", class: "close-icon") + "Awaiting Reshelving"

--- a/spec/helpers/availability_helper_spec.rb
+++ b/spec/helpers/availability_helper_spec.rb
@@ -20,29 +20,13 @@ RSpec.describe AvailabilityHelper, type: :helper do
       end
     end
 
-    context "item is in storage and campus is closed" do
+    context "item is in temporary MAIN storage" do
       let(:item) do
-        Alma::BibItem.new("item_data" => { "location" => { "value" => "storage" } })
+        Alma::BibItem.new("item_data" => { "current_location" => "storage" })
       end
 
-      it "links to new outside form" do
-        label = "<span class=\"close-icon\"></span>In temporary storage"
-
-        expect(availability_status(item)).to eq(label)
-      end
-    end
-
-    context "item is in storage and campus is opened" do
-      let(:item) do
-        Alma::BibItem.new("item_data" => { "location" => { "value" => "storage" } })
-      end
-
-      let(:campus_closed?)  { false }
-
-      it "links to new outside form" do
-        label = "<span class=\"close-icon\"></span>In temporary storage — <a href=\"https://library.temple.edu/forms/storage-request\">Recall item now</a>"
-
-        expect(availability_status(item)).to eq(label)
+      it "displays Temporarily unavailable" do
+        label = "<span class=\"close-icon\"></span>Temporarily unavailable"
       end
     end
 


### PR DESCRIPTION
In anticipation of the arrival of 12” ASRS bins, we are disabling the storage request form for MAIN storage and defaulting the standard "Temporarily unavailable" display for that location. 