### PR TITLE
BL-1715: Use pcAvailability if given in user params.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GIT
 
 GIT
   remote: https://github.com/tulibraries/primo
-  revision: 8e530b555db2f7ca3f274c84cde8a09036060c8f
+  revision: 6ab0de4980dd0b772d74ad107fa400b6b2793a79
   branch: main
   specs:
     primo (0.1.0)

--- a/app/models/blacklight/primo_central/search_builder_behavior.rb
+++ b/app/models/blacklight/primo_central/search_builder_behavior.rb
@@ -46,7 +46,7 @@ module Blacklight::PrimoCentral
         }
       end
 
-      primo_central_parameters[:query].merge!({ searchCDI: true }) if blacklight_params["searchCDI"] == "true"
+      primo_central_parameters[:query].merge!(blacklight_params.slice(:searchCDI, :pcAvailability))
     end
 
     def set_query_field(primo_central_parameters)

--- a/spec/models/primo_search_builder_spec.rb
+++ b/spec/models/primo_search_builder_spec.rb
@@ -70,7 +70,15 @@ RSpec.describe Blacklight::PrimoCentral::SearchBuilder , type: :model do
       let(:params) { ActionController::Parameters.new(q: "foo", searchCDI: "true") }
 
       it "supports Primo's searchCDI field" do
-        expect(primo_central_parameters["query"]["searchCDI"]).to eq(true)
+        expect(primo_central_parameters["query"]["searchCDI"]).to eq("true")
+      end
+    end
+
+    context "with  pcAvailability param"  do
+      let(:params) { ActionController::Parameters.new(q: "foo", pcAvailability: "true") }
+
+      it "supports Primo's pcAvailability field" do
+        expect(primo_central_parameters["query"]["pcAvailability"]).to eq("true")
       end
     end
 


### PR DESCRIPTION
Updates the primo search builder to process the pcAvailability user
params and adds it to the primo query.