### PR TITLE
Add x86_64-linux to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,6 +394,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-linux)
+      racc (~> 1.4)
     okcomputer (1.18.4)
     omniauth (2.1.0)
       hashie (>= 3.4.6)
@@ -553,6 +555,7 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.5.4-arm64-darwin)
     sqlite3 (1.5.4-x86_64-darwin)
+    sqlite3 (1.5.4-x86_64-linux)
     stackprof (0.2.23)
     summon (2.0.5)
       json
@@ -630,6 +633,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   alma!


### PR DESCRIPTION
Deployments are failing because this platform is not in the lock file.