### PR TITLE
Update axe_spec requirements and make needed code changes

### DIFF
--- a/app/assets/stylesheets/partials/_index_results.scss
+++ b/app/assets/stylesheets/partials/_index_results.scss
@@ -122,10 +122,6 @@
   }
 }
 
-.explanation {
-  font-size: 1.1em;
-}
-
 .page-links {
   @media(max-width: 485px) {
     padding-bottom: 0.5rem;

--- a/app/views/almaws/item.html.erb
+++ b/app/views/almaws/item.html.erb
@@ -50,5 +50,5 @@
   <% end %>
 
   <% else %>
-    <div id="error-message"><%= t("blacklight.errors.availability_alert_general_html", href: link_to(t("blacklight.errors.error_help_href"), t("blacklight.errors.error_help_link"))) %></div>
+    <div class="error-message"><%= t("blacklight.errors.availability_alert_general_html", href: link_to(t("blacklight.errors.error_help_href"), t("blacklight.errors.error_help_link"))) %></div>
 <% end %>

--- a/app/views/catalog/_explanation_div.html.erb
+++ b/app/views/catalog/_explanation_div.html.erb
@@ -3,7 +3,7 @@
   <div class="explantion-wrapper col-sm-12 col-lg-10 mt-3 pl-5 pr-5 mx-auto" >
     <p class="explanation">
       <%= explanation_translations(controller_name) %>
-      <%= link_to(t("bento.more_information_html"), t("bento.more_information_link"), target: "_blank") %>
+      <strong><%= link_to(t("bento.more_information_html"), t("bento.more_information_link"), target: "_blank") %></strong>
     </p>
   </div>
     <button class="btn btn-link explantion-btn col-sm-12 col-lg-2 pt-0" data-action="<%= "explanation##{controller_name}" %>">Hide</button>

--- a/app/views/catalog/_hathitrust_button.html.erb
+++ b/app/views/catalog/_hathitrust_button.html.erb
@@ -1,6 +1,6 @@
 <div class="row button-break"></div>
-<button class="btn online-btn collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document.id %>" id="online-<%=  document.id %>">
-  <span class="avail-label" aria-expanded="false">Available online</span>
+<button class="btn online-btn collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document.id %>" aria-expanded="false" id="online-<%=  document.id %>">
+  <span class="avail-label">Available online</span>
 </button>
 <div id="online-document-<%= document.id %>" class="collapse online_resources online-list mt-1">
   <h3 class="online-card-heading card-title mb-0">Online</h3>

--- a/app/views/catalog/_index_summary_field.html.erb
+++ b/app/views/catalog/_index_summary_field.html.erb
@@ -5,12 +5,12 @@
       <% if rendered.length == 1 %>
         <div class="blacklight-<%= field_name.parameterize %> summary-previews pt-2 px-3"><%= safe_join(Array.wrap(rendered)) %></div>
       <% elsif rendered.length > 1 %>
-        <div class="blacklight-<%= field_name.parameterize %> summary-previews pt-2"
+        <div class="blacklight-<%= field_name.parameterize %> summary-previews pt-2">
           <ul>
           <% rendered.each do |value| %>
             <li class="list_items"> <%= safe_join(Array.wrap(value)) %> </li>
           <% end %>
-          </ul
+          </ul> 
         </div>
       <% end -%>
   <% end -%>

--- a/app/views/catalog/_online_availability_button.html.erb
+++ b/app/views/catalog/_online_availability_button.html.erb
@@ -1,7 +1,7 @@
 <% if has_many_electronic_resources?(document) %>
   <div class="row button-break pt-3"></div>
-  <button class="btn online-btn collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document.id %>" id="online-<%=  document.id %>">
-    <span class="avail-label" aria-expanded="false">Available online</span>
+  <button class="btn online-btn collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document.id %>" aria-expanded="false" id="online-<%=  document.id %>">
+    <span class="avail-label">Available online</span>
   </button>
   <%= render "libkey_btn", :document => document %>
   <div id="online-document-<%= document.id %>" class="collapse online_resources online-list mt-1">

--- a/app/views/catalog/_physical_availability_card.html.erb
+++ b/app/views/catalog/_physical_availability_card.html.erb
@@ -47,5 +47,5 @@
   <% end %>
 
 <% else %>
-  <div id="error-message"><%= t("blacklight.errors.availability_alert_general_html", href: link_to(t("blacklight.errors.error_help_href"), t("blacklight.errors.error_help_link"))) %></div>
+  <div class="error-message"><%= t("blacklight.errors.availability_alert_general_html", href: link_to(t("blacklight.errors.error_help_href"), t("blacklight.errors.error_help_link"))) %></div>
 <% end %>

--- a/app/views/catalog/_purchase_order_anonymous_button.html.erb
+++ b/app/views/catalog/_purchase_order_anonymous_button.html.erb
@@ -1,6 +1,6 @@
 <div class="row button-break pt-3"></div>
-<button class="btn purchase-order collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document.id %>" id="many_links_online">
-  <span class="avail-label" aria-expanded="false">Request Rapid Access</span>
+<button class="btn purchase-order collapsed collapse-button" data-toggle="collapse" data-target="#online-document-<%=  document.id %>" aria-expanded="false" id="many_links_online">
+  <span class="avail-label">Request Rapid Access</span>
 </button>
 
 <span class="requests-container"><%= link %></span>

--- a/app/views/catalog/_show_fields.html.erb
+++ b/app/views/catalog/_show_fields.html.erb
@@ -3,7 +3,7 @@
 <% if rendered.length == 1 %>
   <dd class="blacklight-<%= field_name.parameterize %> col-xs-12 col-sm-9"><%= safe_join(Array.wrap(rendered)) %></dd>
 <% elsif rendered.length > 1 %>
-  <dd class="blacklight-<%= field_name.parameterize %> col-xs-12 col-sm-9"
+  <dd class="blacklight-<%= field_name.parameterize %> col-xs-12 col-sm-9">
     <ul>
     <% rendered.each do |value| %>
       <li class="list_items"> <%= safe_join(Array.wrap(value)) %> </li>

--- a/app/views/primo_central/_online_button.html.erb
+++ b/app/views/primo_central/_online_button.html.erb
@@ -1,6 +1,6 @@
 <div class="row button-break pt-3"></div>
-<button class="btn online-btn collapsed collapse-button" data-toggle="collapse" data-target="#<%= document_id %>" onclick="loadArticleIframe('div#<%= document_id %>');" id="online_button">
-  <span class="avail-label" aria-expanded="false">Available online</span>
+<button class="btn online-btn collapsed collapse-button" data-toggle="collapse" data-target="#<%= document_id %>" aria-expanded="false" onclick="loadArticleIframe('div#<%= document_id %>');" id="online_button">
+  <span class="avail-label">Available online</span>
 </button>
 
 <%= render "libkey_btn", :document => @document %>

--- a/spec/features/axe_spec.rb
+++ b/spec/features/axe_spec.rb
@@ -5,28 +5,19 @@ require "rails_helper"
 RSpec.describe "Accessibility testing", api: false, js: true do
   xit "validates the home page" do
     visit root_path
-    #expect(page).to be_accessible
-    expect(page).to be_axe_clean
+    expect(page).to be_axe_clean.according_to :wcag2a, :wcag2aa
   end
 
-  xit "validates the catalog page" do
+  xit "validates a catalog search results page" do
     visit "/catalog"
     fill_in "q", with: "history"
     click_button "search"
-
-    # aria-allowed-role doesn"t like nav[role="region"]
-    #expect(page).to be_accessible(skipping: ["aria-allowed-role"])
-    expect(page).to be_axe_clean
+    expect(page).to be_axe_clean.according_to :wcag2a, :wcag2aa
   end
 
-  xit "validates the single results page" do
+  xit "validates the full record page for catalog record" do
     visit solr_document_path("991012171319703811")
-    #expect(page).to be_accessible
-    expect(page).to be_axe_clean
+    expect(page).to be_axe_clean.according_to :wcag2a, :wcag2aa
   end
 
-  def be_accessible(skipping: [])
-    # typeahead does funny things with the search bar
-    be_axe_clean.excluding(".tt-hint").skipping(skipping + [("color-contrast" if Bootstrap::VERSION < "5")])
-  end
 end


### PR DESCRIPTION
I updated the spec to adhere to WCAG2 Level A and AA, which is TU's standard. I also made the following changes based on failing tests:
- I fixed ul element errors resulting in invalid html structure. 
- The aria-expanded attribute was in the wrong place for some buttons, so I moved the attribute from <span> to <button> whichs match other buttons that were correctly tagged. 
- The id "error-message" is not matched to unique element on page in some scenarios, so I updated to class instead. 
- I updated the styling of explanation box to better distinguish the embedded link. 

There still is one outstanding failure related to https://dequeuniversity.com/rules/axe/4.7/link-in-text-block, which I will need to follow up on design options for. Because of this, I'm leaving the "xit" skips in place for now. 