### PR TITLE
Fixes internal_server_errors coming from catalog/facet

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   before_action :get_manifold_alerts, only: [
     :index, :show, :not_found, :internal_server_error,
-    :account, :librarian_view, :citation, :email, :sms
+    :account, :librarian_view, :citation, :email, :sms, :facet
   ]
 
   rescue_from ActionController::InvalidAuthenticityToken,


### PR DESCRIPTION
Honeybadger reports show that all of the most NoMethodError: undefined method `value' for nil:NilClass are coming from urls that include /catalog/facet.  This adds facet to the before_action so that the page is returned as expected.  