### PR TITLE
Use recaptcha specific error for verification errors.

### DIFF
--- a/app/controllers/concerns/server_errors.rb
+++ b/app/controllers/concerns/server_errors.rb
@@ -32,6 +32,10 @@ module ServerErrors
       render "errors/internal_server_error", status: :bad_gateway
     end
 
+    rescue_from Recaptcha::VerifyError do |exception|
+      render "errors/internal_server_error", status: :bad_gateway
+    end
+
     rescue_from Alma::RequestOptions::ResponseError do |exception|
       Honeybadger.notify(exception)
       render "errors/alma_request_error", status: :bad_gateway

--- a/app/controllers/primo_central_controller.rb
+++ b/app/controllers/primo_central_controller.rb
@@ -24,7 +24,7 @@ class PrimoCentralController < CatalogController
     return if params["q"].blank?
 
     if !verify_recaptcha(action: @recaptcha_action)
-      head :forbidden
+      raise Recaptcha::VerifyError.new("recaptcha verification failed for #{@recaptcha_action}")
     end
   end
 


### PR DESCRIPTION
Give user a useful error befinstead of blank 403 page.