### PR TITLE
Update blacklight-marc to 8.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,8 +200,8 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7.1)
       view_component (~> 2.43)
-    blacklight-marc (7.1.1)
-      blacklight (~> 7.0)
+    blacklight-marc (8.0.0)
+      blacklight (>= 7.11, < 9)
       library_stdnums
       marc (>= 0.4.3, < 2.0)
       marc-fastxmlwriter
@@ -275,8 +275,6 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.0)
     ffi (1.15.5)
-    ffi (1.15.5-x64-mingw-ucrt)
-    ffi (1.15.5-x64-unknown)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -361,6 +359,10 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.13.8-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.13.8-arm64-darwin)
       racc (~> 1.4)
     okcomputer (1.18.4)
     omniauth (2.1.0)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -35,7 +35,7 @@ class SolrDocument
   SolrDocument.use_extension(Blacklight::Document::Sms)
 
   # Add Blacklight-Marc extension:
-  SolrDocument.use_extension(Blacklight::Solr::Document::Marc) do |doc|
+  SolrDocument.use_extension(Blacklight::Marc::DocumentExtension) do |doc|
     doc.has_field? "marc_display_raw"
   end
   SolrDocument.extension_parameters[:marc_source_field] = "marc_display_raw"


### PR DESCRIPTION
It looks like this module was renamed about six months ago.  Both the old and new names work for me locally, but I am hoping updating it will fix the issue on QA that happened yesterday.  The error showed:

uninitialized constant Blacklight::Solr::Document::Marc
Did you mean? Blacklight::Marc