### PR TITLE
DEVO-807 Update skylight version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "railties"
 gem "rsolr", "~> 2.4"
 gem "ruby-saml", "1.14.0"
 gem "sass-rails", "~> 6.0"
-gem "skylight", "4.3.2"
+gem "skylight"
 gem "turbolinks", "~> 5"
 gem "twitter-typeahead-rails", "0.11.1"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,7 @@ GEM
       sprockets-rails
       tilt
     scrub_rb (1.0.1)
-    selenium-webdriver (4.9.1)
+    selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -520,10 +520,8 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
-    skylight (4.3.2)
-      skylight-core (= 4.3.2)
-    skylight-core (4.3.2)
-      activesupport (>= 4.2.0)
+    skylight (5.3.4)
+      activesupport (>= 5.2.0)
     slop (4.10.1)
     spring (4.1.1)
     sprockets (4.2.0)
@@ -682,7 +680,7 @@ DEPENDENCIES
   selenium-webdriver
   simplecov
   simplecov-lcov
-  skylight (= 4.3.2)
+  skylight
   spring
   sqlite3
   stackprof


### PR DESCRIPTION
Now that we are not on CentOS 7 we no longer need to pin skylight to an older version.  I have added the necessary env vars in vault, so I am hoping this is all that is needed to get it running in kubernetes.