### PR TITLE
BL-1813: Temporarily add libproxy to get_it link.

### DIFF
--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -124,10 +124,15 @@ module Blacklight::PrimoCentral::Document
       doc.dig("delivery", "GetIt1", 0, "links", 0) || {}
     end
 
-    def url_query
-      query = (URI.parse(@url).query rescue nil)
+    def url_query(url = @url)
+      query = (URI.parse(url).query rescue nil)
       if (query)
         q = CGI.parse(query) || {}
+
+        if q["url"].present?
+          return url_query(q["url"].first)
+        end
+
         q.select { |k, v| v && !v.empty? && v != [""] }
       else
         {}

--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -107,7 +107,12 @@ module Blacklight::PrimoCentral::Document
     }
 
     def url(doc)
-      get_it(doc).fetch("link", "")
+      # TODO remove adding libroxy once we fix root cause of it getting removed.
+      url = get_it(doc).fetch("link", "")
+      if url.present? && !url.match?(/libproxy/)
+        url = "https://libproxy.temple.edu/login?url=" + url
+      end
+      url
     end
 
     def link_label(doc)

--- a/spec/models/primo_central_document_spec.rb
+++ b/spec/models/primo_central_document_spec.rb
@@ -272,6 +272,42 @@ RSpec.describe PrimoCentralDocument, type: :model do
     end
   end
 
+  describe "url" do
+    let(:link) {}
+    let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
+      delivery: {
+        GetIt1: [{
+          "links" => [{ "link" => link }],
+        }] }) }
+    let(:url) { subject.send(:url, doc) }
+
+    # TODO: This should be removed once we fix root of issue in k8.
+    # @see https://tulibdev.atlassian.net/browse/BL-1813
+    context "proxy URL section not present in link" do
+      let(:link) { "https://search.proquest.com/docview/2848172314?pq-origsite=primo" }
+      it "should add the proxy URL section" do
+
+        expect(url).to eq("https://libproxy.temple.edu/login?url=https://search.proquest.com/docview/2848172314?pq-origsite=primo")
+      end
+    end
+
+    context "proxy URL is present in link" do
+      let(:link) { "http://libproxy.temple.edu/login?url=https://search.proquest.com/docview/2848172314?pq-origsite=primo" }
+
+      it "should return link without changing anything" do
+        expect(url).to eq(link)
+      end
+    end
+
+    context "No link present" do
+      let(:doc) { {} }
+
+      it "should not do anyting" do
+        expect(url).to eq("")
+      end
+    end
+  end
+
   describe "libkey_articles_url" do
     context "doi not present" do
       let(:doc) { {} }


### PR DESCRIPTION
libproxy section to links is getting removed by our k8 instance.

IST is looking into it.

In the meantime we can just add it ourselves and remove this once they fix the root cause.