### PR TITLE
Ignore ActiveRecord::ConnectionNotEstablished errors

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -7,3 +7,4 @@ exceptions:
     - "Alma::BibRequest::ItemAlreadyExists"
     - "ActiveRecord::RecordNotUnique"
     - "Dalli::RingError"
+    - "ActiveRecord::ConnectionNotEstablished"


### PR DESCRIPTION
We can't do anything to resolve these errors and when we get crawled they use up our Honeybadger error allowance for the month.  