### PR TITLE
BL-1882 Fix booking request pickup locations

### DIFF
--- a/app/models/request_data.rb
+++ b/app/models/request_data.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "pry"
-
 class RequestData
   attr_reader :request_level
   attr_reader :pickup_locations

--- a/app/models/request_data.rb
+++ b/app/models/request_data.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "pry"
+
 class RequestData
   attr_reader :request_level
   attr_reader :pickup_locations
@@ -111,17 +113,13 @@ class RequestData
 
   def booking_locations
     pickup_location = @items.map { |item|
-      if item.library == "ASRS"
-        library_name = "Charles Library"
-        [item.library, library_name]
+      campus = determine_campus(item.library)
+      if campus == :MAIN
+        ["MAIN", "Charles Library"]
       else
-        library_name = item.library_name
+        nil
       end
-
-      [item.library, library_name]
-    }
-
-    pickup_location.uniq
+    }.uniq.compact
   end
 
   def default_pickup_locations

--- a/spec/models/request_data_spec.rb
+++ b/spec/models/request_data_spec.rb
@@ -218,10 +218,10 @@ RSpec.describe RequestData, type: :model do
     context "libraries include ASRS and another location" do
       let(:bib_items) { Alma::BibItem.find("booking_locations") }
       it "returns Charles Library as the name for ASRS" do
-        expect(subject.booking_locations).to include(["ASRS", "Charles Library"])
+        expect(subject.booking_locations).to include(["MAIN", "Charles Library"])
       end
-      it "returns other libraries with their assigned name" do
-        expect(subject.booking_locations).to include(["AMBLER", "Ambler Campus Library"])
+      it "does not returns other libraries for booking locations" do
+        expect(subject.booking_locations).not_to include(["AMBLER", "Ambler Campus Library"])
       end
     end
   end


### PR DESCRIPTION
Booking request form is broken. It appears that the logic for the booking pickup locations in Alma has changed, so I've updated our logic accordingly.

There is some cleanup to do related to the library name lookup, but I will need to work on some broader refactoring to do that. 