### PR TITLE
Fix lint error.

### DIFF
--- a/.docker/app/Dockerfile.prod
+++ b/.docker/app/Dockerfile.prod
@@ -39,6 +39,7 @@ RUN apk add -U --no-cache \
     bundle config set --local without "development test" && \    
     bundle install --jobs=8 && \
     yarn install --frozen-lockfile && \
+    yarn cache clean && \
     find "$GEM_HOME" -name yarn.lock -exec rm "{}" \; && \
     if [ ! -f config/apis.yml ]; then cp config/apis.yml.example config/apis.yml; fi && \
     bundle exec rails assets:precompile && \


### PR DESCRIPTION
Fixes 'docker/app/Dockerfile.prod:21 DL3060 info: [yarn cache clean] missing after [yarn install] was run.' lint error.