### PR TITLE
BL-921 Update bento layout to accommodate Guides box

### DIFF
--- a/app/assets/stylesheets/partials/_bento.scss
+++ b/app/assets/stylesheets/partials/_bento.scss
@@ -1,19 +1,12 @@
 @import "_vars.scss";
 
 /* BENTO STYLES */
-.card-columns {
-	@include media-breakpoint-only(sm) {
-		column-count: 1;
+
+.bento-main-container {
+	@media (min-width: 1300px) {
+		max-width: 1200px;
 	}
-	@include media-breakpoint-only(md) {
-		column-count: 2;
-	}
-	@include media-breakpoint-only(lg) {
-		column-count: 3;
-	}
-	@include media-breakpoint-only(xl) {
-		column-count: 3;
-	}
+	
 }
 
 .bento_compartment h2 {
@@ -28,6 +21,10 @@
 		margin-left: -0.3125rem;
 	}
 
+}
+
+.bento_item_row {
+	margin: 0; 
 }
 
 .bento_search_no_results h3, .noresults{

--- a/app/views/bento_search/_std_item.html.erb
+++ b/app/views/bento_search/_std_item.html.erb
@@ -23,7 +23,7 @@
   <%# for debugging purposes, we'll include the vendor-specific unique_id, if we have
       one, in a data-unique-id attribute. %>
 
-  <div class="bento_item border-bottom border-lighter-grey pr-2 pt-3" data-unique-id="<%= item.unique_id %>">
+  <div class="bento_item border-bottom border-lighter-grey pr-2 py-3" data-unique-id="<%= item.unique_id %>">
     <%= render :partial => "bento_search/item_title", :object => item, :as => 'item' %>
 
 

--- a/app/views/layouts/_bento_box_wrapper.html.erb
+++ b/app/views/layouts/_bento_box_wrapper.html.erb
@@ -14,14 +14,17 @@
   </div>
 
   
-  <div class="total-items">
-    <% unless total_items(results) == 0 %>
+  <% unless total_items(results) == 0 %>
+    <div class="total-items">
       <%= bento_link_to_full_results(results) %> &gt;
-    <% end %>
-    <% if results.engine_id == "lib_guides" && results.present? %>
+    </div>
+  <% end %>
+  <% if results.engine_id == "lib_guides" && results.present? %>
+    <div class="total-items">
       <%= bento_link_to_full_results(results) %> &gt;
-    <% end %>
-  </div>
+    </div>
+  <% end %>
+  
   
   <% unless total_online(results) == 0  %>
     <div class="bento-online-results">

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -61,9 +61,7 @@
 
         <main id="main-container" class="col-12 m-0 p-lg-0" role="main">
 
-          <div class="pb-5">
-            <%= yield %>
-          </div>
+        <%= yield %>
 
         </main>
         

--- a/app/views/search/_bento_results.html.erb
+++ b/app/views/search/_bento_results.html.erb
@@ -1,23 +1,33 @@
-<div class="card-columns">
-  <% renderable_results(results, options).each_pair do |engine_id, result| %>
+<% renderable_results(results, options).each_pair do |engine_id, result| %>
   <% if engine_id == 'journals' && with_libguides? %>
     <div data-lib-guides-url="<%= lib_guides_path(q: @lib_guides_query_term) %>" data-controller="lib-guides">
       <%= render :partial => "lib_guide_recommender_bento" %>
     </div>
   <% end %>
-
-    <div class="card mx-auto bento_compartment border-0 <%= engine_id %>">
-      <h2 class="rounded-top m-0"><%= bento_icons(engine_id) %><%= bento_titleize(engine_id) %> </h2>
+  <% unless result.failed? || result.empty? %>
+    <div class="col mx-auto p-2 bento_compartment <%= engine_id %>">
+      <h2 class="m-0"><%= bento_icons(engine_id) %><%= bento_titleize(engine_id) %> </h2>
+      <%= render :layout => "layouts/bento_box_wrapper", :locals => {:results => result } do %>
+      <%= bento_search result %>
+      <% end %>
+      <%= render_linked_results(engine_id) %>
+    </div>
+    <% end %>
+<% end %>
+<% renderable_results(results, options).each_pair do |engine_id, result| %>
+  <% if result.failed? || result.empty? %>
+    <div class="col mx-auto p-2 bento_compartment <%= engine_id %>">
+      <h2 class="m-0"><%= bento_icons(engine_id) %><%= bento_titleize(engine_id) %> </h2>
       <%= render :layout => "layouts/bento_box_wrapper", :locals => {:results => result } do %>
         <% unless result.failed? %>
           <%= bento_search result %>
         <% else %>
-          <div class="error bento_item pt-3">
+          <div class="error bento_item py-3">
             <h3 class="bento_item_title">We're sorry, but something went wrong.</h3>
           </div>
         <% end %>
       <% end %>
       <%= render_linked_results(engine_id) %>
     </div>
-  <% end %>
-</div>
+    <% end %>
+<% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,6 +1,8 @@
 <% if @results %>
-<div class="d-flex justify-content-between bento-main-container container">
-  <%= render_bento_results %>
+<div class="container bento-main-container justify-content-between pb-3">
+  <div class="row row-cols-md-3 row-cols-1">
+    <%= render_bento_results %>
+  </div>
 </div>
 
   <%= render :partial => "digital_collections" %>


### PR DESCRIPTION
- Updated Bootstrap layout from card columns to rows with columns
- "No Results" are now pushed to bottom of display
- Adjusted width of bento container and other minor padding/margin changes