### PR TITLE
Waiver for newly caught CVE-2020-7598 and CVE-2021-44906

### DIFF
--- a/Documentation/minimist-CVE-2020-7598
+++ b/Documentation/minimist-CVE-2020-7598
@@ -1,0 +1,1 @@
+Awaiting updates to minimist package

--- a/Documentation/minimist-CVE-2021-44906
+++ b/Documentation/minimist-CVE-2021-44906
@@ -1,0 +1,1 @@
+Awaiting updates to minimist package


### PR DESCRIPTION
- Though these are old CVEs, they were just caught for the Minimist package. We await updates to the package.