### PR TITLE
BL-1865 Remove HTML markup for confirmation messages 

### DIFF
--- a/app/models/request_confirmation.rb
+++ b/app/models/request_confirmation.rb
@@ -10,7 +10,7 @@ class RequestConfirmation
   end
 
   def message
-    [I18n.t("requests.default_success_html"), delivery_estimate_message, I18n.t("requests.request_status_message")].join("")
+    [I18n.t("requests.default_success"), delivery_estimate_message, I18n.t("requests.request_status_message")].join("")
   end
 
   def delivery_estimate_message

--- a/app/models/request_delivery_estimate.rb
+++ b/app/models/request_delivery_estimate.rb
@@ -27,9 +27,9 @@ class RequestDeliveryEstimate
     pickup_location_name = library_name_from_short_code(pickup_location)
 
     if duration.include?("hour")
-      I18n.t("requests.estimate_hours_html", pickup: pickup_location_name, duration:)
+      I18n.t("requests.estimate_hours", pickup: pickup_location_name, duration:)
     else
-      I18n.t("requests.estimate_days_html", pickup: pickup_location_name, duration:)
+      I18n.t("requests.estimate_days", pickup: pickup_location_name, duration:)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,9 +195,9 @@ en:
     resource_sharing_broker_text: "For books unavailable from Temple University Libraries, search for and request the book through EZBorrow. Books typically arrive in 3-5 business days."
     resource_sharing_broker_link: "Go to EZBorrow"
     no_request_options: "This item cannot be requested from other Temple campuses."
-    default_success_html: "<b>Your request has been submitted!</b> <br>"
-    estimate_days_html: "Your item will be available for pickup at %{pickup} within %{duration}. "
-    estimate_hours_html: "If you placed the order during the library's normal <a href='https://library.temple.edu/hours'>operating hours</a>, your item will be available for pickup at %{pickup} within %{duration}. "
+    default_success: "Your request has been submitted! "
+    estimate_days: "Your item will be available for pickup at %{pickup} within %{duration}. "
+    estimate_hours: "If you placed the order during the library's normal operating hours, your item will be available for pickup at %{pickup} within %{duration}. "
     request_status_message: "We will notify you by email once it's ready."
     form:
       pickup_locations_label: "Where will you pick it up?"

--- a/spec/models/request_confirmation_spec.rb
+++ b/spec/models/request_confirmation_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RequestConfirmation, type: :model do
       )}
       let(:pickup_location) { "MAIN" }
       it "generates time estimate" do
-        expect(subject.message).to eq "<b>Your request has been submitted!</b> <br>Your item will be available for pickup at Charles Library within 1-3 business days. We will notify you by email once it's ready."
+        expect(subject.message).to eq "Your request has been submitted! Your item will be available for pickup at Charles Library within 1-3 business days. We will notify you by email once it's ready."
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe RequestConfirmation, type: :model do
       )}
       let(:pickup_location) { "JAPAN" }
       it "does not generate delivery estimate message" do
-        expect(subject.message).to eq "<b>Your request has been submitted!</b> <br>We will notify you by email once it's ready."
+        expect(subject.message).to eq "Your request has been submitted! We will notify you by email once it's ready."
         expect(subject.delivery_estimate_message).to eq nil
       end
     end

--- a/spec/models/request_delivery_estimate_spec.rb
+++ b/spec/models/request_delivery_estimate_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe RequestDeliveryEstimate, type: :model do
         let(:pickup_location) { "MAIN" }
         it "generates time estimate" do
           expect(subject.duration).to eq "1 hour"
-          expect(subject.message).to eq "If you placed the order during the library's normal <a href='https://library.temple.edu/hours\'>operating hours</a>, your item will be available for pickup at Charles Library within 1 hour. "
+          expect(subject.message).to eq "If you placed the order during the library's normal operating hours, your item will be available for pickup at Charles Library within 1 hour. "
         end
       end
 


### PR DESCRIPTION
This HTML is coming through as escaped, and after working on it locally for a bit, I'm still working through the best way to fix this. For now, I'm going to remove this markup for now, so that we can move forward in production with the plain text version. 