### PR TITLE
Set version of application to CI_TAG

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,7 +121,7 @@ prod_deploy:
     - helm pull oci://$HARBOR/tulibraries/charts/librarysearch --version $HELM_VERSION_PROD --untar
     - |
       helm upgrade librarysearch oci://$HARBOR/tulibraries/charts/librarysearch \
-        --version $HELM_VERSION_PROD \
+        --version $CI_COMMIT_TAG \
         --history-max=5 --namespace=librarysearch-prod \
         --values librarysearch/values-prod.yaml \
         --set image.repository=$IMAGE:$CI_COMMIT_TAG \


### PR DESCRIPTION
helm --version sets the version of the app and in some versions of helm overrides the app image version.