### PR TITLE
BL-1758 Author/responsibility updates

### DIFF
--- a/app/assets/stylesheets/partials/_index_results.scss
+++ b/app/assets/stylesheets/partials/_index_results.scss
@@ -236,3 +236,12 @@ dd.blacklight-format {
     border-top-left-radius: 0 !important;
   }
 }
+
+/* === PRIMO ARTICLE RESULTS === */
+dd.blacklight-creator {
+  @media(min-width: 768px) {
+    a:not(:first-child) {
+      margin-left: 120px;
+    }
+  }
+}

--- a/app/assets/stylesheets/partials/_index_results.scss
+++ b/app/assets/stylesheets/partials/_index_results.scss
@@ -236,12 +236,3 @@ dd.blacklight-format {
     border-top-left-radius: 0 !important;
   }
 }
-
-/* === PRIMO ARTICLE RESULTS === */
-dd.blacklight-creator {
-  @media(min-width: 768px) {
-    a:not(:first-child) {
-      margin-left: 120px;
-    }
-  }
-}

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -49,7 +49,7 @@ class PrimoCentralController < CatalogController
     config.add_index_field :type, label: "Resource Type", raw: true, helper_method: :index_translate_resource_type_code, type: :format
     config.add_index_field :date, label: "Year", type: :date
     config.add_index_field :isPartOf, label: "Is Part Of"
-    config.add_index_field :creator, label: "Author/Creator", helper_method: :creator_links, multi: true
+    config.add_index_field :creator, label: "Author/Creator", helper_method: :creator_links, multi: true, separator: ", "
     config.add_index_field :availability
     config.add_index_field :status
     config.add_index_field :error
@@ -64,7 +64,7 @@ class PrimoCentralController < CatalogController
 
     # Show fields
     config.add_show_field :creator, label: "Author/Creator", helper_method: :creator_links, multi: true, refwork_tag: :A1, type: :primary
-    config.add_show_field :contributor, label: "Contributor", helper_method: :browse_creator, multi: true, refwork_tag: :A2, type: :primary
+    config.add_show_field :contributor, label: "Contributor", helper_method: :creator_links, multi: true, refwork_tag: :A2, type: :primary
     config.add_show_field :type, label: "Resource Type", helper_method: :doc_translate_resource_type_code, type: :primary
     config.add_show_field :publisher, label: "Published", refwork_tag: :PB, type: :primary
     config.add_show_field :date, label: "Date", refwork_tag: :Y1, type: :primary

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -339,8 +339,9 @@ module ApplicationHelper
   end
 
   def creator_links(args)
+    separator = args.dig(:config, :separator)
     creator = args[:document][args[:field]] || []
-    creator.map do |creator_data|
+    creator_links = creator.map do |creator_data|
       begin
         creator_data = JSON.parse(creator_data)
         relation = creator_data["relation"]
@@ -359,6 +360,12 @@ module ApplicationHelper
       ActiveSupport::SafeBuffer.new([ relation,
         name_link,
         role ].join(" ").strip)
-    end.join("<br>").html_safe
+    end
+
+    if separator.present?
+      creator_links.join(separator).html_safe
+    else 
+      creator_links
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -359,6 +359,6 @@ module ApplicationHelper
       ActiveSupport::SafeBuffer.new([ relation,
         name_link,
         role ].join(" ").strip)
-    end.join(", ").html_safe
+    end.join("<br>").html_safe
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -364,7 +364,7 @@ module ApplicationHelper
 
     if separator.present?
       creator_links.join(separator).html_safe
-    else 
+    else
       creator_links
     end
   end

--- a/app/presenters/show_presenter.rb
+++ b/app/presenters/show_presenter.rb
@@ -11,7 +11,9 @@ class ShowPresenter < Blacklight::ShowPresenter
   def each_secondary_field
     fields_to_render.each do |field_name, field_config, field_presenter|
       field_presenter.except_operations << Blacklight::Rendering::Join
-      yield field_name, field_config, field_presenter unless field_config[:type] == :primary
+      unless field_config[:type] == :primary || field_config[:type] == :responsibility
+        yield field_name, field_config, field_presenter
+      end
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -531,7 +531,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context "an article creator with comma separator" do
       let(:controller_name) { "primo_central" }
