### PR TITLE
Fix cached actions.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CatalogController < ApplicationController
-  caches_page :show, expires_in: 24.hours
+  caches_page :show
   caches_action :index, expires_in: 12.hours, cache_path: Proc.new { |c| c.request.url }
 
   include FacetParamsDedupe
@@ -13,6 +13,7 @@ class CatalogController < ApplicationController
   include ServerErrors
   include LCClassifications
 
+  skip_forgery_protection only: [:index]
   before_action :authenticate_purchase_order!, only: [ :purchase_order, :purchase_order_action ]
   before_action :set_thread_request
   before_action only: :index do

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,6 +18,8 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
+  config.cache_store = :mem_cache_store, nil, { pool_size: 10, pool_timeout: 5 }
+
   if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
@@ -89,4 +91,6 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.action_controller.page_cache_directory = Rails.root.join("tmp", "cached_pages")
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -136,4 +136,5 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
   Deprecation.default_deprecation_behavior = :silence
+  config.action_controller.page_cache_directory = Rails.root.join("public", "cached_pages")
 end


### PR DESCRIPTION
Actions fail when cached using memcached because of forgery protection.

Disabling the forgery proection for index actions fixes issue.

Also moves cached pages to temp folder.

Also removes useless expire config for cached pages.