### PR TITLE
CVE-2025-7338 Add on-headers to essential packages

### DIFF
--- a/Documentation/essential_packages.txt
+++ b/Documentation/essential_packages.txt
@@ -1,3 +1,4 @@
 micromatch
 cgi
 nodejs
+on-headers

--- a/Documentation/on-headers-CVE-2025-7339
+++ b/Documentation/on-headers-CVE-2025-7339
@@ -1,0 +1,1 @@
+Awaiting packages dependent on on-headers 1.0.2 to update to 1.1.0

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "json5": "2.2.2",
     "minimist": "1.2.8",
     "node-fetch": "2.6.7",
+    "on-headers": "1.1.0",
     "path-to-regexp": "0.1.12"
   },
   "babel": {


### PR DESCRIPTION
- Packages are dependent on on-headers 1.0.2, so pinning its version to 1.1.0 is not sufficient to pass vulnerabilty scans. Will need to waive this package