### PR TITLE
BL-1814: Fix url_query method in primo document model.

### DIFF
--- a/app/models/blacklight/primo_central/document.rb
+++ b/app/models/blacklight/primo_central/document.rb
@@ -119,10 +119,15 @@ module Blacklight::PrimoCentral::Document
       doc.dig("delivery", "GetIt1", 0, "links", 0) || {}
     end
 
-    def url_query
-      query = (URI.parse(@url).query rescue nil)
+
+    def url_query(url = @url)
+      query = (URI.parse(url).query rescue nil)
       if (query)
         q = CGI.parse(query) || {}
+
+        if q["url"].present?
+          return url_query(q["url"].first)
+        end
         q.select { |k, v| v && !v.empty? && v != [""] }
       else
         {}

--- a/spec/models/primo_central_document_spec.rb
+++ b/spec/models/primo_central_document_spec.rb
@@ -228,6 +228,18 @@ RSpec.describe PrimoCentralDocument, type: :model do
     end
   end
 
+  context "document direct_link is proxied and isbn=foo" do
+    let(:doc) { ActiveSupport::HashWithIndifferentAccess.new(
+      delivery: {
+        GetIt1: [{
+          "links" => [{ "link" => "http://myproxy.edu?url=http://foobar.com?rft.isbn=foo" }],
+        }] }) }
+    it "sets @doc['isbn'] to foo" do
+      expect(subject["isbn"]).to eq(["foo"])
+    end
+  end
+
+
   describe "#purchase_order?" do
     context "with purchase_order false" do
       let(:document) { PrimoCentralDocument.new(purchase_order: false) }


### PR DESCRIPTION
Working on bl-1813 I realized that whe URLs are proxied that url_query method is not working.

This change fixes that issue.