### PR TITLE
BL-1922 More solr error fixes

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -205,8 +205,12 @@ module BlacklightAdvancedSearch
       # @param query the query
       # @return the query with an even number of quotation marks
       def odd_quotes(query)
-        if query&.count('"')&.odd?
-          query.sub(/"/, "")
+        return query unless query&.count('"')&.odd?
+
+        if query.start_with?('"')
+          query[1..]
+        elsif query.end_with?('"')
+          query[0...-1]
         else
           query
         end
@@ -222,14 +226,21 @@ module BlacklightAdvancedSearch
       keyword_queries.each do |field, query|
         field = primo_to_solr_search(field)
         if field == "title_starts_with"
-          queries << %(_query_:"{!lucene df=title_sort}#{query}")
+          queries << %(_query_:"{!lucene df=title_sort}#{escape_nested_lucene_query(query)}")
         else
           queries << ParsingNesting::Tree.parse(query, config.advanced_search[:query_parser]).to_query(local_param_hash(field, config))
         end
-        queries << ops.shift
+        op = ops.shift
+        queries << op if op.present?
       end
       queries.join(" ")
     end
+
+    private
+
+      def escape_nested_lucene_query(query)
+        query.to_s.gsub("\\", "\\\\\\\\").gsub("\"", "\\\\\"")
+      end
   end
 end
 

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -24,6 +24,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   MAX_QUERY_TOKENS = 20
   MAX_PHRASE_BOOST_TOKENS = 10
   MAX_CLAUSE_SAFE_TOKENS = 12
+  MAX_CITATION_QUERY_TERMS = 12
 
   self.default_processor_chain += %i[
     force_query_parser_for_advanced_search
@@ -119,49 +120,12 @@ class SearchBuilder < Blacklight::SearchBuilder
 
     return if tokens.length <= MAX_CLAUSE_SAFE_TOKENS
 
-    if clause_limit_bug_fix_applicable?(q)
-      solr_params[q_key] = q.strip[1..-2]
-
-      df_key = if solr_params.key?("df")
-        "df"
-               elsif solr_params.key?(:df)
-                 :df
-               else
-                 "df"
-      end
-      solr_params[df_key] = "text"
-
-      qf_key = if solr_params.key?("qf")
-        "qf"
-               elsif solr_params.key?(:qf)
-                 :qf
-               else
-                 "qf"
-      end
-      solr_params[qf_key] = "text"
-
-      q_op_key = if solr_params.key?("q.op")
-        "q.op"
-                 elsif solr_params.key?(:"q.op")
-                   :"q.op"
-                 else
-                   "q.op"
-      end
-      solr_params[q_op_key] = "AND"
-
-      mm_key = if solr_params.key?("mm")
-        "mm"
-               elsif solr_params.key?(:mm)
-                 :mm
-               else
-                 "mm"
-      end
-      solr_params[mm_key] = "100%"
-
+    if citation_like_query?(q)
+      apply_citation_like_query_fallback(solr_params, q_key, q)
       return
     end
 
-    phrase_query = fully_quoted_query?(q) ? q.strip[1..-2] : q
+    phrase_query = strip_outer_quotes(q)
     escaped = phrase_query.gsub("\"", "\\\"")
     solr_params[q_key] = "\"#{escaped}\""
 
@@ -249,7 +213,15 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   def fully_quoted_query?(q)
     stripped = q.strip
-    stripped.start_with?("\"") && stripped.end_with?("\"")
+    return false if stripped.length < 2
+
+    %w[" '].include?(stripped[0]) && stripped[0] == stripped[-1]
+  end
+
+  def strip_outer_quotes(q)
+    return q unless fully_quoted_query?(q)
+
+    q.strip[1..-2]
   end
 
   def clear_phrase_boost_params(solr_params)
@@ -260,6 +232,83 @@ class SearchBuilder < Blacklight::SearchBuilder
       solr_params[string_key] = "" if solr_params.key?(string_key) || !solr_params.key?(symbol_key)
       solr_params[symbol_key] = "" if solr_params.key?(symbol_key)
     end
+  end
+
+  def citation_like_query?(q)
+    return false if is_advanced_search?
+
+    search_field = blacklight_params["search_field"]
+    return false unless search_field.blank? || search_field == "all_fields"
+
+    normalized = strip_outer_quotes(q.to_s)
+    tokens = normalized.scan(/[[:alnum:]-]+/)
+    return false if tokens.length <= MAX_CLAUSE_SAFE_TOKENS
+
+    comma_count = normalized.count(",")
+    semicolon_count = normalized.count(";")
+    initial_count = normalized.scan(/\b[A-Z]\./).length
+    author_segment_count = normalized.scan(/\b[[:alpha:]'-]+,\s*(?:[A-Z]\.\s*){1,}/).length
+    has_year = normalized.match?(/\b(19|20)\d{2}\b/)
+
+    (has_year && (comma_count >= 2 || initial_count >= 3)) ||
+      semicolon_count >= 2 ||
+      author_segment_count >= 3
+  end
+
+  def apply_citation_like_query_fallback(solr_params, q_key, q)
+    terms = citation_like_terms(q)
+    return if terms.empty?
+
+    solr_params[q_key] = terms.join(" ")
+
+    df_key = if solr_params.key?("df")
+      "df"
+             elsif solr_params.key?(:df)
+               :df
+             else
+               "df"
+    end
+    solr_params[df_key] = "text"
+
+    mm_key = if solr_params.key?("mm")
+      "mm"
+             elsif solr_params.key?(:mm)
+               :mm
+             else
+               "mm"
+    end
+    solr_params[mm_key] = "3<75%"
+
+    def_type_key = if solr_params.key?("defType")
+      "defType"
+                   elsif solr_params.key?(:defType)
+                     :defType
+                   else
+                     "defType"
+    end
+    solr_params[def_type_key] = "edismax"
+  end
+
+  def citation_like_terms(q)
+    normalized = strip_outer_quotes(q.to_s)
+      .downcase
+      .gsub(/&/, " ")
+      .gsub(/[^[:alnum:]'\-\s]/, " ")
+      .gsub(/\s+/, " ")
+      .strip
+
+    terms = normalized
+      .split(" ")
+      .reject { |term| term.length == 1 && term.match?(/\A[a-z]\z/) }
+      .reject { |term| term == "'" }
+
+    return terms.first(MAX_CITATION_QUERY_TERMS) unless (year_index = terms.index { |term| term.match?(/\A(19|20)\d{2}\z/) })
+
+    author_terms = terms.first(year_index)
+    title_terms = terms[(year_index + 1)..] || []
+
+    prioritized_terms = author_terms.first(5) + [terms[year_index]] + title_terms.first(6)
+    prioritized_terms.first(MAX_CITATION_QUERY_TERMS)
   end
 
   def clause_limit_bug_fix_applicable?(q)

--- a/spec/helpers/advanced_search_helper_spec.rb
+++ b/spec/helpers/advanced_search_helper_spec.rb
@@ -189,3 +189,68 @@ RSpec.describe AdvancedHelper, type: :helper do
 
   end
 end
+
+RSpec.describe BlacklightAdvancedSearch::QueryParser do
+  subject(:parser) { described_class.allocate }
+
+  describe "#odd_quotes" do
+    it "removes a stray leading quote" do
+      expect(parser.send(:odd_quotes, "\"Japan's national clothing")).to eq("Japan's national clothing")
+    end
+
+    it "removes a stray trailing quote" do
+      expect(parser.send(:odd_quotes, "Japan's national clothing\"")).to eq("Japan's national clothing")
+    end
+
+    it "preserves internal quotes when they are unmatched" do
+      query = %q(Costume The Journal of the Costume Society , "Japan's national clothing during the Second World War)
+
+      expect(parser.send(:odd_quotes, query)).to eq(query)
+    end
+  end
+end
+
+RSpec.describe BlacklightAdvancedSearch::ParsingNestingParser do
+  subject(:parser) do
+    Class.new do
+      include BlacklightAdvancedSearch::ParsingNestingParser
+
+      def keyword_op
+        []
+      end
+
+      def keyword_queries
+        { "title_starts_with" => query_string }
+      end
+
+      def primo_to_solr_search(field)
+        field
+      end
+
+      def query_string
+        @query_string
+      end
+
+      def query_string=(value)
+        @query_string = value
+      end
+    end.new
+  end
+
+  let(:config) do
+    double(
+      "blacklight_config",
+      advanced_search: { query_parser: "lucene" }
+    )
+  end
+
+  describe "#process_query" do
+    it "escapes embedded quotes in nested title_starts_with lucene queries" do
+      parser.query_string = %q(Costume The Journal of the Costume Society , "Japan's national clothing during the Second World War Material shortages, war)
+
+      expect(parser.process_query({}, config)).to eq(
+        '_query_:"{!lucene df=title_sort}Costume The Journal of the Costume Society , \\"Japan\'s national clothing during the Second World War Material shortages, war"'
+      )
+    end
+  end
+end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -86,26 +86,152 @@ RSpec.describe SearchBuilder , type: :model do
           .processed_parameters
       end
 
-      it "keeps the full phrase and falls back to lucene on the text field" do
+      it "rewrites citation-like quoted phrases to a softer edismax query" do
         q = solr_params[:q] || solr_params["q"]
         def_type = solr_params[:defType] || solr_params["defType"]
         df = solr_params[:df] || solr_params["df"]
         qf = solr_params[:qf] || solr_params["qf"]
-        q_op = solr_params[:"q.op"] || solr_params["q.op"]
         mm = solr_params[:mm] || solr_params["mm"]
         pf = solr_params[:pf] || solr_params["pf"]
         pf2 = solr_params[:pf2] || solr_params["pf2"]
         pf3 = solr_params[:pf3] || solr_params["pf3"]
 
-        expect(q).to eq("Wiese, D., Escobar, J. R., Hsu, Y., Kulathinal, R. J., & Hayes-Conroy, A. 2018 . The fluidity of biosocial identity.")
-        expect(def_type).not_to eq("lucene")
+        expect(q).to eq("wiese escobar hsu kulathinal hayes-conroy 2018 the fluidity of biosocial identity")
+        expect(def_type).to eq("edismax")
         expect(df).to eq("text")
         expect(qf).to eq("text")
-        expect(q_op).to eq("AND")
-        expect(mm).to eq("100%")
+        expect(mm).to eq("3<75%")
         expect(pf).to eq("")
         expect(pf2).to eq("")
         expect(pf3).to eq("")
+      end
+    end
+
+    context "with a long single-quoted phrase query" do
+      let(:quoted_query) do
+        "'Kubek, J. B., Tindall-Biggins, C., Reed, K., Carr, L. E., & Fenning, P. A. 2020 .'"
+      end
+      let(:params) { { q: quoted_query, search_field: "all_fields" } }
+
+      subject(:solr_params) do
+        described_class
+          .new(context)
+          .with(params)
+          .processed_parameters
+      end
+
+      it "treats matching single quotes as citation-like input and softens the fallback" do
+        q = solr_params[:q] || solr_params["q"]
+        def_type = solr_params[:defType] || solr_params["defType"]
+        df = solr_params[:df] || solr_params["df"]
+        qf = solr_params[:qf] || solr_params["qf"]
+        mm = solr_params[:mm] || solr_params["mm"]
+        pf = solr_params[:pf] || solr_params["pf"]
+        pf2 = solr_params[:pf2] || solr_params["pf2"]
+        pf3 = solr_params[:pf3] || solr_params["pf3"]
+
+        expect(q).to eq("kubek tindall-biggins reed carr fenning 2020")
+        expect(def_type).to eq("edismax")
+        expect(df).to eq("text")
+        expect(qf).to eq("text")
+        expect(mm).to eq("3<75%")
+        expect(pf).to eq("")
+        expect(pf2).to eq("")
+        expect(pf3).to eq("")
+      end
+    end
+
+    context "with a long unquoted citation-style query" do
+      let(:quoted_query) do
+        "Kubek, J. B., Tindall-Biggins, C., Reed, K., Carr, L. E., & Fenning, P. A. 2020 ."
+      end
+      let(:params) { { q: quoted_query, search_field: "all_fields" } }
+
+      subject(:solr_params) do
+        described_class
+          .new(context)
+          .with(params)
+          .processed_parameters
+      end
+
+      it "treats unquoted citation-like input the same way" do
+        q = solr_params[:q] || solr_params["q"]
+        def_type = solr_params[:defType] || solr_params["defType"]
+        df = solr_params[:df] || solr_params["df"]
+        qf = solr_params[:qf] || solr_params["qf"]
+        mm = solr_params[:mm] || solr_params["mm"]
+        pf = solr_params[:pf] || solr_params["pf"]
+        pf2 = solr_params[:pf2] || solr_params["pf2"]
+        pf3 = solr_params[:pf3] || solr_params["pf3"]
+
+        expect(q).to eq("kubek tindall-biggins reed carr fenning 2020")
+        expect(def_type).to eq("edismax")
+        expect(df).to eq("text")
+        expect(qf).to eq("text")
+        expect(mm).to eq("3<75%")
+        expect(pf).to eq("")
+        expect(pf2).to eq("")
+        expect(pf3).to eq("")
+      end
+    end
+
+    context "with a long semicolon-delimited citation-style query without a year" do
+      let(:quoted_query) do
+        %("Koenders, M.A.; Mesman, E.; Giltay, E.J.; Elzinga, B.M.; Hillegers, M.H.J. Traumatic experiences, family functioning, and mood disorder development in bipolar")
+      end
+      let(:params) { { q: quoted_query, search_field: "all_fields" } }
+
+      subject(:solr_params) do
+        described_class
+          .new(context)
+          .with(params)
+          .processed_parameters
+      end
+
+      it "treats semicolon-delimited author lists as citation-like input even without a year" do
+        q = solr_params[:q] || solr_params["q"]
+        def_type = solr_params[:defType] || solr_params["defType"]
+        df = solr_params[:df] || solr_params["df"]
+        qf = solr_params[:qf] || solr_params["qf"]
+        mm = solr_params[:mm] || solr_params["mm"]
+        pf = solr_params[:pf] || solr_params["pf"]
+        pf2 = solr_params[:pf2] || solr_params["pf2"]
+        pf3 = solr_params[:pf3] || solr_params["pf3"]
+
+        expect(q).to eq("koenders mesman giltay elzinga hillegers traumatic experiences family functioning and mood disorder")
+        expect(def_type).to eq("edismax")
+        expect(df).to eq("text")
+        expect(qf).to eq("text")
+        expect(mm).to eq("3<75%")
+        expect(pf).to eq("")
+        expect(pf2).to eq("")
+        expect(pf3).to eq("")
+      end
+    end
+
+    context "with a long non-citation quoted query" do
+      let(:quoted_query) do
+        '"alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu"'
+      end
+      let(:params) { { q: quoted_query, search_field: "all_fields" } }
+
+      subject(:solr_params) do
+        described_class
+          .new(context)
+          .with(params)
+          .processed_parameters
+      end
+
+      it "keeps the strict lucene phrase fallback for non-citation input" do
+        q = solr_params[:q] || solr_params["q"]
+        def_type = solr_params[:defType] || solr_params["defType"]
+        df = solr_params[:df] || solr_params["df"]
+        qf = solr_params[:qf] || solr_params["qf"]
+
+        expect(q).to eq('"alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu"')
+        expect(def_type).to eq("lucene")
+        expect(df).to eq("text")
+        expect(qf).to eq("text")
       end
     end
 
@@ -371,7 +497,7 @@ RSpec.describe SearchBuilder , type: :model do
         )
         .processed_parameters
 
-      expect(solr_params["q"]).to eq(%(_query_:"{!lucene df=title_sort}states*" ))
+      expect(solr_params["q"]).to eq(%(_query_:"{!lucene df=title_sort}states*"))
     end
 
     it "uses a lucene title_sort prefix query for same-field OR rows" do
@@ -388,7 +514,7 @@ RSpec.describe SearchBuilder , type: :model do
         )
         .processed_parameters
 
-      expect(solr_params["q"]).to eq(%(_query_:"{!lucene df=title_sort}(states*) OR (introduction*)" ))
+      expect(solr_params["q"]).to eq(%(_query_:"{!lucene df=title_sort}(states*) OR (introduction*)"))
     end
   end
 


### PR DESCRIPTION
This PR fixes Solr failures from long citation-style searches.
It adds a safer fallback for long citation-like all_fields queries and fixes advanced title begins_with query escaping. Specs were updated for quoted, unquoted, and semicolon-delimited citation inputs, plus the advanced-query escaping path.