### PR TITLE
Rename check_for_full_http_link helper method.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -182,7 +182,7 @@ class CatalogController < ApplicationController
     config.add_index_field "creator_display", label: "Author/Creator", helper_method: :creator_index_separator
     config.add_index_field "format", label: "Resource Type", raw: true, helper_method: :separate_formats
     config.add_index_field "lc_call_number_display", if: :render_lc_call_number_on_index?
-    config.add_index_field "url_finding_aid_display", label: "Finding Aid", helper_method: :check_for_full_http_link
+    config.add_index_field "url_finding_aid_display", label: "Finding Aid", helper_method: :build_availability
     config.add_index_field "availability"
     config.add_index_field "purchase_order_availability", field: "purchase_order", if: false, helper_method: :render_purchase_order_availability, with_po_link: true
     config.add_index_field "bound_with_ids", if: false
@@ -191,7 +191,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
 
     config.add_show_field "title_statement_vern_display", label: "Title Statement", type: :primary
-    config.add_show_field "url_finding_aid_display", label: "Finding Aid", helper_method: :check_for_full_http_link, type: :primary
+    config.add_show_field "url_finding_aid_display", label: "Finding Aid", helper_method: :build_availability, type: :primary
     config.add_show_field "title_uniform_display", label: "Uniform title", helper_method: :additional_title_link, type: :primary
     config.add_show_field "title_uniform_vern_display", label: "Uniform title", type: :primary
     config.add_show_field "title_addl_display", label: "Additional titles", helper_method: :additional_title_link, type: :primary
@@ -274,8 +274,8 @@ class CatalogController < ApplicationController
     config.add_show_field "lc_call_number_display", label: "LC Classification"
     config.add_show_field "alma_mms_display", label: "Catalog Record ID"
     config.add_show_field "language_display", label: "Language"
-    config.add_show_field "url_more_links_display", label: "Other Links", helper_method: :check_for_full_http_link
-    config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :check_for_full_http_link, if: false
+    config.add_show_field "url_more_links_display", label: "Other Links", helper_method: :build_availability
+    config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :build_availability, if: false
     config.add_show_field "bound_with_ids", display: false
 
     config.add_show_field "po_link", field: "purchase_order", if: false, helper_method: :render_purchase_order_show_link

--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -29,7 +29,7 @@ class DatabasesController < CatalogController
 
     # Show fields
     config.add_show_field "note_display", label: "Description", raw: true, helper_method: :join
-    config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :check_for_full_http_link, if: false
+    config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :build_availability, if: false
     config.add_show_field "subject_display", label: "Subject", helper_method: :database_subject_links, multi: true
     config.add_show_field "format", label: "Database Type", helper_method: :database_type_links, multi: true
     config.add_show_field "az_vendor_name_display", label: "Database Vendor"

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -109,7 +109,7 @@ module CatalogHelper
   end
 
   def render_online_availability_button(doc)
-    links = check_for_full_http_link(document: doc, field: "electronic_resource_display")
+    links = build_availability(document: doc, field: "electronic_resource_display")
 
     if !links.empty?
       render "online_availability_button", document: doc, links: links
@@ -458,7 +458,7 @@ module CatalogHelper
       render_electronic_notes(electronic_resources.first).present?
   end
 
-  def check_for_full_http_link(args)
+  def build_availability(args)
     [args[:document][args[:field]]].flatten.compact.map { |field|
       if field["url"].present?
         electronic_access_links(field)

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -445,7 +445,7 @@ RSpec.describe CatalogHelper, type: :helper do
     end
   end
 
-  describe "#check_for_full_http_link(args)" do
+  describe "#build_availability(args)" do
     let(:alma_domain) { "sandbox01-na.alma.exlibrisgroup.com" }
     let(:alma_institution_code) { "01TULI_INST" }
     let(:args) {
@@ -463,13 +463,13 @@ RSpec.describe CatalogHelper, type: :helper do
 
     context "marc field links with http should use the electronic_access_links helper method" do
       it "directs an http link through the electronic_access_links method" do
-        expect(check_for_full_http_link(args)).to have_link(text: "Access electronic resource", href: "http://libproxy.temple.edu/login?url=http://www.aspresolver.com/aspresolver.asp?SHM2;1772483")
+        expect(build_availability(args)).to have_link(text: "Access electronic resource", href: "http://libproxy.temple.edu/login?url=http://www.aspresolver.com/aspresolver.asp?SHM2;1772483")
       end
     end
 
     context "alma api links go through electronic_resource_display method" do
       it "directs an http link through the electronic_access_links method" do
-        expect(check_for_full_http_link(args)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
+        expect(build_availability(args)).to have_link(text: "Sample Name", href: "https://sandbox01-na.alma.exlibrisgroup.com/view/uresolver/01TULI_INST/openurl?Force_direct=true&portfolio_pid=77777&rfr_id=info%3Asid%2Fprimo.exlibrisgroup.com&u.ignore_date_coverage=true")
       end
     end
   end


### PR DESCRIPTION
I was reading the code and was having a hard time understanding what
check_for_full_http_link method did based on name.  I think
build_availability makes more sense or maybe we can come up with another
more suitable name that doesn't imply that
check_for_full_http_link is checking that somethig is true or false
and therefor not actually rendering html that will be displayed on
a page.