### PR TITLE
Fix request form validation for any available copy selections

### DIFF
--- a/app/controllers/almaws_controller.rb
+++ b/app/controllers/almaws_controller.rb
@@ -66,10 +66,11 @@ class AlmawsController < CatalogController
   end
 
   def send_hold_request
+    description = normalized_request_description(params[:hold_description])
     bib_options = {
     mms_id: params[:mms_id],
     user_id: current_user.uid,
-    description: params[:hold_description],
+    description: description,
     pickup_location_library: params[:hold_pickup_location],
     pickup_location_type: "LIBRARY",
     material_type: { value: params[:material_type] },
@@ -80,7 +81,7 @@ class AlmawsController < CatalogController
     log = { type: "submit_hold_request", user: current_user.id }.merge(bib_options)
 
     begin
-      item_options = same_pickup_item_request_options(params[:mms_id], params[:hold_pickup_location], params[:hold_description])
+      item_options = same_pickup_item_request_options(params[:mms_id], params[:hold_pickup_location], description)
       response =
         if item_options.present?
           do_with_json_logger(log.merge(item_options)) { Alma::ItemRequest.submit(bib_options.merge(item_options)) }
@@ -98,10 +99,11 @@ class AlmawsController < CatalogController
   end
 
   def send_asrs_request
+    description = normalized_request_description(params[:asrs_description])
     options = {
     mms_id: params[:mms_id],
     user_id: current_user.uid,
-    description: params[:asrs_description],
+    description: description,
     pickup_location_library: params[:asrs_pickup_location],
     pickup_location_type: "LIBRARY",
     material_type: { value: params[:material_type] },
@@ -154,6 +156,7 @@ class AlmawsController < CatalogController
   def send_booking_request
     start_date = date_or_nil(params[:booking_start_date])
     end_date = date_or_nil(params[:booking_end_date])
+    description = normalized_request_description(params[:booking_description])
     bib_options = {
     mms_id: params[:mms_id],
     user_id: current_user.uid,
@@ -163,7 +166,7 @@ class AlmawsController < CatalogController
     request_type: "BOOKING",
     booking_start_date: start_date,
     booking_end_date: end_date,
-    description: params[:booking_description],
+    description: description,
     comment: params[:booking_comment]
     }
 
@@ -183,10 +186,11 @@ class AlmawsController < CatalogController
   end
 
   def send_digitization_request
+    description = normalized_request_description(params[:digitization_description])
     bib_options = {
       mms_id: params[:mms_id],
       user_id: current_user.uid,
-      description: params[:digitization_description],
+      description: description,
       chapter_or_article_title: params[:chapter_or_article_title],
       chapter_or_article_author: params[:chapter_or_article_author],
       request_type: "DIGITIZATION",
@@ -257,5 +261,9 @@ class AlmawsController < CatalogController
         date = nil
       end
       date
+    end
+
+    def normalized_request_description(description)
+      description == RequestData::BLANK_DESCRIPTION_VALUE ? "" : description
     end
 end

--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -13,7 +13,7 @@ module RequestHelper
   def request_grouped_select_options(option_groups, placeholder:)
     safe_join([
       request_hidden_placeholder_option(placeholder),
-      grouped_options_for_select(option_groups)
+      grouped_options_for_select(normalized_request_grouped_options(option_groups))
     ])
   end
 
@@ -89,6 +89,22 @@ module RequestHelper
   end
 
   private
+
+    def normalized_request_grouped_options(option_groups)
+      option_groups.map do |group_label, options|
+        [group_label, normalize_grouped_option_values(options)]
+      end
+    end
+
+    def normalize_grouped_option_values(options)
+      Array(options).map do |option|
+        if option.is_a?(Array) && option.length >= 2 && option.last == ""
+          [option.first, RequestData::BLANK_DESCRIPTION_VALUE]
+        else
+          option
+        end
+      end
+    end
 
     def request_hidden_placeholder_option(text)
       content_tag(:option, text, value: "", disabled: true, selected: true, hidden: true)

--- a/app/models/request_data.rb
+++ b/app/models/request_data.rb
@@ -4,6 +4,7 @@ class RequestData
   include Lookupable
 
   BLANK_DESCRIPTION_LABEL = "any available copy"
+  BLANK_DESCRIPTION_VALUE = "__any_available_copy__"
 
   attr_reader :request_level
   attr_reader :pickup_location_codes

--- a/spec/controllers/almaws_controller_spec.rb
+++ b/spec/controllers/almaws_controller_spec.rb
@@ -303,6 +303,33 @@ RSpec.describe AlmawsController, type: :controller do
         expect(Alma::ItemRequest).not_to have_received(:submit)
         expect(Alma::BibRequest).to have_received(:submit)
       end
+
+      it "normalizes the any available copy sentinel back to a blank description" do
+        allow(controller).to receive(:get_bib_items).and_return([
+          Alma::BibItem.new(
+            "holding_data" => { "holding_id" => "holding_main" },
+            "item_data" => {
+              "pid" => "item_main",
+              "description" => "",
+              "library" => { "value" => "MAIN", "desc" => "Charles Library" },
+              "base_status" => { "value" => "1", "desc" => "Item in place" }
+            }
+          )
+        ])
+
+        response_double = double("request_response", request_id: "1", managed_by_library_code: "MAIN", loggable: {})
+        allow(Alma::BibRequest).to receive(:submit).and_return(response_double)
+
+        post(:send_hold_request, params: {
+          mms_id: "foo",
+          hold_description: RequestData::BLANK_DESCRIPTION_VALUE,
+          hold_pickup_location: "MAIN",
+          material_type: "BOOK",
+          request_level: "bib"
+        })
+
+        expect(Alma::BibRequest).to have_received(:submit).with(hash_including(description: ""))
+      end
     end
   end
 

--- a/spec/helpers/request_helper_spec.rb
+++ b/spec/helpers/request_helper_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe RequestHelper, type: :helper do
       expect(placeholder["selected"]).to eq("selected")
       expect(placeholder["hidden"]).to eq("hidden")
       expect(options.map(&:text)).to eq(["c. 3", "any available copy"])
+      expect(options.last["value"]).to eq(RequestData::BLANK_DESCRIPTION_VALUE)
     end
   end
 

--- a/spec/javascript/packs/controllers/request_form_controller.spec.js
+++ b/spec/javascript/packs/controllers/request_form_controller.spec.js
@@ -16,11 +16,11 @@ describe("RequestFormController", () => {
         <select id="hold_description" data-request-form-target="descriptions">
           <option value="" disabled selected hidden>Select volume/issue or additional item details, if applicable</option>
           <optgroup label="DVD">
-            <option value="">any available copy</option>
+            <option value="__any_available_copy__">any available copy</option>
           </optgroup>
           <optgroup label="Book">
             <option value="booklet">booklet</option>
-            <option value="">any available copy</option>
+            <option value="__any_available_copy__">any available copy</option>
           </optgroup>
         </select>
 
@@ -55,7 +55,7 @@ describe("RequestFormController", () => {
         <select id="booking_description" data-request-form-target="descriptions">
           <option value="" disabled selected hidden>Select volume/issue or additional item details, if applicable</option>
           <optgroup label="Book">
-            <option value="">any available copy</option>
+            <option value="__any_available_copy__">any available copy</option>
           </optgroup>
         </select>
 
@@ -78,7 +78,7 @@ describe("RequestFormController", () => {
         <select id="asrs_description" data-request-form-target="descriptions">
           <option value="" disabled selected hidden>Select volume/issue or additional item details, if applicable</option>
           <optgroup label="Book">
-            <option value="">any available copy</option>
+            <option value="__any_available_copy__">any available copy</option>
           </optgroup>
         </select>
         
@@ -130,7 +130,7 @@ describe("RequestFormController", () => {
     const pickups = Array.from(root.querySelectorAll('[data-request-form-target="pickups"] option'))
 
     expect(descriptionOptions).toHaveLength(1)
-    expect(descriptions.value).toBe("")
+    expect(descriptions.value).toBe("__any_available_copy__")
     expect(descriptionOptions[0].textContent).toBe("any available copy")
     expect(pickups).toHaveLength(2)
     expect(pickups[0].textContent).toBe("")
@@ -179,7 +179,7 @@ describe("RequestFormController", () => {
     controller.typeSelect()
     expect(Array.from(descriptions.options)).toHaveLength(1)
     expect(descriptions.options[0].textContent).toBe("any available copy")
-    expect(descriptions.value).toBe("")
+    expect(descriptions.value).toBe("__any_available_copy__")
   })
 
   it("prepends a hidden disabled selected pickup placeholder when filtering by description", async () => {


### PR DESCRIPTION
Blank values were throwing off the HTML form validation, as if no value was selected. This consistently sets the value for the DOM when the value is blank, conveniently labelled as "any available copy" for users, and converts back to "" when the form passes validation and is submitted.