### PR TITLE
BL-2030 Add citeproc service to normalize data

### DIFF
--- a/app/models/citeproc_citation.rb
+++ b/app/models/citeproc_citation.rb
@@ -19,7 +19,7 @@ class CiteprocCitation
   end
 
   def citable?
-    title.present?
+    csl_item.present?
   end
 
   def citations
@@ -37,7 +37,7 @@ class CiteprocCitation
     attr_reader :document, :formats
 
     def return_null_citation?
-      title.blank?
+      csl_item.blank?
     end
 
     def all_formats_requested?
@@ -69,116 +69,7 @@ class CiteprocCitation
     end
 
     def csl_item
-      @csl_item ||= begin
-        attributes = {
-          id: document.id.to_s,
-          type: csl_type,
-          title: title,
-          author: csl_names(author_names),
-          editor: csl_names(editor_names),
-          issued: issued_date,
-          publisher: publisher,
-          publisher_place: publisher_place,
-          ISBN: isbn,
-          ISSN: issn
-        }.compact
-        CiteProc::Item.new(attributes)
-      end
-    end
-
-    def title
-      Array(document["title_statement_display"]).first.to_s.presence
-    end
-
-    def author_names
-      Array(document["creator_display"]).presence ||
-        Array(document["contributor_display"]).presence ||
-        []
-    end
-
-    def editor_names
-      return [] if Array(document["creator_display"]).present?
-      Array(document["contributor_display"])
-    end
-
-    def csl_names(names)
-      Array(names).filter_map do |name|
-        value = extract_name_value(name)
-        next if value.blank?
-
-        if value.include?(",")
-          family, given = value.split(",", 2).map(&:strip)
-          { family:, given: given.presence }
-        else
-          { literal: value }
-        end
-      end
-    end
-
-    def extract_name_value(name)
-      return name["name"].to_s.strip if name.is_a?(Hash)
-
-      value = name.to_s.strip
-      return "" if value.blank?
-      return value unless value.start_with?("{") && value.end_with?("}")
-
-      parsed = JSON.parse(value)
-      parsed.is_a?(Hash) ? parsed["name"].to_s.strip : value
-    rescue JSON::ParserError
-      value
-    end
-
-    def issued_date
-      year = publication_year
-      return nil if year.blank?
-
-      { "date-parts" => [[year.to_i]] }
-    end
-
-    def publication_year
-      candidates = [
-        Array(document["pub_date_display"]).first,
-        Array(document["pub_date"]).first,
-        document["date_copyright_display"]
-      ].compact.map(&:to_s)
-
-      match = candidates.join(" ").match(/\b\d{4}\b/)
-      match&.to_s
-    end
-
-    def csl_type
-      formats = Array(document["format"])
-      return "book" if formats.include?("Book")
-      return "article-journal" if formats.include?("Journal/Periodical") || formats.include?("Article")
-      return "thesis" if formats.include?("Dissertation/Thesis")
-      "document"
-    end
-
-    def imprint
-      Array(document["imprint_display"]).first ||
-        Array(document["imprint_prod_display"]).first ||
-        Array(document["imprint_dist_display"]).first ||
-        Array(document["imprint_man_display"]).first
-    end
-
-    def publisher_place
-      return nil if imprint.blank?
-      imprint.to_s.split(":").first.to_s.strip.presence
-    end
-
-    def publisher
-      return nil if imprint.blank?
-      parts = imprint.to_s.split(":")
-      publisher_section = parts.length > 1 ? parts.last : parts.first
-      publisher_section.to_s.split(",").first.to_s.strip.presence
-    end
-
-    def isbn
-      Array(document["isbn_display"]).first
-    end
-
-    def issn
-      Array(document["issn_display"]).first
+      @csl_item ||= Citeproc::ItemService.build(document)
     end
 
     def null_citation

