### PR TITLE
BL-1873 Response sort and pagination

### DIFF
--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,4 +1,0 @@
-<div id="sortAndPerPage" class="sort-pagination d-flex flex-wrap align-items-start">
-  <%= render partial: "paginate_compact", object: @response if show_pagination? %>
-  <%= render_results_collection_tools wrapping_class: "search-widgets" %>
-</div>


### PR DESCRIPTION
It looks like we are already using the Blacklight components for sort and pagination.  We were overriding a related Blacklight partial that I think we can remove.  They made some updates that now render the content the same way that we were rendering it.