### PR TITLE
BL-1865 Add time estimates to request confirmation message

### DIFF
--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -25,10 +25,6 @@ module RequestHelper
       })).to_s
   end
 
-  def successful_request_message
-    t("requests.success_message_html", href: link_to(t("requests.success_message_href"), users_account_path))
-  end
-
   def modal_exit_button_name(make_modal_link)
     name = raw("&times;")
 

--- a/app/models/request_confirmation.rb
+++ b/app/models/request_confirmation.rb
@@ -18,8 +18,7 @@ class RequestConfirmation
   end
 
   def delivery_estimate
-    unless pickup_location.blank?
-      if pickup_location == "JAPAN" || pickup_location == "ROME"
+      if pickup_location == "JAPAN" || pickup_location == "ROME" || pickup_location.blank?
         nil
       elsif pickup_location == "MAIN" && sent_from == "ASRS"
         "1 hour, delivered from the Charles Library BookBot when open"
@@ -28,7 +27,6 @@ class RequestConfirmation
       else
         "1-3 business days"
       end
-    end
   end
 
   def delivery_estimate?

--- a/app/models/request_confirmation.rb
+++ b/app/models/request_confirmation.rb
@@ -18,7 +18,7 @@ class RequestConfirmation
   end
 
   def delivery_estimate
-    if pickup_location == "JAPAN" || pickup_location == "ROME" || pickup_location.blank?
+    if pickup_location.blank? || [ "JAPAN", "ROME"].include?(pickup_location)
       nil
     elsif pickup_location == "MAIN" && sent_from == "ASRS"
       "1 hour, delivered from the Charles Library BookBot when open"

--- a/app/models/request_confirmation.rb
+++ b/app/models/request_confirmation.rb
@@ -18,15 +18,15 @@ class RequestConfirmation
   end
 
   def delivery_estimate
-      if pickup_location == "JAPAN" || pickup_location == "ROME" || pickup_location.blank?
-        nil
-      elsif pickup_location == "MAIN" && sent_from == "ASRS"
-        "1 hour, delivered from the Charles Library BookBot when open"
-      elsif pickup_location == sent_from
-        "1-2 business days"
-      else
-        "1-3 business days"
-      end
+    if pickup_location == "JAPAN" || pickup_location == "ROME" || pickup_location.blank?
+      nil
+    elsif pickup_location == "MAIN" && sent_from == "ASRS"
+      "1 hour, delivered from the Charles Library BookBot when open"
+    elsif pickup_location == sent_from
+      "1-2 business days"
+    else
+      "1-3 business days"
+    end
   end
 
   def delivery_estimate?

--- a/app/models/request_confirmation.rb
+++ b/app/models/request_confirmation.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class RequestConfirmation
+  include AvailabilityHelper
+
+  attr_reader :request_id
+  attr_reader :sent_from
+  attr_reader :pickup_location
+
+  def initialize(response, pickup_location = nil)
+    @request_id = response&.request_id
+    @sent_from = response&.managed_by_library_code
+    @pickup_location = pickup_location
+  end
+
+  def message
+    I18n.t("requests.default_success_message") + delivery_estimate_message + I18n.t("requests.request_status_message")
+  end
+
+  def delivery_estimate
+    if pickup_location == "JAPAN" || pickup_location == "ROME"
+      nil
+    elsif pickup_location == "MAIN" && sent_from == "ASRS"
+      "1 hour, delivered from the Charles Library BookBot when open"
+    elsif pickup_location == sent_from
+      "1-2 business days"
+    else
+      "1-3 business days"
+    end
+  end
+
+  def delivery_estimate?
+    delivery_estimate.present?
+  end
+
+  def delivery_estimate_message
+    pickup_location_name = library_name_from_short_code(pickup_location)
+
+    if delivery_estimate?
+      I18n.t("requests.delivery_estimate_message", pickup: pickup_location_name, estimate: delivery_estimate)
+    else
+      ""
+    end
+  end
+end

--- a/app/models/request_confirmation.rb
+++ b/app/models/request_confirmation.rb
@@ -18,14 +18,16 @@ class RequestConfirmation
   end
 
   def delivery_estimate
