### PR TITLE
BL-1828 Fix RIS export in articles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,6 +48,8 @@ module ApplicationHelper
   def ris_path(opts = {})
     if controller_name == "bookmarks"
       bookmarks_path(opts.merge(format: "ris"))
+    elsif controller_name == "primo_central"
+      article_document_path(opts.merge(format: "ris"))
     else
       solr_document_path(opts.merge(format: "ris"))
     end


### PR DESCRIPTION
This code was removed in https://github.com/tulibraries/tul_cob/pull/4043 which broke the RIS export for articles. 