### PR TITLE
Bl 1829 update digital collections results on bento page

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,12 +15,13 @@ class SearchController < CatalogController
   def index
     @per_page = 3
     if params[:q]
-      engines = %i(books_and_media articles databases journals library_website lib_guides cdm)
+      engines = %i(books_and_media articles databases journals library_website lib_guides)
       searcher = BentoSearch::ConcurrentSearcher.new(*engines)
       searcher.search(params[:q], per_page: @per_page, semantic_search_field: params[:field])
 
       @results = process_results(searcher.results)
       @lib_guides_query_term = helpers.derived_lib_guides_search_term(@response)
+      @cdm_records = cdm_records(params[:q])
     end
 
     respond_to do |format|
@@ -49,15 +50,44 @@ class SearchController < CatalogController
         items.display_configuration = results["books_and_media"].display_configuration
 
         # Grabbing and setting @response in order to render facets.
-        # Merges cdm totals into the @response.
+        # Merges cdm records into the @response.
         @response = results["books_and_media"].last.custom_data
         @response.merge_facet(name: "format", value: "digital_collections", hits: cdm_total_items)
 
         results.merge(
-          "books_and_media" => items,
+          "books_and_media" => items
           ).except("cdm")
       else
         results.except("cdm")
       end
+    end
+
+    def cdm_records(query)
+      # binding.pry
+      query.gsub("/", " ")
+      query = ERB::Util.url_encode(query)
+      fields = "title!date"
+      format = "json"
+      cdm_url = "https://digital.library.temple.edu/digital/bl/dmwebservices/index.php?q=dmQuery/all/CISOSEARCHALL^#{query}^all^and/#{fields}/sortby/3/#{format}"
+      results = []
+      response = []
+
+      begin
+        response = JSON.load(URI.open(cdm_url))
+        total_items = response.dig("pager", "total") || 0
+        response["records"].each do |i|
+          item = OpenStruct.new
+          item.title = i.fetch("title")
+          item.date = i.fetch("date")
+          item.collection = i.fetch("collection")
+          item.link = "https://digital.library.temple.edu/digital/collection#{i["collection"]}/id/#{i["pointer"]}"
+          item.thumbnail = "https://digital.library.temple.edu/utils/ajaxhelper/?CISOROOT=#{i["collection"]}&CISOPTR=#{i["pointer"]}&action=2&DMSCALE=10&DMHEIGHT=340"
+          results << item
+        end 
+      rescue StandardError => e
+        total_items = 0
+        Honeybadger.notify("Ran into error while try to process CDM: #{e.message}")
+      end
+      results
     end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -63,7 +63,6 @@ class SearchController < CatalogController
     end
 
     def cdm_records(query)
-      # binding.pry
       query.gsub("/", " ")
       query = ERB::Util.url_encode(query)
       fields = "title!date"
@@ -83,7 +82,7 @@ class SearchController < CatalogController
           item.link = "https://digital.library.temple.edu/digital/collection#{i["collection"]}/id/#{i["pointer"]}"
           item.thumbnail = "https://digital.library.temple.edu/utils/ajaxhelper/?CISOROOT=#{i["collection"]}&CISOPTR=#{i["pointer"]}&action=2&DMSCALE=10&DMHEIGHT=340"
           results << item
-        end 
+        end
       rescue StandardError => e
         total_items = 0
         Honeybadger.notify("Ran into error while try to process CDM: #{e.message}")

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -92,6 +92,8 @@ module SearchHelper
       link_to "Books & Media", engine.url(self), id: "bento_" + id + "_header"
     elsif id == "lib_guides"
       link_to "Research Guides", engine.url(self), id: "bento_" + id + "_header"
+    elsif id == "cdm"
+      link_to "Digital Collections", engine.url(self), id: "bento_" + id + "_header"
     else
       link_to id.titleize , engine.url(self), id: "bento_" + id + "_header"
     end
@@ -128,5 +130,12 @@ module SearchHelper
       config = BentoSearch.get_engine(engine_id).configuration[:for_display]
       [engine_id, config]
     }.to_h
