### PR TITLE
BL-1898 Fix honeybadger no_method error for primo_central#show

### DIFF
--- a/app/models/blacklight/primo_central/response.rb
+++ b/app/models/blacklight/primo_central/response.rb
@@ -38,8 +38,8 @@ module Blacklight::PrimoCentral
           .map { |f| { value: f["value"].to_i, count: f["count"] } }
           .sort_by { |f| f[:value] }
 
-        min = (range.min || values&.first&.fetch(:value, 0)).to_i
-        max = (range.max || values&.last&.fetch(:value, 9999)).to_i
+        min = (range&.min || values&.first&.fetch(:value, 0)).to_i
+        max = (range&.max || values&.last&.fetch(:value, 9999)).to_i
         raise BlacklightRangeLimit::InvalidRange, "The min date must be before the max date" if min > max
 
         data = facet_segments(field["name"], min, max, values)


### PR DESCRIPTION
This error has been thrown a lot lately, usually when a user is trying to access a page that doesn't exist:
NoMethodError: undefined method `min' for nil
https://librarysearch.temple.edu/articles/login is an example

This just handles cases where range is nil so that an error isn't thrown.  It seems like this error is being caused by bots, but it doesn't hurt to handle it.