### PR TITLE
Allow adding javascript enabled feature specs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,10 @@ jobs:
           command: make ci-yarn-install
 
       - run:
+          name: Add headless browser testing dependencies
+          command: make add-testing-deps
+
+      - run:
           name: Copy the vendor/bundle from the container to local
           command: make ci-copy-bundle-files-to-local
 

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,8 @@ group :development, :test do
   gem "cob_az_index", git: "https://github.com/tulibraries/cob_az_index.git",
     branch: "main"
 
-  gem "capybara", "3.37.1"
+  gem "capybara", "~> 3"
+  gem "selenium-webdriver"
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (4.1.0)
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -276,6 +277,7 @@ GEM
     faraday-net_http (3.0.0)
     ffi (1.15.5)
     ffi (1.15.5-x64-mingw-ucrt)
+    ffi (1.15.5-x64-unknown)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -494,6 +496,11 @@ GEM
       sprockets-rails
       tilt
     scrub_rb (1.0.1)
+    selenium-webdriver (4.4.0)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     semantic_range (3.0.0)
     simplecov (0.21.2)
       docile (~> 1.1)
@@ -579,6 +586,7 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -610,7 +618,7 @@ DEPENDENCIES
   bootstrap (~> 4.6)
   browser
   byebug
-  capybara (= 3.37.1)
+  capybara (~> 3)
   cdm!
   cob_az_index!
   cob_index!
@@ -657,6 +665,7 @@ DEPENDENCIES
   ruby-prof
   ruby-saml (= 1.12.2)
   sass-rails (~> 6.0)
+  selenium-webdriver
   simplecov
   simplecov-lcov
   skylight (= 4.3.2)
@@ -674,4 +683,4 @@ DEPENDENCIES
   webpacker (= 6.0.0.rc.6)
 
 BUNDLED WITH
-   2.3.9
+   2.3.21

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ attach:
 	@bin/attach.sh tul_cob_app
 
 # CI Specific Targets
+add-testing-deps:
+	$(DOCKER) exec app apk add -U --no-cache chromium chromium-chromedriver
+
+
 ci-copy-bundle-files-to-local:
 	docker cp tul_cob_app_1:/app/vendor/bundle vendor/
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ If Docker is available, we defined a Makefile with many useful commands.
 * To enter into the solr container, run ```make tty-solr```
 * To run the linter, run ```make lint```
 * To run the Ruby tests, run ```make test```
+  * Some tests require chromium driver to be installed on system.
+    * On macs, run: `brew install chromiumdriver`
 * To run Javascript tests, run ```make test-js```
 * To load sample data, run ```DO_INGEST=yes make up``` or ```make load-data```
 * To reload solr configs, run ```make reload-configs```

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Facets" do
+
+
+  it "is able to expand facets when javascript is enabled", js: true do
+    visit "/catalog?search_field=all_fields&q=test"
+
+    expect(page).to have_css("#facet-library_facet", visible: false)
+
+    page.find("#facet-library_facet-header").click()
+
+    sleep(1) # let facet animation finish and wait for it to potentially re-collapse
+
+    expect(page).to have_css("#facet-library_facet", visible: true)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,10 +10,24 @@ require "spec_helper"
 require "rspec/rails"
 require "capybara/rspec"
 require "capybara/rails"
+require "selenium-webdriver"
 require "view_component/test_case"
 
 # Add additional requires below this line. Rails is not loaded until this point!
 Capybara.default_max_wait_time = 5
+
+Capybara.javascript_driver = :headless_chrome
+
+Capybara.register_driver :headless_chrome do |app|
+  Capybara::Selenium::Driver.load_selenium
+  capabilities = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.args << "--headless"
+    opts.args << "--disable-gpu"
+    opts.args << "--no-sandbox"
+    opts.args << "--window-size=1280,1696"
+  end
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: capabilities)
+end
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -393,7 +393,8 @@ RSpec.configure do |config|
 end
 
 VCR.configure do |config|
-  config.ignore_hosts "127.0.0.1", "localhost", "solr", "lgapi-us.libapps.com", "np-fim.temple.edu", ENV["SOLRCLOUD_HOST"]
+  config.ignore_hosts "127.0.0.1", "localhost", "solr", "lgapi-us.libapps.com",
+    "np-fim.temple.edu", ENV["SOLRCLOUD_HOST"], "chromedriver.storage.googleapis.com"
   config.allow_http_connections_when_no_cassette = false
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
   config.hook_into :webmock


### PR DESCRIPTION
We have some features that require JavaScript to test them properly.

However, JavaScript testing frameworks are not easy to manage and
understand when you are not constantly writing JavaScript.

A different approach we can take is to test these features via a web
browser interaction using a feature test that interacts with the codes
behavior.

This should suffice to test features in our site that require
JavaScript.

This change updates our code to:
* Add dependencies to the test and developer environment to enable
  JavaScript enabled feature specs.
* Adds an example test that test that clicking on facet headers opens
  the closed facets.