--- a/app/services/citeproc/item_service.rb
+++ b/app/services/citeproc/item_service.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+module Citeproc
+  class ItemService
+    ROLE_MAPPINGS = {
+      "author" => "author",
+      "aut" => "author",
+      "editor" => "editor",
+      "edt" => "editor",
+      "translator" => "translator",
+      "trl" => "translator",
+      "illustrator" => "illustrator",
+      "ill" => "illustrator"
+    }.freeze
+
+    def self.build(document)
+      new(document).item
+    end
+
+    def initialize(document)
+      @document = document
+    end
+
+    attr_reader :document
+
+    def item
+      return if normalized_title.blank?
+
+      ::CiteProc::Item.new(item_attributes.compact_blank)
+    end
+
+    private
+
+      def item_attributes
+        {
+          id: document.id.to_s,
+          type: "book",
+          title: normalized_title,
+          author: extract_names("author"),
+          editor: extract_names("editor"),
+          translator: extract_names("translator"),
+          illustrator: extract_names("illustrator")
+        }
+      end
+
+      def normalized_title
+        return @normalized_title if defined?(@normalized_title)
+
+        title = Array(document["title_with_subtitle_display"]).first ||
+          Array(document["title_with_subtitle_truncated_display"]).first ||
+          Array(document["title_statement_display"]).first
+
+        @normalized_title = normalize_title(title)
+      end
+
+      def normalize_title(value)
+        title = value.to_s.split(%r{\s+/\s+}, 2).first.to_s
+        title = title.gsub(/\s+/, " ").strip
+        title.presence
+      end
+
+      def extract_names(target_role)
+        extract_main_entry_names(target_role) + extract_contributor_names(target_role)
+      end
+
+      def extract_main_entry_names(target_role)
+        Array(document["creator_display"]).filter_map do |value|
+          role = extract_role(value, default_role: "author")
+          extract_name(value) if role == target_role
+        end.uniq
+      end
+
+      def extract_contributor_names(target_role)
+        Array(document["contributor_display"]).filter_map do |value|
+          role = extract_role(value, default_role: default_role_for_contributor_entries)
+          extract_name(value) if role == target_role
+        end.uniq
+      end
+
+      def default_role_for_contributor_entries
+        return unless Array(document["creator_display"]).blank?
+
+        "author"
+      end
+
+      def extract_name(value)
+        name = parsed_indexed_value(value)[:name]
+        build_name(name)
+      end
+
+      def build_name(value)
+        return if value.blank?
+
+        normalized_value = strip_trailing_meeting_metadata(strip_trailing_name_dates(value))
+
+        if personal_name?(normalized_value)
+          family, given = normalized_value.split(",", 2).map(&:strip)
+          { family: strip_trailing_name_dates(family), given: strip_trailing_name_dates(given).presence }
+        else
+          { literal: normalized_value }
+        end
+      end
+
+      def personal_name?(value)
+        value.count(",") == 1
+      end
+
+      def extract_role(value, default_role: nil)
+        relator_segments(value).each do |segment|
+          role = ROLE_MAPPINGS[normalize_relator(segment)]
+          return role if role.present?
+        end
+
+        default_role
+      end
+
+      def relator_segments(value)
+        parsed = parsed_indexed_value(value)
+        Array(parsed[:relators])
+      end
+
+      def normalize_relator(value)
+        normalized = strip_trailing_punct(value).downcase
+        normalized.include?("relators/") ? normalized.split("/").last : normalized
+      end
+
+      def parsed_indexed_value(value)
+        return parse_json_indexed_value(value) if json_indexed_value?(value)
+
+        parse_pipe_indexed_value(value)
+      end
+
+      def json_indexed_value?(value)
+        string = value.to_s.strip
+        string.start_with?("{") && string.end_with?("}")
+      end
+
+      def parse_json_indexed_value(value)
+        parsed = JSON.parse(value.to_s)
+        {
+          name: parsed["name"].to_s.strip,
+          relators: [parsed["role"], parsed["relation"]].compact_blank
+        }
+      rescue JSON::ParserError
+        parse_pipe_indexed_value(value)
+      end
+
+      def parse_pipe_indexed_value(value)
+        segments = value.to_s.split("|").map(&:strip)
+        {
+          name: segments.first.to_s,
+          relators: segments.drop(1)
+        }
+      end
+
+      def strip_trailing_punct(value)
+        value.to_s.strip.gsub(/[.,:;\/]+\z/, "")
+      end
+
+      def strip_trailing_name_dates(value)
+        normalized = strip_trailing_punct(value)
+          .sub(/\s*\((?:ca\.?\s*)?\d{3,4}(?:\s*-\s*\d{0,4}\??)?\)\z/i, "")
+          .sub(/,\s*b\.\s*\d{3,4}\z/i, "")
+          .sub(/,\s*d\.\s*\d{3,4}\z/i, "")
+          .sub(/,\s+(?:ca\.?|approximately)?\s*\d{3,4}\s*-\s*(?:ca\.?|approximately)?\s*\d{0,4}\??\z/i, "")
+          .sub(/,\s+(?:ca\.?|approximately)?\s*\d{3,4}\??\z/i, "")
+
+        strip_trailing_punct(normalized)
+          .strip
+      end
+
+      def strip_trailing_meeting_metadata(value)
+        normalized = value.to_s.gsub(/\s+/, " ").strip
+        normalized = normalized
+          .sub(/\s*\((?=[^)]*\d{4})(?=[^)]*:)[^)]*\)\z/, "")
+          .sub(/\s+\(?\d+(?:st|nd|rd|th)?\s*:\s*\d{4}\s*:\s*[^)]*\)?\z/i, "")
+          .sub(/\s+\(?\d{4}\s*:\s*[^)]*\)?\z/i, "")
+          .strip
+
+        strip_trailing_punct(normalized)
+      end
+  end
+end

