### PR TITLE
Revert "Bump mysql2 from 0.5.5 to 0.5.6"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ group :development, :test do
 end
 
 group :production do
-  gem "mysql2", "~> 0.5.6"
+  gem "mysql2", "~> 0.5.5"
   # required for using memcached
   gem "dalli"
   gem "connection_pool"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,7 +358,7 @@ GEM
     msgpack (1.7.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    mysql2 (0.5.6)
+    mysql2 (0.5.5)
     net-http (0.4.1)
       uri
     net-imap (0.4.10)
@@ -663,7 +663,7 @@ DEPENDENCIES
   jwt
   launchy
   lc_solr_sortable!
-  mysql2 (~> 0.5.6)
+  mysql2 (~> 0.5.5)
   net-smtp
   nokogiri (= 1.16.2)
   okcomputer


### PR DESCRIPTION
Reverts tulibraries/tul_cob#4201

crash looping on qa with this error:

```
+ librarysearch-app-7f65694c76-px6c5 › db-migrate
librarysearch-app-7f65694c76-px6c5 db-migrate Can't connect to server on 'librarysearch-mariadb-primary' (115)
librarysearch-app-7f65694c76-px6c5 db-migrate Couldn't create 'librarysearch' database. Please check your configuration.
librarysearch-app-7f65694c76-px6c5 db-migrate rails aborted!
librarysearch-app-7f65694c76-px6c5 db-migrate ActiveRecord::ConnectionNotEstablished: Can't connect to server on 'librarysearch-mariadb-primary' (115) (ActiveRecord::ConnectionNotEstablished)
librarysearch-app-7f65694c76-px6c5 db-migrate 
librarysearch-app-7f65694c76-px6c5 db-migrate 
librarysearch-app-7f65694c76-px6c5 db-migrate Caused by:
librarysearch-app-7f65694c76-px6c5 db-migrate Mysql2::Error::ConnectionError: Can't connect to server on 'librarysearch-mariadb-primary' (115) (Mysql2::Error::ConnectionError)
librarysearch-app-7f65694c76-px6c5 db-migrate 
librarysearch-app-7f65694c76-px6c5 db-migrate Tasks: TOP => db:setup => db:create
librarysearch-app-7f65694c76-px6c5 db-migrate (See full trace by running task with --trace)
```