### PR TITLE
Revert "Bump blacklight-marc from 7.1.1 to 8.0.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,8 +200,8 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7.1)
       view_component (~> 2.43)
-    blacklight-marc (8.0.0)
-      blacklight (>= 7.11, < 9)
+    blacklight-marc (7.1.1)
+      blacklight (~> 7.0)
       library_stdnums
       marc (>= 0.4.3, < 2.0)
       marc-fastxmlwriter
@@ -291,6 +291,7 @@ GEM
     faraday-rack (1.0.0)
     ffi (1.15.5)
     ffi (1.15.5-x64-mingw-ucrt)
+    ffi (1.15.5-x64-unknown)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -574,7 +575,7 @@ GEM
     unf_ext (0.0.8.2)
     unicode-display_width (2.2.0)
     vcr (6.1.0)
-    view_component (2.61.1)
+    view_component (2.61.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     warden (1.2.9)


### PR DESCRIPTION
QA broke after I merged this.  I tried rebooting the linode, restarting httpd, and restarting passenger but it is still down.  Reverting this to see if that resolves it.

Reverts tulibraries/tul_cob#3292