### PR TITLE
Bl 1911 try ignoring by regex

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -5,5 +5,5 @@ test:
 exceptions:
   ignore:
     - "Alma::BibRequest::ItemAlreadyExists"
-    - "No items can fulfill the submitted request"
+    - !ruby/regexp "an /No items can fulfill the submitted request/"
     - "ActiveRecord::RecordNotUnique"

--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -5,5 +5,5 @@ test:
 exceptions:
   ignore:
     - "Alma::BibRequest::ItemAlreadyExists"
-    - !ruby/regexp "an /No items can fulfill the submitted request/"
+    - !ruby/regexp /No items can fulfill the submitted request/
     - "ActiveRecord::RecordNotUnique"


### PR DESCRIPTION
Honeybadger documentation says the gem will ignore any exceptions matching the string, regex or class that you add to exceptions.ignore. I tried adding this as a string, but it didn't work.  Now I'm trying as regex to see if that gives the results we want.