-    if pickup_location == "JAPAN" || pickup_location == "ROME"
-      nil
-    elsif pickup_location == "MAIN" && sent_from == "ASRS"
-      "1 hour, delivered from the Charles Library BookBot when open"
-    elsif pickup_location == sent_from
-      "1-2 business days"
-    else
-      "1-3 business days"
+    unless pickup_location.blank?
+      if pickup_location == "JAPAN" || pickup_location == "ROME"
+        nil
+      elsif pickup_location == "MAIN" && sent_from == "ASRS"
+        "1 hour, delivered from the Charles Library BookBot when open"
+      elsif pickup_location == sent_from
+        "1-2 business days"
+      else
+        "1-3 business days"
+      end
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,8 +195,9 @@ en:
     resource_sharing_broker_text: "For books unavailable from Temple University Libraries, search for and request the book through EZBorrow. Books typically arrive in 3-5 business days."
     resource_sharing_broker_link: "Go to EZBorrow"
     no_request_options: "This item cannot be requested from other Temple campuses."
-    success_message_html: "Your request has been submitted. You will receive an email notification when an item is ready for pickup. See %{href} for status information about your request."
-    success_message_href: "My Account"
+    default_success_message: "Request submitted! "
+    delivery_estimate_message: "Your item will be available for pickup at %{pickup} in approximately %{estimate}. "
+    request_status_message: "You will receive an email notification when the item is ready."
     form:
       pickup_locations_label: "Where will you pick it up?"
       description_label_html: "Description <i>(optional): </i>"

--- a/spec/fixtures/requests/request_sent_from_ambler.json
+++ b/spec/fixtures/requests/request_sent_from_ambler.json
@@ -1,0 +1,32 @@
+{
+    "title": "Test Ambler",
+    "author": "",
+    "description": "",
+    "volume": "",
+    "issue": "",
+    "part": "",
+    "user_primary_id": "user_id",
+    "request_id": "ambler_request_id",
+    "additional_id": "",
+    "request_type": "HOLD",
+    "request_sub_type": {
+      "value": "PATRON_PHYSICAL",
+      "desc": "Patron physical item request"
+    },
+    "mms_id": "request_sent_from_ambler",
+    "holding_id": "holding_id",
+    "pickup_location": "Charles Library",
+    "pickup_location_type": "LIBRARY",
+    "pickup_location_library": "MAIN",
+    "managed_by_library": "Ambler Campus Library",
+    "managed_by_circulation_desk": "Ambler Circulation Desk",
+    "managed_by_library_code": "AMBLER",
+    "managed_by_circulation_desk_code": "AMB_CIRC",
+    "material_type": {},
+    "date_of_publication": "",
+    "request_status": "IN_PROCESS",
+    "request_date": "2024-05-24Z",
+    "request_time": "2024-05-24T17:35:20.393Z",
+    "task_name": "Pickup From Shelf",
+    "expiry_date": "2024-06-08Z"
+  }

--- a/spec/fixtures/requests/request_sent_from_bookbot.json
+++ b/spec/fixtures/requests/request_sent_from_bookbot.json
@@ -1,0 +1,32 @@
+{
+    "title": "Test BookBot",
+    "author": "",
+    "description": "",
+    "volume": "",
+    "issue": "",
+    "part": "",
+    "user_primary_id": "user_id",
+    "request_id": "bookbot_request_id",
+    "additional_id": "",
+    "request_type": "HOLD",
+    "request_sub_type": {
+      "value": "PATRON_PHYSICAL",
+      "desc": "Patron physical item request"
+    },
+    "mms_id": "request_sent_from_bookbot",
+    "holding_id": "holding_id",
+    "pickup_location": "Charles Library",
+    "pickup_location_type": "LIBRARY",
+    "pickup_location_library": "MAIN",
+    "managed_by_library": "Charles BookBot",
+    "managed_by_circulation_desk": "ASRS Circulation Desk",
+    "managed_by_library_code": "ASRS",
+    "managed_by_circulation_desk_code": "DEFAULT_CIRC_DESK",
+    "material_type": {},
+    "date_of_publication": "",
+    "request_status": "IN_PROCESS",
+    "request_date": "2024-05-24Z",
+    "request_time": "2024-05-24T17:35:20.393Z",
+    "task_name": "Pickup From Shelf",
+    "expiry_date": "2024-06-08Z"
+  }

