### PR TITLE
Remove confusing helper_method configuration.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -275,11 +275,11 @@ class CatalogController < ApplicationController
     config.add_show_field "alma_mms_display", label: "Catalog Record ID"
     config.add_show_field "language_display", label: "Language"
     config.add_show_field "url_more_links_display", label: "Other Links", helper_method: :check_for_full_http_link
-    config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :check_for_full_http_link, if: false
+    config.add_show_field "electronic_resource_display", label: "Availability", if: false
     config.add_show_field "bound_with_ids", display: false
 
-    config.add_show_field "po_link", field: "purchase_order", if: false, helper_method: :render_purchase_order_show_link
-    config.add_show_field "purchase_order_availability", label: "Request Rapid Access", field: "purchase_order", if: false, helper_method: :render_purchase_order_availability, with_panel: true
+    config.add_show_field "po_link", field: "purchase_order", if: false
+    config.add_show_field "purchase_order_availability", label: "Request Rapid Access", field: "purchase_order", if: false, with_panel: true
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -29,7 +29,7 @@ class DatabasesController < CatalogController
 
     # Show fields
     config.add_show_field "note_display", label: "Description", raw: true, helper_method: :join
-    config.add_show_field "electronic_resource_display", label: "Availability", helper_method: :check_for_full_http_link, if: false
+    config.add_show_field "electronic_resource_display", label: "Availability", if: false
     config.add_show_field "subject_display", label: "Subject", helper_method: :database_subject_links, multi: true
     config.add_show_field "format", label: "Database Type", helper_method: :database_type_links, multi: true
     config.add_show_field "az_vendor_name_display", label: "Database Vendor"


### PR DESCRIPTION
We're defining helper_method for some of the fields that we also set
`if:
false` to.

The :if config for blacklight is a configuration tha is used to set if
a field gets rendered by blacklight.  If so, then the defined
:helper_method would be used to render the field instead of whatever the
default is.  But since we are setting :if that means we are not
rendering this field (at least we are not having Blacklight render it
for us).

It's unnecessary to define a rendering :hlper_method field level config
if the field is configured never to be rendered by blacklight.