### PR TITLE
DEVO-1105: Update catalog on deployment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
 
   update_airflow_variables:
     docker:
-      - image: cimg/python:3.10.13
+      - image: cimg/python:3.12.3
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD


### PR DESCRIPTION
Task failing because it is trying to use the wrong version of python.