### PR TITLE
Enable devise login tracker.

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -20,7 +20,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     auth.uid = auth.extra.raw_info["urn:oid:2.16.840.1.113730.3.1.3"]
     @user = User.from_omniauth(auth)
-    sign_in(:user, @user)
+    sign_in(:user, @user, event: :authentication)
 
     session[:alma_auth_type] = "sso"
     session[:alma_sso_user] = @user.uid

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :omniauthable, omniauth_providers: [:shibboleth, :saml]
+  devise :trackable, :database_authenticatable, :omniauthable, omniauth_providers: [:shibboleth, :saml]
 
   def alma
     log = { type: "alma_user", uid: }

--- a/spec/features/basic_page_elements_spec.rb
+++ b/spec/features/basic_page_elements_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-
 RSpec.feature "Basic Page Elements" do
 
   feature "Check the home page for nav elements when anonymous" do
@@ -25,8 +24,7 @@ RSpec.feature "Basic Page Elements" do
   feature "Check for home page features when logged in" do
 
     before do
-      DatabaseCleaner.clean
-      user = FactoryBot.build_stubbed(:user)
+      user = FactoryBot.create(:user)
       login_as(user, scope: :user)
 
     end
@@ -40,7 +38,6 @@ RSpec.feature "Basic Page Elements" do
     end
 
     after(:all) do
-      DatabaseCleaner.clean
       Warden.test_reset!
     end
 

--- a/spec/features/record_page_fields_spec.rb
+++ b/spec/features/record_page_fields_spec.rb
@@ -11,9 +11,7 @@ RSpec.feature "RecordPageFields" do
 
   feature "Purchase order link" do
     before do
-      DatabaseCleaner.clean
-      DatabaseCleaner.strategy = :truncation
-      user = FactoryBot.build_stubbed :user
+      user = FactoryBot.create :user
       allow(user).to receive(:can_purchase_order?) { can_purchase_order? }
       login_as user, scope: :user
     end


### PR DESCRIPTION
This will help us match f5 logs to OSD logs when users log in.