### PR TITLE
Update selenium webdriver gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,10 @@ jobs:
 
       - restore_cache:
           keys:
-            - gem-cache-v8-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - gem-cache-v8-{{ arch }}-{{ .Branch }}
-            - gem-cache-v8-{{ arch }}
-            - yarn-cache-v8-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - gem-cache-v12-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - gem-cache-v12-{{ arch }}-{{ .Branch }}
+            - gem-cache-v12-{{ arch }}
+            - yarn-cache-v12-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
 
       - setup_remote_docker:
           docker_layer_caching: false
@@ -64,12 +64,12 @@ jobs:
           command: make ci-copy-node-modules-to-local
 
       - save_cache:
-          key: gem-cache-v8-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: gem-cache-v12-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
               - vendor/bundle
 
       - save_cache:
-          key: yarn-cache-v8-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: yarn-cache-v12-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
               - node_modules
 

--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ group :development, :test do
   gem "rspec-rails"
   gem "rubocop"
   gem "rubocop-rails"
-  gem "selenium-webdriver"
+  gem "selenium-webdriver", "4.10.0"
   gem "simplecov"
   gem "simplecov-lcov"
   gem "vcr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,7 +510,7 @@ GEM
       sprockets-rails
       tilt
     scrub_rb (1.0.1)
-    selenium-webdriver (4.9.0)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -599,7 +599,7 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -680,7 +680,7 @@ DEPENDENCIES
   ruby-prof
   ruby-saml (= 1.15.0)
   sass-rails (~> 6.0)
-  selenium-webdriver
+  selenium-webdriver (= 4.10.0)
   simplecov
   simplecov-lcov
   skylight


### PR DESCRIPTION
We keep having issues with tests on main failing.  This updates the seleniuv-webdriver to the last passing version.  It also changes the cache versions to something that I didn't use when I was trying to fix the selenium issue earlier this week.