### PR TITLE
Remove preload tag

### DIFF
--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -36,7 +36,7 @@
     <%= opensearch_description_tag application_name, opensearch_catalog_url(:format => "xml") %>
     <%= favicon_link_tag %>
     <%= stylesheet_link_tag "application", media: "all" %>
-    <%= stylesheet_link_tag "application", "//use.fontawesome.com/releases/v5.6.1/css/all.css", rel="preload" %>
+    <%= stylesheet_link_tag "application", "//use.fontawesome.com/releases/v5.6.1/css/all.css" %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
     <%= render partial: "shared/campus_closed" %>
     <%= javascript_pack_tag "application", 'data-turbolinks-track': 'reload', defer: true %>


### PR DESCRIPTION
I have noticed in the logs that we have a significant number of get requests for stylesheets/preload.css that are erroring out because that file doesn't exist. Removing rel=preload removes the error for me locally. 