### PR TITLE
BL-1904: Fix error on logout

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,10 @@ module Tulcob
       g.fixture_replacement :factory_bot
     end
     #config.log_level = :debug
+
+    # Could be removed once this issue is fixed:
+    # https://github.com/heartcombo/devise/pull/5462
+    config.action_controller.raise_on_open_redirects = false
   end
 end
 


### PR DESCRIPTION
A new Rails 7 security feature breaks logouts because devise trys to redirect user to fim.temple.edu in produciton on logoout.

We can monkey patch devise or we can disable the feature.

For now I've disabled the feature.

I tried adding an exception for fim.temple.edu, bu that didn't work.