### PR TITLE
Update OCLC API endpoint to HTTPS

### DIFF
--- a/config/oclc.yml
+++ b/config/oclc.yml
@@ -1,6 +1,6 @@
 default: &default
   apikey: <%= ENV['OCLC_WS_KEY'] || "ws_key" %>
-  base_url: http://www.worldcat.org/webservices/catalog/content/citations
+  base_url: https://www.worldcat.org/webservices/catalog/content/citations
   citation_formats: ["all"]
 
 development:


### PR DESCRIPTION
OCLC has reported that there is an API issue with the redirect from http to https currently. I haven't tested this locally, but I'd like to push this update to QA to see if it fixes the issues with citations. 