### PR TITLE
BL-1809 Don't include null values in article creator links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -337,6 +337,7 @@ module ApplicationHelper
   def creator_links(args)
     separator = args.dig(:config, :separator)
     creator = args[:document][args[:field]] || []
+    creator.delete("null")
     creator_links = creator.map do |creator_data|
       begin
         creator_data = JSON.parse(creator_data)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -540,6 +540,20 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
 
+    context "an article creator with a null value" do
+      let(:controller_name) { "primo_central" }
+      let(:args) { { document: { creator: ["null", "Emily Dickinson"] }, field: :creator } }
+
+      it "returns a list of links without null values" do
+        expect(creator_links(args)).to_not include([
+          "<a href=\"http://test.host/articles?search_field=creator&amp;q=null\">null</a>"
+        ])
+        expect(creator_links(args)).to eq([
+          "<a href=\"http://test.host/articles?search_field=creator&amp;q=Emily Dickinson\">Emily Dickinson</a>"
+        ])
+      end
+    end
+
     context "no catalog creator" do
       let(:controller_name) { "primo_central" }
       let(:args) { { document: { creator_facet: [""] }, field: :creator_facet } }


### PR DESCRIPTION
We received a honey badger error this week due to the fact that an article creator has a null value.  Refactored the helper method to delete null values.