### PR TITLE
Fix honeybadger reporting issue

### DIFF
--- a/config/apis.yml.example
+++ b/config/apis.yml.example
@@ -100,7 +100,3 @@ shared:
     exceptions:
       ignore:
         - "Alma::BibRequest::ItemAlreadyExists"
-
-test:
-  honeybadger:
-    backend: "test"

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -4,7 +4,7 @@
 Honeybadger.configure do |config|
   honeybadger_config = Rails.configuration.apis.dig(:honeybadger) || {}
   config.api_key = honeybadger_config[:api_key].presence || "foobar"
-  config.backend = honeybadger_config[:backend].presence || "test"
+  config.backend = honeybadger_config[:backend].presence
 
   ignored_exceptions = Array(honeybadger_config.dig(:exceptions, :ignore))
   if ignored_exceptions.present?

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -4,7 +4,12 @@
 Honeybadger.configure do |config|
   honeybadger_config = Rails.configuration.apis.dig(:honeybadger) || {}
   config.api_key = honeybadger_config[:api_key].presence || "foobar"
-  config.backend = honeybadger_config[:backend].presence
+
+  if honeybadger_config[:backend].present?
+    config.backend = honeybadger_config[:backend]
+  elsif Rails.env.test?
+    config.backend = "test"
+  end
 
   ignored_exceptions = Array(honeybadger_config.dig(:exceptions, :ignore))
   if ignored_exceptions.present?


### PR DESCRIPTION
Ever since we did the api work, we have not been receiving honeybadger errors for librarysearch.  This is because we are defaulting to the "test" backend and that doesn't send honeybadger notifications.  We need to remove the default to start getting errors again.  I already removed the relevant section from vault.