### PR TITLE
Fixes bug with sending sms messages

### DIFF
--- a/app/models/concerns/blacklight/document/email.rb
+++ b/app/models/concerns/blacklight/document/email.rb
@@ -5,7 +5,7 @@ module Blacklight::Document::Email
   include ApplicationHelper
   # Return a text string that will be the body of the email
   # Overridden in order to add our own custom fields to email text.
-  def to_email_text
+  def to_email_text(config = nil)
     semantics = to_semantic_values
     body = []
     ["title", "imprint", "author", "contributor",

--- a/app/models/concerns/blacklight/document/sms.rb
+++ b/app/models/concerns/blacklight/document/sms.rb
@@ -7,7 +7,7 @@ module Blacklight::Document::Sms
   # Return a text string that will be the body of the email
   include ApplicationHelper
 
-  def to_sms_text
+  def to_sms_text(config = nil)
     if self[:sms]
       [ :library, :location, :call_number ]
         .map { |field|


### PR DESCRIPTION
The blacklight methods to_email_text and to_sms_text take an optional argument.  The way our methods were written, an argument was not allowed, so when we tried to pass one it failed.  This just adds a default argument to both methods to match what the blacklight methods have.

Emails are still sending correctly, but I am adding the optional argument to that method so that we match the format that blacklight is using.