### PR TITLE
BL-1868-combine-request-item-from-book-bot-and-request-item-for-pickup-dropdowns

### DIFF
--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -4,7 +4,6 @@ module AlmawsHelper
   include Blacklight::CatalogHelperBehavior
 
   def hold_allowed_partial(request_options, document)
-    # binding.pry
     if request_options.hold_allowed? && non_asrs_items.present?
       render partial: "hold_allowed", locals: { request_options:, document: }
     end

--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -11,7 +11,7 @@ module AlmawsHelper
 
   def asrs_allowed_partial(request_options, document)
     if request_options.hold_allowed? && available_asrs_items.present?
-      render partial: "asrs_allowed", locals: { request_options:, document: }
+      render partial: "asrs_allowed", locals: { request_options:, document: } unless non_asrs_items.present?
     end
   end
 

--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -4,14 +4,15 @@ module AlmawsHelper
   include Blacklight::CatalogHelperBehavior
 
   def hold_allowed_partial(request_options, document)
+    # binding.pry
     if request_options.hold_allowed? && non_asrs_items.present?
       render partial: "hold_allowed", locals: { request_options:, document: }
     end
   end
 
   def asrs_allowed_partial(request_options, document)
-    if request_options.hold_allowed? && available_asrs_items.present?
-      render partial: "asrs_allowed", locals: { request_options:, document: } unless non_asrs_items.present?
+    if request_options.hold_allowed? && available_asrs_items.present? && !non_asrs_items.present?
+      render partial: "asrs_allowed", locals: { request_options:, document: }
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -176,7 +176,7 @@ en:
     footer_link: "http://answers.library.temple.edu/faq/195868"
     cancel: "Close"
     hold_allowed_link: "Request item for pickup"
-    asrs_allowed_link: "Request item from Charles Library BookBot"
+    asrs_allowed_link: "Request item for pickup"
     digitization_allowed_link: "Request a scan of an article or book chapter"
     booking_allowed_link: "Request booking"
     aeon_request_allowed_header: "Request materials to view in Special Collections Research Center"

--- a/spec/helpers/almaws_helper_spec.rb
+++ b/spec/helpers/almaws_helper_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe AlmawsHelper, type: :helper do
       }.to_json
     }
 
-    context "asrs request can be placed on an book that is in_place" do
+    context "asrs request can be placed on a book that is in_place" do
       let(:item) do
        Alma::BibItem.new(
          "holding_data" => {
@@ -120,7 +120,8 @@ RSpec.describe AlmawsHelper, type: :helper do
 
       it "renders the hold partial" do
         allow(helper).to receive(:available_asrs_items) { [item] }
-        expect(helper.asrs_allowed_partial(request_options, document)).not_to be_nil
+        expect(helper.asrs_allowed_partial(request_options, document)).to be_nil
+        expect(helper.hold_allowed_partial(request_options, document)).to_not be_nil
       end
     end
 
@@ -154,7 +155,8 @@ RSpec.describe AlmawsHelper, type: :helper do
 
       it "renders the hold partial" do
         allow(helper).to receive(:available_asrs_items) { [item] }
-        expect(helper.asrs_allowed_partial(request_options, document)).not_to be_nil
+        expect(helper.asrs_allowed_partial(request_options, document)).to be_nil
+        expect(helper.hold_allowed_partial(request_options, document)).to_not be_nil
       end
     end
 


### PR DESCRIPTION
This is a temporary workaround to be tested while ongoing work to completely remove the asrs pickup location select list on hold requests is finished.