### PR TITLE
BL-1675 Update advanced search to remove single quotes from queries

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -110,8 +110,13 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   def process_is(value, op)
     return if value.blank?
-    return value if value.match(/"/) rescue true
-    if op == "is"
+    
+    if value&.scan(/"/).size == 1
+      updated_value = value.sub(/"/, "")
+      "\"#{updated_value}\""
+    elsif value&.scan(/"/).size > 1
+      value
+    elsif op == "is"
       "\"#{value}\""
     else
       value

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -110,6 +110,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   def process_is(value, op)
     return if value.blank?
+    return if value.class != String
 
     if value&.scan(/"/).size == 1
       updated_value = value.sub(/"/, "")

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -110,7 +110,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   def process_is(value, op)
     return if value.blank?
-    
+
     if value&.scan(/"/).size == 1
       updated_value = value.sub(/"/, "")
       "\"#{updated_value}\""

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -207,6 +207,10 @@ RSpec.describe SearchBuilder , type: :model do
       expect(subject.process_is("foo", "is")).to eq("\"foo\"")
     end
 
+    it "removes a single quote and then adds quotes to value" do
+      expect(subject.process_is("\"bar", "is")).to eq("\"bar\"")
+    end
+
     it "avoids escape hell by ignoring values with quotes" do
       expect(subject.process_is("foo\"bar\"", "is")).to eq("foo\"bar\"")
     end


### PR DESCRIPTION
There are times when a user accidentally uses a single quote when searching for a term.  The way our code was previously written, if a search term included any number of quotation marks, it returns the search term value.  

So if a user searched for `"George Washington",` it would search for that term with the existing quotes.  If a user selects the is(exact) operator and does not use quotes, the method adds them to the term.

This updates the code to remove any single quotes from a search term, and then puts quotes around the search term so that the is(exact) precision is applied.

So, `"George Washington` would become `"George Washington"`