### PR TITLE
Remove unnecessary catalog#show override.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -575,25 +575,6 @@ class CatalogController < ApplicationController
     redirect_back(**to_the_future) unless current_user.can_purchase_order?
   end
 
-  # Override the show method so we can suppress some items that solr doesn't want to filter out
-  # get a single document from the index
-  # to add responses for formats other than html or json see _Blacklight::Document::Export_
-  def show
-    deprecated_response, @document = search_service.fetch(params[:id])
-    @response = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_response, "The @response instance variable is deprecated; use @document.response instead.")
-
-    # Our override that can be removed if we can figure out how to do a negatove filter query in the document/get handler
-    # without breaking results that shouldn't be filtered.
-    if @document.blank? || @document.is_suppressed?
-      raise Blacklight::Exceptions::RecordNotFound
-    end
-
-    respond_to do |format|
-      format.html { @search_context = setup_next_and_previous_documents }
-      format.json
-      additional_export_formats(@document, format)
-    end
-  end
 
   # Override index because we don't show any results at /catalog when
   # there are no parameters, and so we don't need to bother solr

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -9,8 +9,7 @@ class PrimoCentralController < CatalogController
   helper_method :tags_strip
   helper_method :solr_range_queries_to_a
 
-  rescue_from Primo::Search::ArticleNotFound, with: :invalid_document_id_error
-  rescue_from Blacklight::Exceptions::RecordNotFound, with: :invalid_document_id_error
+  rescue_from ArticleNotFound, with: :invalid_document_id_error
   rescue_from Net::ReadTimeout, with: :net_read_timeout_rescue
 
   configure_blacklight do |config|

--- a/app/models/blacklight/primo_central/repository.rb
+++ b/app/models/blacklight/primo_central/repository.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-class ArticleNotFound < RuntimeError
-end
-
 module Blacklight::PrimoCentral
   class Repository < Blacklight::AbstractRepository
     include JsonLogger
@@ -50,7 +47,8 @@ module Blacklight::PrimoCentral
         )
         data[:range] = params[:range] || {}
       else
-        if response.count == 1
+        # Validate that for specific document searches we return a file.
+        if response["docs"].blank?
           raise ArticleNotFound
         end
       end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -14,7 +14,12 @@ class SolrDocument
   def initialize(doc, req = nil)
     doc[:materials_data] = materials_data
     @libkey_journals_url_thread = libkey_journals_url_thread(doc)
+
     super
+
+    if is_suppressed?
+      raise Blacklight::Exceptions::RecordNotFound
+    end
   end
 
   use_extension(Blacklight::Solr::Document::RisExport)

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module Tulcob
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    config.autoload_paths << Rails.root.join("lib")
     # Rails.autoloaders.logger = Logger.new "#{Rails.root}/log/autoloading.log"
 
     require "lc_classifications"

--- a/lib/article_not_found.rb
+++ b/lib/article_not_found.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ArticleNotFound < RuntimeError
+end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -23,9 +23,8 @@ RSpec.describe CatalogController, type: :controller do
     end
 
     context "when the record is suppressed" do
-      let(:document) { SolrDocument.new(id: doc_id, suppress_items_b: true) }
       it "raises a record not found error if the record is suppressed", with_rescue: true do
-        allow(search_service).to receive(:fetch).with(doc_id).and_return([mock_response, document])
+        allow(search_service).to receive(:fetch).with(doc_id).and_raise(Blacklight::Exceptions::RecordNotFound)
         allow(controller).to receive(:search_service).and_return(search_service)
 
         get :show, params: { id: doc_id }

--- a/spec/controllers/primo_central_controller_spec.rb
+++ b/spec/controllers/primo_central_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe PrimoCentralController, type: :controller do
     render_views
 
     it "handles a record not found exception", with_rescue: true do
-      allow(search_service).to receive(:fetch).and_raise(Primo::Search::ArticleNotFound, "glub glub glub")
+      allow(search_service).to receive(:fetch).and_raise(::ArticleNotFound, "glub glub glub")
       get :show, params: { id: 1 }
       expect(response.code).to eq "404"
       expect(response.body).to include "error-header not-found"

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -231,12 +231,22 @@ RSpec.describe SolrDocument, type: :model do
     end
 
   describe "#is_suppressed?" do
-    it "returns false when the document does not have the suppress_items_b field" do
-      expect(document.is_suppressed?).to be false
+    context "document does not have a supress_items_b field" do
+      it "returns false" do
+        expect(document.is_suppressed?).to be false
+      end
     end
 
-    it "returns true when the document has suppress_items_b as true" do
-      expect(SolrDocument.new(id: "1", suppress_items_b: true).is_suppressed?).to be true
+    context "document has a supress_items_b field value false" do
+      it "returns false" do
+        expect(document.is_suppressed?).to be false
+      end
+    end
+
+    context "document has a supress_items_b field value true" do
+      it "raises a  Blacklight::Exceptions::RecordNotFound error" do
+        expect { SolrDocument.new(id: "1", suppress_items_b: true) }.to raise_error(Blacklight::Exceptions::RecordNotFound)
+      end
     end
   end
 


### PR DESCRIPTION
The function of validating if the record is suppressed or nil can happen without overriding the blacklight catatalog#show method.