### PR TITLE
Bootstrap 5 HTML Objects

### DIFF
--- a/app/components/facet_item_pivot_component.rb
+++ b/app/components/facet_item_pivot_component.rb
@@ -45,7 +45,7 @@ class FacetItemPivotComponent < Blacklight::FacetItemPivotComponent
 
   def facet_toggle_button(id)
     content_tag "button", class: "btn pivot-top-level-expand facet-toggle-handle #{'collapsed' unless uncollapse?}",
-                "data-bs": { toggle: "collapse", target: "##{id}" },
+                "data": { "bs-toggle": "collapse", "bs-target": "##{id}" },
                 aria: { expanded: uncollapse?, controls: id, describedby: "#{id}_label" } do
       concat toggle_icon(:show)
       concat toggle_icon(:hide)

--- a/app/components/facet_item_pivot_component.rb
+++ b/app/components/facet_item_pivot_component.rb
@@ -45,7 +45,7 @@ class FacetItemPivotComponent < Blacklight::FacetItemPivotComponent
 
   def facet_toggle_button(id)
     content_tag "button", class: "btn pivot-top-level-expand facet-toggle-handle #{'collapsed' unless uncollapse?}",
-                data: { toggle: "collapse", target: "##{id}" },
+                "data-bs": { toggle: "collapse", target: "##{id}" },
                 aria: { expanded: uncollapse?, controls: id, describedby: "#{id}_label" } do
       concat toggle_icon(:show)
       concat toggle_icon(:hide)

--- a/app/views/almaws/_asrs_request_form.html.erb
+++ b/app/views/almaws/_asrs_request_form.html.erb
@@ -39,7 +39,7 @@
         <div class="form-group hold-form">
           <%= form.label(:asrs_description, t("requests.form.description_label_html")) %>
           <p><%= t("requests.form.description_additional_text") %></p>
-          <%= select_tag(:asrs_description, grouped_options_for_select(@asrs_description), { data: { "action": "request-form#select", "target": "request-form.descriptions" }, class: "request-form form-control", include_blank: true }) %>
+          <%= select_tag(:asrs_description, grouped_options_for_select(@asrs_description), { data: { "action": "request-form#select", "bs-target": "request-form.descriptions" }, class: "request-form form-control", include_blank: true }) %>
         </div>
       <% else %>
         <%= form.hidden_field :asrs_description, value: @asrs_description.flatten.last%>

--- a/app/views/almaws/_booking_request_form.html.erb
+++ b/app/views/almaws/_booking_request_form.html.erb
@@ -22,7 +22,7 @@
       <div class="hold-form form-group">
         <%= form.label(:booking_description, t("requests.form.description_label_html")) %>
         <p><%= t("requests.form.description_additional_text") %></p>
-        <%= select_tag(:booking_description,  grouped_options_for_select(@description), data: { "target": "request-form.descriptions" }, class: "request-form form-control", include_blank: true) %>
+        <%= select_tag(:booking_description,  grouped_options_for_select(@description), data: { "bs-target": "request-form.descriptions" }, class: "request-form form-control", include_blank: true) %>
       </div>
     <% else %>
         <%= form.hidden_field :booking_description, value: @description.flatten.last %>


### PR DESCRIPTION
Syntax for data attributes needed a fix. Also adds other files without the -bs- in the attribute.