### PR TITLE
DEVO-554 Rails config changes for 6.1

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -25,13 +25,13 @@ Rails.application.config.active_job.skip_after_callbacks_if_terminated = true
 #
 # This change is not backwards compatible with earlier Rails versions.
 # It's best enabled when your entire app is migrated and stable on 6.1.
-# Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
+Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
 
 # Generate CSRF tokens that are encoded in URL-safe Base64.
 #
 # This change is not backwards compatible with earlier Rails versions.
 # It's best enabled when your entire app is migrated and stable on 6.1.
-# Rails.application.config.action_controller.urlsafe_csrf_tokens = true
+Rails.application.config.action_controller.urlsafe_csrf_tokens = true
 
 # Specify whether `ActiveSupport::TimeZone.utc_to_local` returns a time with an
 # UTC offset or a UTC time.
@@ -44,7 +44,7 @@ Rails.application.config.action_dispatch.ssl_default_redirect_status = 308
 # Use new connection handling API. For most applications this won't have any
 # effect. For applications using multiple databases, this new API provides
 # support for granular connection swapping.
-# Rails.application.config.active_record.legacy_connection_handling = false
+Rails.application.config.active_record.legacy_connection_handling = false
 
 # Make `form_with` generate non-remote forms by default.
 Rails.application.config.action_view.form_with_generates_remote_forms = false


### PR DESCRIPTION
Now that the rest of the changes have been pushed to production, we can add the configurations that are not backwards compatible.  This includes:

Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
Rails.application.config.action_controller.urlsafe_csrf_tokens = true
Rails.application.config.active_record.legacy_connection_handling = false
