### PR TITLE
BL-1676 Add advanced solr params to web content

### DIFF
--- a/app/controllers/web_content_controller.rb
+++ b/app/controllers/web_content_controller.rb
@@ -44,6 +44,12 @@ class WebContentController < CatalogController
         qf: "${title_qf}",
         pf: "${title_pf}",
       }
+
+      field.solr_adv_parameters = {
+        # Added to avoid solr errors when users switch between searches
+        qf: "$title_qf",
+        pf: "$title_pf"
+      }
     end
 
     # Sort fields.


### PR DESCRIPTION
Currently, if a user has search results from a catalog title advanced search and then clicks on the web content tab, they get an unsupported query error.  Adding the advanced solr parameters to the title search field for web content allows the user to go through.