+  end
+
+  def cdm_collection_name(cdm_alias)
+    cdm_url = "https://digital.library.temple.edu/digital/bl/dmwebservices/index.php?q=dmGetCollectionList/json"
+    response = JSON.load(URI.open(cdm_url))
+    collection = response.select {|collection| collection["name"] if collection["alias"] == cdm_alias}
+    collection.first["name"]
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -135,7 +135,7 @@ module SearchHelper
   def cdm_collection_name(cdm_alias)
     cdm_url = "https://digital.library.temple.edu/digital/bl/dmwebservices/index.php?q=dmGetCollectionList/json"
     response = JSON.load(URI.open(cdm_url))
-    collection = response.select {|collection| collection["name"] if collection["alias"] == cdm_alias}
+    collection = response.select { |collection| collection["name"] if collection["alias"] == cdm_alias }
     collection.first["name"]
   end
 end

--- a/app/views/search/_digital_collections.html.erb
+++ b/app/views/search/_digital_collections.html.erb
@@ -1,17 +1,23 @@
-<% format_facet = @response.aggregations["format"] %>
 
   <div class="bento-resource-container">
-    <h2 class="bento-resource-types bg-lighter-grey"><%= t("bento.digital_collections_header") %></h2>
+    <h2 class="bento-resource-types bg-lighter-grey">
+      <%= link_to t("bento.digital_collections_header"), "https://digital.library.temple.edu/digital/search/searchterm/#{params[:q]}/order/nosort", style: "color: #011238" %></h2>
     <ul class="bento-resource-types-list pt-2 list-inline d-flex flex-wrap justify-content-start">
-      <% format_facet.items.select do |item| -%>
-        <% if item.value == "digital_collections" %>
-          <li class="bento-resource-list-item list-inline-item pb-1">
-            <%= render_bento_format_facet_value(item) %>
-            <%= link_to path_for_books_and_media_facet(format_facet, item) do %>
-              <span class='external-link-icon'></span>
-            <% end %>
-          </li>
-        <% end %>
+
+      <% @cdm_records.each do |cdm_record| %>
+        <li class="bento-resource-list-item list-inline-item pb-1">
+          <%= link_to cdm_record.link do %>
+            <%= image_tag cdm_record.thumbnail %>
+            <div class="pt-2 w-75">
+              <%= cdm_record.title %>
+            </div>
+          <% end %>
+          <p class="w-75" style="color:black;font-size:1rem;">
+            <%= "Date: #{cdm_record["date"]}" if cdm_record["date"].present? %>
+            <br /><%= cdm_collection_name(cdm_record.collection) %>
+          </p>
+        </li>
       <% end %>
+
     </ul>
   </div>

--- a/config/initializers/cdm.rb
+++ b/config/initializers/cdm.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 CDM.configure do |config|
-  config.server_url = "https://server16002.contentdm.oclc.org"
-  config.max_recs = "1"
+  config.server_url = "https://digital.library.temple.edu/digital"
+  config.max_recs = "3"
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,7 +251,7 @@ en:
     faq_link: "https://answers.library.temple.edu"
     resource_types_header: "More search results"
     research_guides_header: "Browse our Research Guides and FAQ"
-    digital_collections_header: "Search our Digitized Collections for unique materials held by Temple"
+    digital_collections_header: "Digitized Collections for unique materials held by Temple"
     application_name: "Library Bento Search Beta"
     explanation_html: "<strong>Library Search:</strong> results from %{articles}, %{journals}, and %{more}."
     section_heading_html: "Library Search is your gateway to discover library content. Search <strong>Everything</strong> to discover results in %{more}, %{articles}, %{databases}, %{journals}, and %{website}."


### PR DESCRIPTION
This is a work in progress. Currently it avoids trying to get the CDM api data into the BentoSearchResults structure.

It may be possible to get the data to work in the BentoSearch system but the CDM gem will need updating. It currently only does a simple find without using the dmWebServices api endpoint (although there was work done in the gem to construct more advanced queries against that endpoint, it is not used). Also, either custom fields will need to be added to a BentoSearchItem, or existing fields repurposed to bring in the data. There is a digital_collections partial which does not render as a bento box and which can use custom logic and repurposed field names if the data can be put into the bento_results.

No rspec work has been started yet.