--- a/spec/fixtures/requests/request_sent_from_japan.json
+++ b/spec/fixtures/requests/request_sent_from_japan.json
@@ -1,0 +1,32 @@
+{
+    "title": "Test Japan",
+    "author": "",
+    "description": "",
+    "volume": "",
+    "issue": "",
+    "part": "",
+    "user_primary_id": "user_id",
+    "request_id": "japan_request_id",
+    "additional_id": "",
+    "request_type": "HOLD",
+    "request_sub_type": {
+      "value": "PATRON_PHYSICAL",
+      "desc": "Patron physical item request"
+    },
+    "mms_id": "request_sent_from_japan",
+    "holding_id": "holding_id",
+    "pickup_location": "Japan Campus Library",
+    "pickup_location_type": "LIBRARY",
+    "pickup_location_library": "JAPAN",
+    "managed_by_library": "Japan Campus Library",
+    "managed_by_circulation_desk": "Japan Circulation Desk",
+    "managed_by_library_code": "JAPAN",
+    "managed_by_circulation_desk_code": "JAPAN_CIRC",
+    "material_type": {},
+    "date_of_publication": "",
+    "request_status": "IN_PROCESS",
+    "request_date": "2024-05-24Z",
+    "request_time": "2024-05-24T17:35:20.393Z",
+    "task_name": "Pickup From Shelf",
+    "expiry_date": "2024-06-08Z"
+  }

--- a/spec/fixtures/requests/request_sent_from_main.json
+++ b/spec/fixtures/requests/request_sent_from_main.json
@@ -1,0 +1,32 @@
+{
+    "title": "Test Main",
+    "author": "",
+    "description": "",
+    "volume": "",
+    "issue": "",
+    "part": "",
+    "user_primary_id": "user_id",
+    "request_id": "main_request_id",
+    "additional_id": "",
+    "request_type": "HOLD",
+    "request_sub_type": {
+      "value": "PATRON_PHYSICAL",
+      "desc": "Patron physical item request"
+    },
+    "mms_id": "request_sent_from_bookbot",
+    "holding_id": "holding_id",
+    "pickup_location": "Charles Library",
+    "pickup_location_type": "LIBRARY",
+    "pickup_location_library": "MAIN",
+    "managed_by_library": "Charles Library",
+    "managed_by_circulation_desk": "Charles Hold Shelf",
+    "managed_by_library_code": "MAIN",
+    "managed_by_circulation_desk_code": "MAIN_CIRC",
+    "material_type": {},
+    "date_of_publication": "",
+    "request_status": "IN_PROCESS",
+    "request_date": "2024-05-24Z",
+    "request_time": "2024-05-24T17:35:20.393Z",
+    "task_name": "Pickup From Shelf",
+    "expiry_date": "2024-06-08Z"
+  }

--- a/spec/helpers/request_helper_spec.rb
+++ b/spec/helpers/request_helper_spec.rb
@@ -11,13 +11,6 @@ RSpec.describe RequestHelper, type: :helper do
     end
   end
 
-  describe "#successful_request_message" do
-    it "renders the error message text correctly" do
-      expect(successful_request_message).to eq("Your request has been submitted. You will receive an email notification when an item is ready for pickup. See <a href=\"/users/account\">My Account</a> for status information about your request.")
-    end
-
-  end
-
   describe "#request_redirect_url" do
 
     it "generates expected url" do

