### PR TITLE
Don't notify Honeybadger when a CDM image isn't available

### DIFF
--- a/app/search_engines/bento_search/cdm_engine.rb
+++ b/app/search_engines/bento_search/cdm_engine.rb
@@ -106,7 +106,6 @@ module BentoSearch
         response = http.head(url.request_uri)
         response.code.to_i == 200
       rescue => e
-        Honeybadger.notify(e, error_message: "Error when checking if CDM image is available")
         false
       end
     end


### PR DESCRIPTION
If we include this notification, we will get lots of errors for expected behavior (ex. when there isn't a "full_image_url" and switch to using a "thumbnail_image_url")