### PR TITLE
Fix asset precompile incompatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "cob_index",
 gem "cob_web_index", git: "https://github.com/tulibraries/cob_web_index.git",
   branch: "main"
 gem "concurrent-ruby"
+gem "connection_pool", "< 3"
 gem "dartsass-rails"
 gem "devise"
 gem "devise-guests", "~> 0.8"
@@ -106,7 +107,6 @@ group :production do
   gem "pg"
   # required for using memcached
   gem "dalli"
-  gem "connection_pool"
 end
 
 gem "recaptcha", "~> 5.21"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,7 @@ GEM
     concurrent-ruby (1.3.6)
     confstruct (1.1.0)
       hashie (>= 3.3, < 5)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -809,7 +809,7 @@ DEPENDENCIES
   cob_index!
   cob_web_index!
   concurrent-ruby
-  connection_pool
+  connection_pool (< 3)
   csl-styles
   dalli
   dartsass-rails


### PR DESCRIPTION
CI asset precompile failed because connection_pool 3.0.2 is incompatible with Rails’ current initializer call path. Pin connection_pool below 3 to restore successful app boot during Docker builds.