### PR TITLE
Fixes a bug when params["operator"] is nil

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -35,17 +35,19 @@ class CatalogController < ApplicationController
   end
 
   def advanced_override_path
-    if params["q_1"]&.split&.count == 1 && params["operator"]["q_1"] == "is"
-      blacklight_config.solr_path = "single_quoted_search"
-    end
+    unless params["operator"].nil?
+      if params["q_1"]&.split&.count == 1 && params["operator"]["q_1"] == "is"
+        blacklight_config.solr_path = "single_quoted_search"
+      end
 
-    if
-      params["q_2"]&.split&.count == 1 && params["operator"]["q_2"] == "is"
-      blacklight_config.solr_path = "single_quoted_search"
-    end
+      if
+        params["q_2"]&.split&.count == 1 && params["operator"]["q_2"] == "is"
+        blacklight_config.solr_path = "single_quoted_search"
+      end
 
-    if params["q_3"]&.split&.count == 1 && params["operator"]["q_3"] == "is"
-      blacklight_config.solr_path = "single_quoted_search"
+      if params["q_3"]&.split&.count == 1 && params["operator"]["q_3"] == "is"
+        blacklight_config.solr_path = "single_quoted_search"
+      end
     end
   end
 


### PR DESCRIPTION
There have been some Honeybadger errors thrown when users are switching to an everything search after an advanced catalog search. This fixes it so that the search won't error out.