### PR TITLE
Revert HELM_VERSION_PROD change and export VERSION=$CI_COMMIT_TAG

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,10 +118,11 @@ prod_deploy:
   only:
     - tags
   script:
+    - export VERSION=$CI_COMMIT_TAG
     - helm pull oci://$HARBOR/tulibraries/charts/librarysearch --version $HELM_VERSION_PROD --untar
     - |
       helm upgrade librarysearch oci://$HARBOR/tulibraries/charts/librarysearch \
-        --version $CI_COMMIT_TAG \
+        --version $HELM_VERSION_PROD \
         --history-max=5 --namespace=librarysearch-prod \
         --values librarysearch/values-prod.yaml \
         --set image.repository=$IMAGE:$CI_COMMIT_TAG \


### PR DESCRIPTION
I was wrong about there being two uses of --version in helm.