### PR TITLE
Alpine version docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ workflows:
 jobs:
   run_tests:
     docker:
-      - image: cimg/ruby:3.1-node
+      - image: cimg/ruby:3.1.3-node
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD

--- a/.docker/app/Dockerfile.prod
+++ b/.docker/app/Dockerfile.prod
@@ -14,18 +14,18 @@ ARG SECRET_KEY_BASE
 
 # libc6-compat is required for m1 build.
 RUN apk add -U --no-cache \
-      bash=5.2.15-r5 \
-      libc6-compat=1.2.4-r2 \
-      libxslt=1.1.38-r0 \
-      mariadb-connector-c=3.3.5-r0 \
-      shared-mime-info=2.2-r5  \
+      bash=5.2.21-r0 \
+      libc6-compat=1.1.0-r4 \
+      libxslt=1.1.39-r0 \
+      mariadb-connector-c=3.3.8-r0 \
+      shared-mime-info=2.4-r0  \
       tzdata=2023c-r1 && \
     apk add -U --no-cache --virtual build-dependencies \
       build-base=0.5-r3 \
-      git=2.40.1-r0 \
-      libxslt-dev=1.1.38-r0 \
-      mariadb-dev=10.11.5-r0 \
-      nodejs=18.18.2-r0 \
+      git=2.43.0-r0 \
+      libxslt-dev=1.1.39-r0 \
+      mariadb-dev=10.11.5-r3 \
+      nodejs=20.10.0-r1 \
       yarn=1.22.19-r0 && \
     bundle config set --local without "development test" && \
     bundle install --jobs=8 && \

--- a/.docker/ci-app/Dockerfile.ci
+++ b/.docker/ci-app/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM ruby:3.1-alpine
+FROM ruby:3.1.3-alpine
 RUN apk --update add nodejs yarn git build-base bash mysql-dev sqlite-dev tzdata shared-mime-info libssl1.1
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
Uses 3.1.3-alpine to get libssl1.1. This is an old version and should be updated in future. 3.1.4-alpine uses libssl3. 

Current rails dependencies (bootsnap) require this older version.