### PR TITLE
Ref: Bl-1783: Alert honeybadger on libkey error

### DIFF
--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -150,8 +150,13 @@ module Blacklight::PrimoCentral::Document
       libkey_articles_url = "#{base_url}/#{library_id}/articles/doi/#{@doi}?access_token=#{access_token}"
 
       Thread.new {
-        (HTTParty.get(libkey_articles_url, timeout: 2) rescue {})["data"]
-          &.slice("retractionNoticeUrl", "fullTextFile", "contentLocation")
+        begin
+          HTTParty.get(libkey_articles_url, timeout: 2)["data"]
+            &.slice("retractionNoticeUrl", "fullTextFile", "contentLocation")
+        rescue => e
+          Honeybadger.notify(e)
+          nil
+        end
       }
     end
 end


### PR DESCRIPTION
If something goes wrong getting a libkey, send an error to Honeybadger logs.