### PR TITLE
BL-1855 Convert single quotes to double quotes for exact searches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ yarn-error.log
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+/public/cached_pages*
 
 /config/master.key
 

--- a/spec/features/indices_spec.rb
+++ b/spec/features/indices_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 require "traject"
 require "traject/command_line"
 require "yaml"
-require "pry"
 
 RSpec.feature "Indices" do
   let (:fixtures) {


### PR DESCRIPTION
I also refactored the process_is method to be a case statement and when I did that the is (exact) searches started working again in the advanced search.