### PR TITLE
Bl 1976 honeybadger action view missing template missing template errors not found with locale en formats ris variants handlers raw erb html builder ruby coffee jbuilder

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,8 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActionController::InvalidAuthenticityToken,
     with: :redirect_to_referer
+  rescue_from ActionController::UnknownFormat,
+    with: :render_unsupported_format
 
   # Rails 5.1 and above requires permitted params to be defined in the Controller
   # BL doesn't do that, but might in the future. This allows us to use the pre 5.1
@@ -87,5 +89,9 @@ class ApplicationController < ActionController::Base
     # ensure that rails treats request as xhr
     def xhr!
       request.headers["HTTP_X_REQUESTED_WITH"] = "XMLHttpRequest"
+    end
+
+    def render_unsupported_format
+      render plain: "Unsupported format", status: :bad_request, content_type: "text/plain"
     end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -611,6 +611,7 @@ class CatalogController < ApplicationController
     else
       respond_to do |format|
         format.html { store_preferred_view }
+        format.any { render_unsupported_format }
       end
     end
   end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -6,6 +6,7 @@ class ErrorsController < ApplicationController
       format.woff2 { render plain: "", status: 400, content_type: "text/plain" }
       format.css { render plain: "", status: 400, content_type: "text/plain" }
       format.js { render plain: "", status: 400, content_type: "text/plain" }
+      format.ris { render plain: "", status: 400, content_type: "text/plain" }
       format.all { render(layout(status: 404, formats: :html)) }
     end
   end

--- a/spec/controllers/databases_controller_spec.rb
+++ b/spec/controllers/databases_controller_spec.rb
@@ -100,4 +100,13 @@ RSpec.describe DatabasesController, type: :controller do
       end
     end
   end
+
+  describe "unsupported formats" do
+    it "returns 400 and plain text when the format is not supported" do
+      get :index, params: { format: "ris" }
+      expect(response.status).to eq(400)
+      expect(response.body).to eq("Unsupported format")
+      expect(response.media_type).to eq("text/plain")
+    end
+  end
 end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe ErrorsController, type: :controller do
     expect(response.body).to include "DOCTYPE html"
   end
 
+  it "returns plain text for RIS not found requests" do
+    get :not_found, params: { format: "ris" }
+    expect(response.status).to eq(400)
+    expect(response.media_type).to eq("text/plain")
+  end
+
   it "ignores file extensions in url when a server error arises" do
     get :internal_server_error, params: { format: "txt" }
     expect(response.status).to eq(500)


### PR DESCRIPTION
When an invalid MMS ID is requested—whether the user hits /catalog/:id.ris, /databases/:id.ris, or even tacks .ris onto an arbitrary record URL—we hit the invalid_document_id_error override in catalog_controller.rb. That method renders the RIS response as plain text with a 404 status: "Record not found", which keeps Honeybadger quiet and gives the user a clean message. For non-record URLs (e.g., /databases.ris) the new render_unsupported_format helper produces a 400 “Unsupported format” response instead of raising a missing-template exception.