### PR TITLE
BL-1878: Disable forgery protection for clear caches endpoint.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,8 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  skip_before_action :verify_authenticity_token, only: [:clear_caches]
+
   before_action :get_manifold_alerts, only: [
     :index, :show, :not_found, :internal_server_error,
     :account, :librarian_view, :citation, :email, :facet

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -14,8 +14,19 @@ RSpec.describe ApplicationController, type: :controller do
   end
 
   describe "DELETE #clear_caches action" do
+    # We disable forgery protection by default in  our test environment.
+    # We need to enable it to properly test this endpoint.
+    around do |example|
+      original_setting = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+      example.run
+    ensure
+      ActionController::Base.allow_forgery_protection = original_setting
+    end
+
     context "anonymous user" do
       it "clears the caches" do
+        request.headers["Authorization"] = "Bearer token"
         delete(:clear_caches)
         expect(response.body).to match "Cache has been cleared"
       end


### PR DESCRIPTION
The clear caches endpoint does not need forgery protection.

Fixes airflow task not able to clear caches due to forgery protection of endpoint.