--- a/spec/services/citeproc/item_service_spec.rb
+++ b/spec/services/citeproc/item_service_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Citeproc::ItemService do
+  subject(:item) { described_class.build(document) }
+
+  let(:document) do
+    SolrDocument.new(
+      "id" => "991012041239703811",
+      "title_statement_display" => ["Big mechanisms in systems biology : big data mining, network modeling, and genome-wide data identification / Bor-Sen Chen, Cheng-Wei Li."],
+      "creator_display" => ["Chen, Bor-Sen|author."],
+      "contributor_display" => ["Li, Zhengwei|author."],
+      "format" => ["Book"]
+    )
+  end
+
+  def citeproc_names(value)
+    value&.to_citeproc
+  end
+
+  it "builds a citeproc item from indexed title and relator-normalized names" do
+    expect(item.id).to eq("991012041239703811")
+    expect(item.type).to eq("book")
+    expect(item.title).to eq("Big mechanisms in systems biology : big data mining, network modeling, and genome-wide data identification")
+    expect(citeproc_names(item.author)).to eq([{ "family" => "Chen", "given" => "Bor-Sen" }, { "family" => "Li", "given" => "Zhengwei" }])
+  end
+
+  it "maps supported contributor relators from indexed fields" do
+    document["contributor_display"] = [
+      "Norris, Denne Michele,|editor.",
+      "Diaz, Ana|http://id.loc.gov/vocabulary/relators/trl",
+      "Example Press|illustrator."
+    ]
+
+    expect(citeproc_names(item.editor)).to eq([{ "family" => "Norris", "given" => "Denne Michele" }])
+    expect(citeproc_names(item.translator)).to eq([{ "family" => "Diaz", "given" => "Ana" }])
+    expect(citeproc_names(item.illustrator)).to eq([{ "literal" => "Example Press" }])
+  end
+
+  it "parses contributor-only json indexed values" do
+    document["creator_display"] = []
+    document["contributor_display"] = [
+      '{"relation":"","name":"Norris, Denne Michele","role":"editor"}'
+    ]
+
+    expect(citeproc_names(item.editor)).to eq([{ "family" => "Norris", "given" => "Denne Michele" }])
+  end
+
+  it "parses author relators from contributor-only json indexed values" do
+    document["creator_display"] = []
+    document["contributor_display"] = [
+      '{"relation":"","name":"Example, Avery","role":"author"}'
+    ]
+
+    expect(citeproc_names(item.author)).to eq([{ "family" => "Example", "given" => "Avery" }])
+  end
+
+  it "uses contributor_display as author when there is no creator_display" do
+    document["creator_display"] = []
+    document["contributor_display"] = [
+      "Norris, Denne Michele,"
+    ]
+
+    expect(citeproc_names(item.author)).to eq([{ "family" => "Norris", "given" => "Denne Michele" }])
+  end
+
+  it "returns nil when indexed title data is missing" do
+    document["title_statement_display"] = []
+    document["title_with_subtitle_display"] = []
+    document["title_with_subtitle_truncated_display"] = []
+
+    expect(item).to be_nil
+  end
+
+  it "treats creator_display as author when there is no relator" do
+    document["creator_display"] = ["World Health Organization."]
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "literal" => "World Health Organization" }])
+  end
+
+  it "defaults unsupported creator relators to author" do
+    document["creator_display"] = ["Norris, Denne Michele,|writer of supplementary textual content."]
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "family" => "Norris", "given" => "Denne Michele" }])
+  end
+
+  it "strips life dates from indexed personal names" do
+    document["creator_display"] = ["Boswell, James, 1740-1795"]
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "family" => "Boswell", "given" => "James" }])
+  end
+
+  it "strips life dates when the indexed personal name ends with punctuation" do
+    document["creator_display"] = ["Pong, Chun-ho, 1969-."]
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "family" => "Pong", "given" => "Chun-ho" }])
+  end
+
+  it "strips parenthesized life dates from indexed personal names" do
+    document["creator_display"] = ["Example, Avery (1969-)"]
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "family" => "Example", "given" => "Avery" }])
+  end
+
+  it "strips a trailing standalone year from indexed personal names" do
+    document["creator_display"] = ["Example, Avery, 1969"]
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "family" => "Example", "given" => "Avery" }])
+  end
+
+  it "strips trailing meeting metadata from literal names" do
+    document["creator_display"] = ["International Society on Oxygen Transport to Tissue. Annual Meeting (36th : 2008 : Sapporo-shi, Japan)"]
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "literal" => "International Society on Oxygen Transport to Tissue. Annual Meeting" }])
+  end
+
+  it "strips trailing meeting metadata from json indexed literal names" do
+    document["creator_display"] = ['{"relation":"","name":"International Society on Oxygen Transport to Tissue. Annual Meeting (36th : 2008 : Sapporo-shi, Japan)","role":"author"}']
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "literal" => "International Society on Oxygen Transport to Tissue. Annual Meeting" }])
+  end
+
+  it "strips unparenthesized trailing meeting metadata from literal names" do
+    document["creator_display"] = ["International Society on Oxygen Transport to Tissue. Annual Meeting 36th : 2008 : Sapporo-shi, Japan"]
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "literal" => "International Society on Oxygen Transport to Tissue. Annual Meeting" }])
+  end
+
+  it "strips compact trailing meeting metadata from literal names" do
+    document["creator_display"] = ["International Society on Oxygen Transport to Tissue. Annual Meeting (36th: 2008: Sapporo-shi, Japan)"]
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "literal" => "International Society on Oxygen Transport to Tissue. Annual Meeting" }])
+  end
+
+  it "treats multi-comma non-personal names as literals" do
+    document["creator_display"] = ["International Society on Oxygen Transport to Tissue. Annual Meeting, Sapporo-shi, Japan"]
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "literal" => "International Society on Oxygen Transport to Tissue. Annual Meeting, Sapporo-shi, Japan" }])
+  end
+
+  it "ignores contributor_display entries without supported relators when creator_display is present" do
+    document["creator_display"] = ["Primary, Pat|author."]
+    document["contributor_display"] = [
+      "Contributor, Chris.",
+      "Helper, Pat|writer of supplementary textual content."
+    ]
+
+    expect(citeproc_names(item.author)).to eq([{ "family" => "Primary", "given" => "Pat" }])
+    expect(item.editor).to be_nil
+    expect(item.translator).to be_nil
+  end
+end


### PR DESCRIPTION
Updated citeproc citation generation to use a dedicated Citeproc::ItemService that normalizes Temple’s indexed title, creator, and contributor fields into CSL item data for print books. The change focuses on author/contributor handling, including relator mapping, contributor-only fallback to author, and cleanup of trailing life dates and meeting metadata in citation display, without changing indexing.