### PR TITLE
BL-1866 Clean up almaws controller and add low-level caching

### DIFF
--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -89,7 +89,7 @@ module AlmawsHelper
     item.library == "ASRS"
   end
 
-  def available_asrs_items(items = @items.all)
+  def available_asrs_items(items = @items)
     asrs_items(items).select { |item|
       if item.physical_material_type["value"] == "DVD"
         item

--- a/app/lib/cob_alma/requests.rb
+++ b/app/lib/cob_alma/requests.rb
@@ -48,14 +48,13 @@ module CobAlma
       ["MAIN", "AMBLER", "GINSBURG", "PODIATRY", "HARRISBURG"]
     end
 
-    def self.available_locations(grouped_by_library_items_list)
-      grouped_by_library_items_list.select { |key, val|
-        val.any?(&:in_place?) }.keys
+    def self.available_libraries(items_list)
+      items_list.select { |library, items| items.any?(&:in_place?) }.keys
     end
 
     def self.valid_pickup_locations(items_list)
+      libraries = self.available_libraries(items_list)
       pickup_locations = self.possible_pa_pickup_locations
-      libraries = self.available_locations(items_list)
 
       if libraries.any?
         removals = []
@@ -84,7 +83,7 @@ module CobAlma
 
       pickup_locations = self.possible_pa_pickup_locations
 
-      items_list.all.reduce({}) { |libraries, item|
+      items_list.reduce({}) { |libraries, item|
         desc = item.description
         campus = self.determine_campus(item.library)
         removals = []
@@ -138,7 +137,7 @@ module CobAlma
     end
 
     def self.descriptions(items_list)
-      descriptions = items_list.all.map(&:description)
+      descriptions = items_list.map(&:description)
 
       if descriptions.any?
         descriptions.each do |desc|
@@ -149,7 +148,7 @@ module CobAlma
     end
 
     def self.material_type_and_asrs_descriptions(items_list)
-      types_and_descriptions = items_list.all
+      types_and_descriptions = items_list
         .select { |item| item.library == "ASRS" && item.in_place? }
         .map { |item|
           Hash[item.physical_material_type["desc"], [item.description]] unless item.physical_material_type["value"] == ""
@@ -194,7 +193,7 @@ module CobAlma
     end
 
     def self.physical_material_type_and_descriptions(items_list)
-      types_and_descriptions = items_list.all.map { |item|
+      types_and_descriptions = items_list.map { |item|
         Hash[item.physical_material_type["desc"], [item.description]] unless item.physical_material_type["value"] == ""
       }.uniq.compact
 


### PR DESCRIPTION
Updates include: 
- Moved bib items api call to private method and added low-level cache with duration of 30 seconds -- We want close to real-time availability for item and request views, but my hope is that this might help in cases where users view item availability panels and request modal in quick succession. We can remove the cache, though, if needed. 
- Removed code that it is no longer actively used, primarily related to item display pagination (not active)
- Simplified and fixed some issues with how we were using the methods related to Alma::BibItem and Alma::BibItemSet 
- Switched to using @document for data that can be pulled from the bibliographic record (@books, @author)
- Reordered and grouped variables according to their function

This should also fix BL-1825.
