### PR TITLE
BL-1875 Add start over button component

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
-require:
-  - rubocop-rails
+
+plugins: rubocop-rails
 
 AllCops:
   TargetRubyVersion: 3.3

--- a/app/components/blacklight/constraints_component.html.erb
+++ b/app/components/blacklight/constraints_component.html.erb
@@ -1,0 +1,5 @@
+<% if query_has_constraints? %>
+  <div id="applied_params_facet" class="clearfix mb-3">
+    <%= render_constraints(params) %>
+  </div>
+<% end %>

--- a/app/components/blacklight/start_over_button_component.rb
+++ b/app/components/blacklight/start_over_button_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class StartOverButtonComponent < Blacklight::Component
+    def call
+      link_to t("blacklight.search.start_over"),
+              helpers.bento_search_engine_path,
+              id: "start_over",
+              class: "btn text-white"
+    end
+  end
+end

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,5 +1,14 @@
-<% if query_has_constraints? %>
-  <div id="applied_params_facet" class="clearfix mb-3">
-    <%= render_constraints(params) %>
-  </div>
+<% if constraints_helpers_and_partials_from_blacklight? || blacklight_config&.view_config(document_index_view_type)&.constraints_component %>
+  <%= render((blacklight_config&.view_config(document_index_view_type)&.constraints_component || Blacklight::ConstraintsComponent).new(search_state: convert_to_search_state(controller.params != params ? params : search_state))) %>
+<% else %>
+  <% Deprecation.warn(Blacklight::RenderConstraintsHelperBehavior, 'Constraints helpers or partials were overridden; not using components') %>
+  <% if Deprecation.silence(Blacklight::RenderConstraintsHelperBehavior) { query_has_constraints? } %>
+    <div id="appliedParams" class="clearfix constraints-container">
+      <h2 class="sr-only visually-hidden"><%= t('blacklight.search.search_constraints_header') %></h2>
+
+      <span class="constraints-label sr-only visually-hidden"><%= t('blacklight.search.filters.title') %></span>
+      <%= render_constraints(controller.params != params ? params : search_state) %>
+      <%= render 'start_over' %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -11,7 +11,7 @@
 
    <%= render "constraints" %>
 
-  <%= link_to t("blacklight.search.start_over"), bento_search_engine_path, :class => "catalog_startOverLink btn mb-md-3", :id=>"startOverLink" %>
+  <%= render @start_over_component.new if @start_over_component %>
 
   <button id="filter-mobile" type="button" class="btn collapsed d-md-none" data-bs-toggle="collapse" data-bs-target="#facet-panel-collapse" aria-controls="facet-panel-collapse" aria-expanded="false" aria-label="Toggle facets">
     Limit Your Search <span class="caret"></span>

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -6,7 +6,7 @@
   <% if current_search_session %>
     <div class="search-widgets d-flex ps-3">
       <%= link_back_to_catalog class: "btn btn-back-to-search", id: "back_to_search" %>
-      <%= link_to t("blacklight.search.start_over"), bento_search_engine_path, id: "start_over", class: "btn text-white" %>
+      <%= render Blacklight::StartOverButtonComponent.new %>
     </div>
   <% end %>
 


### PR DESCRIPTION
Also adds the constraints component because that initializes the start over button component.  The component has to be called in slightly different ways on the search results/record page due to the context that it is in.  