### PR TITLE
DEVO-805: Use memacached as the session store.

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,10 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: "_tulcob_session"
+
+if ENV["K8"] == "yes"
+  require "action_dispatch/middleware/session/dalli_store"
+  Rails.application.config.session_store :dalli_store, "_tulcob_session"
+else
+  Rails.application.config.session_store :cookie_store, key: "_tulcob_session"
+end


### PR DESCRIPTION
Move the session state out of the app to avoid needing to coordinate sessions with the k8 ingress.