--- a/spec/models/request_confirmation_spec.rb
+++ b/spec/models/request_confirmation_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RequestConfirmation, type: :model do
+
+  subject { described_class.new(response, pickup_location) }
+
+  describe "confirmation message" do
+
+    context "item to be delivered from Ambler Campus Library to Charles Library" do
+      let(:response) { Alma::BibRequest.submit(
+        mms_id: "request_sent_from_ambler", user_id: "user_id", request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "MAIN"
+      )}
+      let(:pickup_location) { "MAIN" }
+      it "generates time estimate" do
+        expect(subject.message).to eq "Request submitted! Your item will be available for pickup at Charles Library in approximately 1-3 business days. You will receive an email notification when the item is ready."
+      end
+    end
+
+  end
+
+  describe "delivery estimates" do
+
+    context "item to be delivered from Ambler Campus Library to Charles Library" do
+      let(:response) { Alma::BibRequest.submit(
+        mms_id: "request_sent_from_ambler", user_id: "user_id", request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "MAIN"
+      )}
+      let(:pickup_location) { "MAIN" }
+      it "generates time estimate" do
+        expect(subject.delivery_estimate).to eq "1-3 business days"
+        expect(subject.delivery_estimate?).to eq true
+      end
+    end
+
+    context "item to be delivered within Charles Library (not ASRS)" do
+      let(:response) { Alma::BibRequest.submit(
+        mms_id: "request_sent_from_main", user_id: "user_id", request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "MAIN"
+      )}
+      let(:pickup_location) { "MAIN" }
+      it "generates time estimate" do
+        expect(subject.delivery_estimate).to eq "1-2 business days"
+        expect(subject.delivery_estimate?).to eq true
+      end
+    end
+
+    context "item to be delivered from ASRS to Charles Library" do
+      let(:response) { Alma::BibRequest.submit(
+        mms_id: "request_sent_from_bookbot", user_id: "user_id", request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "MAIN"
+      )}
+      let(:pickup_location) { "MAIN" }
+      it "generates time estimate" do
+        expect(subject.delivery_estimate).to eq "1 hour, delivered from the Charles Library BookBot when open"
+        expect(subject.delivery_estimate?).to eq true
+      end
+    end
+
+    context "item to be delivered with Japan Campus Library" do
+      let(:response) { Alma::BibRequest.submit(
+        mms_id: "request_sent_from_bookbot", user_id: "user_id", request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "JAPAN"
+      )}
+      let(:pickup_location) { "JAPAN" }
+      it "does not generate time estimate" do
+        expect(subject.delivery_estimate).to eq nil
+        expect(subject.delivery_estimate?).to eq false
+        expect(subject.delivery_estimate_message).to eq ""
+      end
+    end
+
+    context "no pickup location submitted in request (application to Digitization and Booking request currently, though also works for Holds)" do
+      let(:response) { Alma::BibRequest.submit(
+        mms_id: "request_sent_from_ambler", user_id: "user_id", request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "MAIN"
+      )}
+      it "does not generate time estimate" do
+        expect(subject.delivery_estimate).to eq nil
+        expect(subject.delivery_estimate?).to eq false
+        expect(subject.delivery_estimate_message).to eq ""
+      end
+    end
+
+  end
+
+end

--- a/spec/models/request_confirmation_spec.rb
+++ b/spec/models/request_confirmation_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe RequestConfirmation, type: :model do
       let(:response) { Alma::BibRequest.submit(
         mms_id: "request_sent_from_ambler", user_id: "user_id", request_type: "HOLD", pickup_location_type: "LIBRARY", pickup_location_library: "MAIN"
       )}
+      let(:pickup_location) { nil }
       it "does not generate time estimate" do
         expect(subject.delivery_estimate).to eq nil
         expect(subject.delivery_estimate?).to eq false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -306,8 +306,28 @@ RSpec.configure do |config|
 
     stub_request(:get, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/japan_and_rome\/holdings\/.*\/items/).
     to_return(status: 200,
-              headers: { "Content-Type" => "application/json" },
-              body: File.open(SPEC_ROOT + "/fixtures/requests/japan_and_rome.json"))
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/japan_and_rome.json"))
+
+    stub_request(:post, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/request_sent_from_ambler\/requests/).
+    to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/request_sent_from_ambler.json"))
+
+    stub_request(:post, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/request_sent_from_main\/requests/).
+    to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/request_sent_from_main.json"))
+
+    stub_request(:post, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/request_sent_from_bookbot\/requests/).
+    to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/request_sent_from_bookbot.json"))
+
+    stub_request(:post, /.*\.exlibrisgroup\.com\/almaws\/v1\/bibs\/request_sent_from_japan\/requests/).
+    to_return(status: 200,
+                headers: { "Content-Type" => "application/json" },
+                body: File.open(SPEC_ROOT + "/fixtures/requests/request_sent_from_japan.json"))
 
     stub_request(:get, /.*library.temple.edu\/alerts/).
       to_return(status: 200,


### PR DESCRIPTION
- Added new RequestConfirmation model to determine delivery estimate from request submission API response
- Updated message text accordingly (to be reviewed with Justin), removing old helper method in the process
- Added correpsonding spec and fixtures

As always, I welcome any feedback and suggestions to improve this code!