### PR TITLE
Update the keyword for capabilities

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,7 @@ Capybara.register_driver :headless_chrome do |app|
     opts.args << "--no-sandbox"
     opts.args << "--window-size=1280,1696"
   end
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: capabilities)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: capabilities)
 end
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Version 4.12.0 of the seleniuv-webdriver has an update that is breaking one of our tests.  The capabilities keyword has been changed to options instead.  See further details here: https://stackoverflow.com/questions/77045183/rails-7-capybara-with-selenium-webdrivers-fails-unknown-keyword-capabilitie
