### PR TITLE
BL-2037 preselect-description-if-only-one-option-remains

### DIFF
--- a/app/javascript/controllers/request_form_controller.js
+++ b/app/javascript/controllers/request_form_controller.js
@@ -6,8 +6,27 @@ export default class extends Controller {
   static targets = [ "pickups", "descriptions" ]
 
   connect() {
+    this.descriptionGroups = Array.from(this.descriptionsTarget.querySelectorAll("optgroup")).map((optgroup) => optgroup.cloneNode(true))
+    this.pickupGroups = Array.from(this.pickupsTarget.querySelectorAll("optgroup")).map((optgroup) => optgroup.cloneNode(true))
     this.booking_end_date()
     this.to_page()
+  }
+
+  resetPickupSelection() {
+    $(this.pickupsTarget).prop("selectedIndex", 0)
+  }
+
+  hiddenOption(label = "") {
+    return $("<option />")
+      .attr("value", "")
+      .text(label)
+      .prop("disabled", true)
+      .prop("selected", true)
+      .prop("hidden", true)
+  }
+
+  replaceOptions(target, options) {
+    $(target).empty().append(options)
   }
 
   to_page() {
@@ -26,52 +45,34 @@ export default class extends Controller {
   }
 
   select() {
-    // We need this variable to be global so that it doesn't mutate in multiple uses
-    if (typeof window.item_level_pickup_locations == "undefined") {
-       window.item_level_pickup_locations = $(this.pickupsTarget).html();
-    }
-
     let description = $("#hold_description option:selected").text();
-    let date = new Date();
-    let emptyOption = $("<option />")
-      .attr("value", "")
-      .prop("disabled", true)
-      .prop("selected", true)
-      .prop("hidden", true);
-    let options = $(window.item_level_pickup_locations).filter(`optgroup[label='${description}']`).prepend(emptyOption).html();
-    if(options) {
-      $(this.pickupsTarget).html(options);
+    let matchingPickupGroup = this.pickupGroups.find((optgroup) => optgroup.label === description);
+
+    if(matchingPickupGroup) {
+      let options = [this.hiddenOption()[0], ...Array.from(matchingPickupGroup.querySelectorAll("option")).map((option) => option.cloneNode(true))]
+      this.replaceOptions(this.pickupsTarget, options)
     } else {
-      $(this.pickupsTarget);
+      this.resetPickupSelection();
     }
   }
 
   typeSelect() {
-    // We need this variable to be global so that it doesn't mutate in multiple uses
-    if (typeof window.item_level_descriptions == "undefined") {
-       window.item_level_descriptions = $(this.descriptionsTarget).html();
-    }
     let material_type = $("#material_type option").filter(":selected").text();
-    let matchingDescriptions = $(window.item_level_descriptions).filter(`optgroup[label='${material_type}']`);
-    let descriptionOptions = matchingDescriptions.find("option");
-    let emptyOption = $("<option />")
-      .attr("value", "")
-      .text(descriptionPlaceholderLabel)
-      .prop("disabled", true)
-      .prop("selected", true)
-      .prop("hidden", true);
+    let matchingDescriptionGroup = this.descriptionGroups.find((optgroup) => optgroup.label === material_type);
+    let descriptionOptions = matchingDescriptionGroup ? Array.from(matchingDescriptionGroup.querySelectorAll("option")) : [];
+
     if(descriptionOptions.length === 1) {
-      $(this.descriptionsTarget).html(matchingDescriptions.html());
+      this.replaceOptions(this.descriptionsTarget, descriptionOptions.map((option) => option.cloneNode(true)));
       $(this.descriptionsTarget).prop("selectedIndex", 0);
-      this.select();
+      this.resetPickupSelection();
     } else {
-      let options = matchingDescriptions.prepend(emptyOption).html();
-      if(options) {
-        $(this.descriptionsTarget).html(options);
+      if(descriptionOptions.length > 1) {
+        let options = [this.hiddenOption(descriptionPlaceholderLabel)[0], ...descriptionOptions.map((option) => option.cloneNode(true))]
+        this.replaceOptions(this.descriptionsTarget, options)
       } else {
         $(this.descriptionsTarget).prop("selectedIndex", 0);
       }
-      $(this.pickupsTarget).prop("selectedIndex", 0);
+      this.resetPickupSelection();
     }
   }
 }

--- a/app/javascript/controllers/request_form_controller.js
+++ b/app/javascript/controllers/request_form_controller.js
@@ -6,13 +6,15 @@ export default class extends Controller {
   static targets = [ "pickups", "descriptions" ]
 
   connect() {
-    this.descriptionGroups = Array.from(this.descriptionsTarget.querySelectorAll("optgroup")).map((optgroup) => optgroup.cloneNode(true))
-    this.pickupGroups = Array.from(this.pickupsTarget.querySelectorAll("optgroup")).map((optgroup) => optgroup.cloneNode(true))
+    this.descriptionGroups = this.hasDescriptionsTarget ? Array.from(this.descriptionsTarget.querySelectorAll("optgroup")).map((optgroup) => optgroup.cloneNode(true)) : []
+    this.pickupGroups = this.hasPickupsTarget ? Array.from(this.pickupsTarget.querySelectorAll("optgroup")).map((optgroup) => optgroup.cloneNode(true)) : []
     this.booking_end_date()
     this.to_page()
   }
 
   resetPickupSelection() {
+    if (!this.hasPickupsTarget) return
+
     $(this.pickupsTarget).prop("selectedIndex", 0)
   }
 
@@ -45,7 +47,9 @@ export default class extends Controller {
   }
 
   select() {
-    let description = $("#hold_description option:selected").text();
+    if (!this.hasDescriptionsTarget || !this.hasPickupsTarget) return
+
+    let description = this.descriptionsTarget.options[this.descriptionsTarget.selectedIndex]?.text;
     let matchingPickupGroup = this.pickupGroups.find((optgroup) => optgroup.label === description);
 
     if(matchingPickupGroup) {
@@ -57,6 +61,8 @@ export default class extends Controller {
   }
 
   typeSelect() {
+    if (!this.hasDescriptionsTarget) return
+
     let material_type = $("#material_type option").filter(":selected").text();
     let matchingDescriptionGroup = this.descriptionGroups.find((optgroup) => optgroup.label === material_type);
     let descriptionOptions = matchingDescriptionGroup ? Array.from(matchingDescriptionGroup.querySelectorAll("option")) : [];

--- a/spec/javascript/packs/controllers/request_form_controller.spec.js
+++ b/spec/javascript/packs/controllers/request_form_controller.spec.js
@@ -44,6 +44,51 @@ describe("RequestFormController", () => {
     await new Promise(resolve => setTimeout(resolve, 0))
   }
 
+  const bookingDom = () => {
+    document.body.innerHTML = `
+      <div id="request-form-root" data-controller="request-form">
+        <select id="material_type">
+          <option value="">Select a format</option>
+          <option value="Book">Book</option>
+        </select>
+
+        <select id="booking_description">
+          <option value="" disabled selected hidden>Select volume/issue or additional item details, if applicable</option>
+          <optgroup label="Book">
+            <option value="">any available copy</option>
+          </optgroup>
+        </select>
+
+        <select id="booking_pickup_location">
+          <option value="" disabled selected hidden></option>
+          <option value="MAIN">Charles Library</option>
+        </select>
+      </div>
+    `
+  }
+
+  const asrsDom = () => {
+    document.body.innerHTML = `
+      <div id="request-form-root" data-controller="request-form">
+        <select id="material_type">
+          <option value="">Select a format</option>
+          <option value="Book">Book</option>
+        </select>
+
+        <select id="asrs_description">
+          <option value="" disabled selected hidden>Select volume/issue or additional item details, if applicable</option>
+          <optgroup label="Book">
+            <option value="">any available copy</option>
+          </optgroup>
+        </select>
+
+        <select id="asrs_pickup_location">
+          <option value="MAIN" selected>Charles Library</option>
+        </select>
+      </div>
+    `
+  }
+
   afterEach(() => {
     if (application) application.stop()
     application = null
@@ -156,5 +201,33 @@ describe("RequestFormController", () => {
     expect(options[0].disabled).toBe(true)
     expect(options[0].hidden).toBe(true)
     expect(options[1].textContent).toBe("Charles Library")
+  })
+
+  it("connects safely for a booking-style form without hold targets", async () => {
+    bookingDom()
+
+    await expect(startController()).resolves.toBeUndefined()
+
+    const root = document.getElementById("request-form-root")
+    const controller = application.getControllerForElementAndIdentifier(root, "request-form")
+
+    expect(() => controller.typeSelect()).not.toThrow()
+    expect(() => controller.select()).not.toThrow()
+    expect(root.querySelector("#booking_description")).not.toBeNull()
+    expect(root.querySelector("#booking_pickup_location")).not.toBeNull()
+  })
+
+  it("connects safely for an asrs-style form without hold targets", async () => {
+    asrsDom()
+
+    await expect(startController()).resolves.toBeUndefined()
+
+    const root = document.getElementById("request-form-root")
+    const controller = application.getControllerForElementAndIdentifier(root, "request-form")
+
+    expect(() => controller.typeSelect()).not.toThrow()
+    expect(() => controller.select()).not.toThrow()
+    expect(root.querySelector("#asrs_description")).not.toBeNull()
+    expect(root.querySelector("#asrs_pickup_location")).not.toBeNull()
   })
 })

--- a/spec/javascript/packs/controllers/request_form_controller.spec.js
+++ b/spec/javascript/packs/controllers/request_form_controller.spec.js
@@ -14,20 +14,22 @@ describe("RequestFormController", () => {
         </select>
 
         <select id="hold_description" data-request-form-target="descriptions">
+          <option value="" disabled selected hidden>Select volume/issue or additional item details, if applicable</option>
           <optgroup label="DVD">
             <option value="">any available copy</option>
           </optgroup>
           <optgroup label="Book">
-            <option value="c. 3" selected>c. 3</option>
+            <option value="booklet">booklet</option>
             <option value="">any available copy</option>
           </optgroup>
         </select>
 
         <select data-request-form-target="pickups">
+          <option value="" disabled selected hidden></option>
           <optgroup label="any available copy">
             <option value="MEDIA">Media Services Desk</option>
           </optgroup>
-          <optgroup label="c. 3">
+          <optgroup label="booklet">
             <option value="MAIN">Charles Library</option>
           </optgroup>
         </select>
@@ -45,8 +47,6 @@ describe("RequestFormController", () => {
   afterEach(() => {
     if (application) application.stop()
     application = null
-    window.item_level_descriptions = undefined
-    window.item_level_pickup_locations = undefined
     document.body.innerHTML = ""
   })
 
@@ -66,11 +66,11 @@ describe("RequestFormController", () => {
     expect(options[0].textContent).toBe("Select volume/issue or additional item details, if applicable")
     expect(options[0].disabled).toBe(true)
     expect(options[0].hidden).toBe(true)
-    expect(options[1].textContent).toBe("c. 3")
+    expect(options[1].textContent).toBe("booklet")
     expect(options[2].textContent).toBe("any available copy")
   })
 
-  it("auto-selects the only description for a material type and updates pickup options", async () => {
+  it("auto-selects the only description for a material type without filtering pickup options", async () => {
     setupDom()
     await startController()
 
@@ -87,7 +87,33 @@ describe("RequestFormController", () => {
     expect(descriptionOptions).toHaveLength(1)
     expect(descriptions.value).toBe("")
     expect(descriptionOptions[0].textContent).toBe("any available copy")
+    expect(pickups).toHaveLength(3)
+    expect(pickups[0].textContent).toBe("")
     expect(pickups[1].textContent).toBe("Media Services Desk")
+    expect(pickups[2].textContent).toBe("Charles Library")
+  })
+
+  it("keeps any available copy alongside other description options for a material type", async () => {
+    setupDom()
+    await startController()
+
+    const root = document.getElementById("request-form-root")
+    const controller = application.getControllerForElementAndIdentifier(root, "request-form")
+    const descriptions = root.querySelector('[data-request-form-target="descriptions"]')
+    const pickups = root.querySelector('[data-request-form-target="pickups"]')
+
+    document.querySelector("#material_type").value = "Book"
+    controller.typeSelect()
+
+    expect(Array.from(descriptions.options)).toHaveLength(3)
+    expect(descriptions.options[0].textContent).toBe("Select volume/issue or additional item details, if applicable")
+    expect(descriptions.options[1].textContent).toBe("booklet")
+    expect(descriptions.options[2].textContent).toBe("any available copy")
+    expect(descriptions.value).toBe("")
+    expect(Array.from(pickups.options)).toHaveLength(3)
+    expect(pickups.options[0].textContent).toBe("")
+    expect(pickups.options[1].textContent).toBe("Media Services Desk")
+    expect(pickups.options[2].textContent).toBe("Charles Library")
   })
 
   it("re-applies description selection rules when the material type changes", async () => {
@@ -102,7 +128,8 @@ describe("RequestFormController", () => {
     materialType.value = "Book"
     controller.typeSelect()
     expect(Array.from(descriptions.options)).toHaveLength(3)
-    expect(descriptions.options[0].textContent).toBe("Select volume/issue or additional item details, if applicable")
+    expect(descriptions.options[1].textContent).toBe("booklet")
+    expect(descriptions.options[2].textContent).toBe("any available copy")
 
     materialType.value = "DVD"
     controller.typeSelect()
@@ -117,6 +144,9 @@ describe("RequestFormController", () => {
 
     const root = document.getElementById("request-form-root")
     const controller = application.getControllerForElementAndIdentifier(root, "request-form")
+    const descriptions = root.querySelector('[data-request-form-target="descriptions"]')
+
+    descriptions.value = "booklet"
 
     controller.select()
 

--- a/spec/models/request_data_spec.rb
+++ b/spec/models/request_data_spec.rb
@@ -354,6 +354,30 @@ RSpec.describe RequestData, type: :model do
         expect(subject.material_types_and_descriptions).to eq([["DVD", ["sample", "second"]]])
       end
     end
+
+    context "material type with a blank and an additional description" do
+      let(:bib_items) do
+        [
+          Alma::BibItem.new(
+            "item_data" => {
+              "description" => "",
+              "physical_material_type" => { "value" => "BOOK", "desc" => "Book" }
+            }
+          ),
+          Alma::BibItem.new(
+            "item_data" => {
+              "description" => "booklet",
+              "physical_material_type" => { "value" => "BOOK", "desc" => "Book" }
+            }
+          )
+        ]
+      end
+
+      it "retains any available copy alongside the additional description" do
+        expect(subject.material_types_and_descriptions).to eq([["Book", [["any available copy", ""], "booklet"]]])
+      end
+    end
+
     context "material type with empty description" do
       let(:bib_items) { Alma::BibItem.find("empty_descriptions") }
       it "returns an array of hashes with the blank description label and blank string value" do


### PR DESCRIPTION
Fixes intended blank values (any available copy) from being stripped out of description lists while still ensuring the prompt text is not included in list.