### PR TITLE
BL-921 Update guides header link and reorder bento

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,7 +15,7 @@ class SearchController < CatalogController
   def index
     @per_page = 3
     if params[:q]
-      engines = %i(books_and_media articles journals databases library_website lib_guides cdm)
+      engines = %i(books_and_media articles databases journals library_website lib_guides cdm)
       searcher = BentoSearch::ConcurrentSearcher.new(*engines)
       searcher.search(params[:q], per_page: @per_page, semantic_search_field: params[:field])
 

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -35,7 +35,7 @@ module SearchHelper
     if id == "books_and_media"
       link_to "Books & Media", engine.url(self), id: "bento_" + id + "_header"
     elsif id == "lib_guides"
-      link_to "Research Guides", "https://guides.temple.edu/", target: "_blank", id: "bento_" + id + "_header"
+      link_to "Research Guides", engine.url(self), id: "bento_" + id + "_header"
     else
       link_to id.titleize , engine.url(self), id: "bento_" + id + "_header"
     end

--- a/app/search_engines/bento_search/lib_guides_engine.rb
+++ b/app/search_engines/bento_search/lib_guides_engine.rb
@@ -41,7 +41,7 @@ module BentoSearch
 
     def view_link(total = nil, helper)
       url = url(helper)
-      helper.link_to "View all research guide results", url, target: "_blank", class: "bento-full-results"
+      helper.link_to "View all research guide results", url, class: "bento-full-results"
     end
   end
 end

--- a/app/views/search/_bento_results.html.erb
+++ b/app/views/search/_bento_results.html.erb
@@ -4,30 +4,17 @@
       <%= render :partial => "lib_guide_recommender_bento" %>
     </div>
   <% end %>
-  <% unless result.failed? || result.empty? %>
-    <div class="col mx-auto p-2 bento_compartment <%= engine_id %>">
-      <h2 class="m-0"><%= bento_icons(engine_id) %><%= bento_titleize(engine_id) %> </h2>
-      <%= render :layout => "layouts/bento_box_wrapper", :locals => {:results => result } do %>
-      <%= bento_search result %>
+  <div class="col mx-auto p-2 bento_compartment <%= engine_id %>">
+    <h2 class="m-0"><%= bento_icons(engine_id) %><%= bento_titleize(engine_id) %> </h2>
+    <%= render :layout => "layouts/bento_box_wrapper", :locals => {:results => result } do %>
+      <% unless result.failed? %>
+        <%= bento_search result %>
+      <% else %>
+        <div class="error bento_item py-3">
+          <h3 class="bento_item_title">We're sorry, but something went wrong.</h3>
+        </div>
       <% end %>
-      <%= render_linked_results(engine_id) %>
-    </div>
     <% end %>
-<% end %>
-<% renderable_results(results, options).each_pair do |engine_id, result| %>
-  <% if result.failed? || result.empty? %>
-    <div class="col mx-auto p-2 bento_compartment <%= engine_id %>">
-      <h2 class="m-0"><%= bento_icons(engine_id) %><%= bento_titleize(engine_id) %> </h2>
-      <%= render :layout => "layouts/bento_box_wrapper", :locals => {:results => result } do %>
-        <% unless result.failed? %>
-          <%= bento_search result %>
-        <% else %>
-          <div class="error bento_item py-3">
-            <h3 class="bento_item_title">We're sorry, but something went wrong.</h3>
-          </div>
-        <% end %>
-      <% end %>
-      <%= render_linked_results(engine_id) %>
-    </div>
-    <% end %>
+    <%= render_linked_results(engine_id) %>
+  </div>
 <% end %>


### PR DESCRIPTION
- Matches guide header link to "View all" link
- Switches databases and journals in bento order
- Remove dynamic "no results" ordering that I had tried in a previous PR