### PR TITLE
MAN-1542-improve-manifold-alerts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -206,9 +206,14 @@ module ApplicationHelper
         message = a.dig("attributes", "scroll_text")
 
         link = a.dig("attributes", "link")
+        link_text = a.dig("attributes", "link_text")
 
-        if !link.blank?
-          messages << message + " " + link_to(t("blacklight.banner_link"), link)
+        if link.present?
+          if link_text.present?
+            messages << message + " " + link_to(link_text, link)
+          else
+            messages << message + " " + link_to(t("blacklight.banner_link"), link)
+          end
         else
           messages << message
         end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -175,6 +175,56 @@ RSpec.describe ApplicationHelper, type: :helper do
         expect(helper.emergency_alert_messages).to have_text(/Click here to see full details./)
       end
     end
+
+    context "link_text is present" do
+      it "uses the custom link text" do
+        helper.instance_variable_set(
+          "@manifold_alerts_thread",
+          Thread.new do
+            [
+              {
+                "attributes" => {
+                  "for_header" => false,
+                  "scroll_text" => "Test banner message",
+                  "link" => "https://library.temple.edu/details",
+                  "link_text" => "Read the full announcement"
+                }
+              }
+            ]
+          end
+        )
+
+        expect(helper.emergency_alert_messages).to have_link(
+          "Read the full announcement",
+          href: "https://library.temple.edu/details"
+        )
+      end
+    end
+
+    context "link_text is an empty string" do
+      it "falls back to the default banner link text" do
+        helper.instance_variable_set(
+          "@manifold_alerts_thread",
+          Thread.new do
+            [
+              {
+                "attributes" => {
+                  "for_header" => false,
+                  "scroll_text" => "Test banner message",
+                  "link" => "https://library.temple.edu/details",
+                  "link_text" => ""
+                }
+              }
+            ]
+          end
+        )
+
+        expect(helper.emergency_alert_messages).to have_link(
+          I18n.t("blacklight.banner_link"),
+          href: "https://library.temple.edu/details"
+        )
+      end
+    end
   end
 
   describe "#manifold_alerts" do


### PR DESCRIPTION
This PR updates ApplicationHelper#emergency_alert_messages so manifold alert banners use attributes.link_text when it is provided. When link_text is blank, including when it is an empty string, the helper continues to fall back to the existing translated default link label.

It also adds helper spec coverage for both paths: using custom link text when present and falling back to blacklight.banner_link when link_text is empty.