### PR TITLE
BL-1713 Summary preview updates

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -225,19 +225,30 @@ window.addEventListener('load', function(event) {
 });
 
 $(window).on('turbolinks:load', function() {
-	$(".summary-previews").each(function () {
-		console.log($(".summary-previews").height());
-		if ($(".summary-previews").height() > 40) {
-				let readMore = $('<a class="read-more">read more</a>');
+	const previews = document.getElementsByClassName("summary-previews");
+	
+	$(previews).each(function () {	
+		let readLess = $('<a class="read-less">less</a>');
+		let readMore = $('<a class="read-more">read more</a>');
+	
+		if ($(this).text().length > 300) {
+			console.log($(this).text().length);
 				$(this).css("display", "-webkit-box").css("-webkit-box-orient", "vertical").css("-webkit-line-clamp", "2").css("margin-bottom", "0");
 				$(readMore).insertAfter($(this));
+				$(readLess).insertAfter($(this)).hide();
 		}
-	});
 
-	$(".read-more").on("click", function () {
-		$(this).hide();
-		$(this).prev("div").removeAttr("style");
-		$(this).prev("div").css("margin-bottom", "20px");
+		$(readMore).on("click", function () {
+			$(this).hide();
+			console.log($(this).prev("div"));
+			$(this).siblings("div.summary-previews").removeAttr("style");
+			$(readLess).show();
+		});
+	
+			$(readLess).on("click", function () {
+			$(this).hide();
+			$(readMore).removeAttr("style");
+			$(this).prev("div").css("-webkit-box-orient", "vertical").css("-webkit-line-clamp", "2").css("margin-bottom", "0");
+		});
 	});
 });
-

--- a/app/assets/stylesheets/partials/_index_results.scss
+++ b/app/assets/stylesheets/partials/_index_results.scss
@@ -12,7 +12,8 @@
     padding-top: 1rem;
   }
 
-  .documentHeader, .document-info-container {
+  .documentHeader, .document-info-container,
+  .summary-preview-container {
     margin-left: 1.75rem;
     margin-right: 0;
   }
@@ -131,7 +132,8 @@
   margin-bottom: 1rem;
 }
 
-.read-more {
+.read-more,
+.read-less {
   margin-bottom: 20px;
   padding-left: 1rem;
 }

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,7 +1,8 @@
 <% doc_presenter = document_presenter(document) %>
 
-<div class="document-info-container clearfix flex-row-reverse">
 <%= render "index_summary_field", :document => document %>
+
+<div class="document-info-container clearfix flex-row-reverse">
 
 <%# default partial to display solr document fields in catalog index view %>
   <% unless controller_name == "databases" %>


### PR DESCRIPTION
* Only displays button for longer-text summaries
* Adds a "less" link to collapse preview
* Adjusts css to align with the document header