-      let(:args) { { document: { creator: ["Louisa May Alcott", "Emily Dickinson"] }, field: :creator, config: { separator: ", "} } }
+      let(:args) { { document: { creator: ["Louisa May Alcott", "Emily Dickinson"] }, field: :creator, config: { separator: ", " } } }
 
       it "returns a list of links to creator search for each creator, with comma seaprator" do
         expect(creator_links(args)).to eq(

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -514,7 +514,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:args) { { document: { creator: [""] }, field: :creator } }
 
       it "returns an empty list if no creators are available" do
-        expect(creator_links(args)).to eq("")
+        expect(creator_links(args)).to eq([""])
       end
     end
 
@@ -523,9 +523,20 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:args) { { document: { creator: ["Louisa May Alcott"] }, field: :creator } }
 
       it "returns a list of links to creator search for each creator" do
-        expect(creator_links(args)).to eq(
+        expect(creator_links(args)).to eq([
           "<a href=\"http://test.host/articles?search_field=creator&amp;q=Louisa May Alcott\">Louisa May Alcott</a>"
-        )
+      ])
+      end
+    end
+
+    context "an article creator with comma separator" do
+      let(:controller_name) { "primo_central" }
+      let(:args) { { document: { creator: ["Louisa May Alcott", "Emily Dickinson"] }, field: :creator, config: { separator: ", "} } }
+
+      it "returns a list of links to creator search for each creator, with comma seaprator" do
+        expect(creator_links(args)).to eq(
+          "<a href=\"http://test.host/articles?search_field=creator&amp;q=Louisa May Alcott\">Louisa May Alcott</a>, <a href=\"http://test.host/articles?search_field=creator&amp;q=Emily Dickinson\">Emily Dickinson</a>"
+      )
       end
     end
 
@@ -534,7 +545,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:args) { { document: { creator_facet: [""] }, field: :creator_facet } }
 
       it "returns an empty list if no creators are available" do
-        expect(creator_links(args)).to eq("")
+        expect(creator_links(args)).to eq([""])
       end
     end
 
@@ -543,9 +554,9 @@ RSpec.describe ApplicationHelper, type: :helper do
       let(:args) { { document: { creator_facet: ["Louise Penny"] }, field: :creator_facet } }
 
       it "returns a list of links to creator search for each creator" do
-        expect(creator_links(args)).to eq(
+        expect(creator_links(args)).to eq([
           "<a href=\"http://test.host/articles?search_field=creator&amp;q=Louise Penny\">Louise Penny</a>"
-        )
+      ])
       end
     end
 
@@ -555,7 +566,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       field: :creator_display } }
 
       it "returns an empty string list" do
-        expect(creator_links(args)).to eq("")
+        expect(creator_links(args)).to eq([""])
       end
     end
 
@@ -565,7 +576,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       field: :creator_display } }
 
       it "returns role in a list" do
-        expect(creator_links(args)).to eq("MyRole")
+        expect(creator_links(args)).to eq(["MyRole"])
       end
     end
 
@@ -575,7 +586,7 @@ RSpec.describe ApplicationHelper, type: :helper do
       field: :creator_display } }
 
       it "returns role in a list" do
-        expect(creator_links(args)).to eq("MyRelation")
+        expect(creator_links(args)).to eq(["MyRelation"])
       end
     end
 
@@ -585,9 +596,9 @@ RSpec.describe ApplicationHelper, type: :helper do
       field: :creator_display } }
 
       it "returns name as a link to query" do
-        expect(creator_links(args)).to eq(
+        expect(creator_links(args)).to eq([
           "<a href=\"catalog?f[creator_facet][]=MyName\">MyName</a>"
-        )
+      ])
       end
     end
 
@@ -597,9 +608,9 @@ RSpec.describe ApplicationHelper, type: :helper do
       field: :creator_display } }
 
       it "returns name as a link to query + plus role appended" do
-        expect(creator_links(args)).to eq(
+        expect(creator_links(args)).to eq([
           "<a href=\"catalog?f[creator_facet][]=MyName\">MyName</a> MyRole"
-        )
+       ])
       end
     end
 
@@ -609,9 +620,9 @@ RSpec.describe ApplicationHelper, type: :helper do
       field: :creator_display } }
 
       it "returns name as a link to query + plus role appended + relation prepended" do
-        expect(creator_links(args)).to eq(
+        expect(creator_links(args)).to eq([
           "MyRelation <a href=\"catalog?f[creator_facet][]=MyName\">MyName</a> MyRole"
-        )
+      ])
       end
     end
   end


### PR DESCRIPTION
* Remove responsibility_display from secondary fields on full record pages
* Updates multiple authors in articles to display on separate lines (this matches what we do for catalog results)