### PR TITLE
BL-2015 Make QuikPay sessionless callback permanent

### DIFF
--- a/app/controllers/concerns/quik_pay.rb
+++ b/app/controllers/concerns/quik_pay.rb
@@ -106,24 +106,17 @@ module QuikPay
     end
 
     def authenticate_quik_pay_user!
-      if params[:action] == "quik_pay_callback" && Flipflop.quik_pay_sessionless_callback?
-        return
-      end
+      return if params[:action] == "quik_pay_callback"
 
       authenticate_user!
     end
 
     def quik_pay_user_id
-      return current_user&.uid || params["orderNumber"] if Flipflop.quik_pay_sessionless_callback?
-
-      current_user.uid
+      current_user&.uid || params["orderNumber"]
     end
 
     def quik_pay_redirect_url_parameters
-      base_params = "transactionStatus,transactionTotalAmount"
-      return base_params unless Flipflop.quik_pay_sessionless_callback?
-
-      "#{base_params},orderNumber"
+      "transactionStatus,transactionTotalAmount,orderNumber"
     end
 
     def validate_quik_pay_timestamp(timestamp)

--- a/config/features.rb
+++ b/config/features.rb
@@ -15,12 +15,7 @@ Flipflop.configure do
     feature :citeproc_citations
   end
 
-  group :quik_pay do
-    feature :quik_pay_sessionless_callback
-  end
-
   group :experimental do
     feature :bot_challenge, default: false
   end
-
 end

--- a/spec/controllers/quik_pay_spec.rb
+++ b/spec/controllers/quik_pay_spec.rb
@@ -46,58 +46,31 @@ RSpec.describe UsersController, type: "controller"  do
       end
     end
 
-    context "when quik pay sessionless callback is disabled" do
-      before { allow(Flipflop).to receive(:quik_pay_sessionless_callback?).and_return(false) }
-      let(:redirect_params) { "transactionStatus%2CtransactionTotalAmount" }
+    let(:redirect_params) { "transactionStatus%2CtransactionTotalAmount%2CorderNumber" }
 
-      include_examples "quik pay redirect parameters"
-    end
-
-    context "when quik pay sessionless callback is enabled" do
-      before { allow(Flipflop).to receive(:quik_pay_sessionless_callback?).and_return(true) }
-      let(:redirect_params) { "transactionStatus%2CtransactionTotalAmount%2CorderNumber" }
-
-      include_examples "quik pay redirect parameters"
-    end
+    include_examples "quik pay redirect parameters"
   end
 
-  describe "GET #quik_pay_callback" do
-    context "when quik pay sessionless callback is disabled" do
-      before { allow(Flipflop).to receive(:quik_pay_sessionless_callback?).and_return(false) }
-
-      context "user is not logged in" do
-        it "redirects you to login page" do
-          get :quik_pay_callback
-          expect(response).to redirect_to new_user_session_path
-
-          post :quik_pay_callback
-          expect(response).to redirect_to new_user_session_path
-        end
+  describe "#quik_pay_callback" do
+    context "user is not logged in but parameters are valid" do
+      let (:params) { with_validation_params(transactionStatus: "1") }
+      before(:each) do
+        resp = OpenStruct.new(total_sum: 0.0)
+        balance = Alma::PaymentResponse.new(resp)
+        allow(Alma::User).to receive(:send_payment) { balance }
       end
-    end
 
-    context "when quik pay sessionless callback is enabled" do
-      before { allow(Flipflop).to receive(:quik_pay_sessionless_callback?).and_return(true) }
+      it "redirects GET requests to the users account page with success notice" do
+        get(:quik_pay_callback, params:)
+        expect(Alma::User).to have_received(:send_payment).with(user_id: params[:orderNumber])
+        expect(response).to redirect_to users_account_path
+        expect(flash[:notice]).to include("Your fees have been paid.");
+      end
 
-      context "user is not logged in but parameters are valid" do
-        let (:params) { with_validation_params(transactionStatus: "1") }
-        before(:each) do
-          resp = OpenStruct.new(total_sum: 0.0)
-          balance = Alma::PaymentResponse.new(resp)
-          allow(Alma::User).to receive(:send_payment) { balance }
-        end
-
-        it "redirects GET requests to the users account page with success notice" do
-          get(:quik_pay_callback, params:)
-          expect(response).to redirect_to users_account_path
-          expect(flash[:notice]).to include("Your fees have been paid.");
-        end
-
-        it "redirects POST requests to the users account page with success notice" do
-          post(:quik_pay_callback, params:)
-          expect(response).to redirect_to users_account_path
-          expect(flash[:notice]).to include("Your fees have been paid.");
-        end
+      it "redirects POST requests to the users account page with success notice" do
+        post(:quik_pay_callback, params:)
+        expect(response).to redirect_to users_account_path
+        expect(flash[:notice]).to include("Your fees have been paid.");
       end
     end
 
@@ -226,22 +199,9 @@ RSpec.describe UsersController, type: "controller"  do
           session["can_pay_online?"] = true;
         end
 
-        context "when quik pay sessionless callback is disabled" do
-          before { allow(Flipflop).to receive(:quik_pay_sessionless_callback?).and_return(false) }
-
-          it "redirects to users account paths" do
-            get :quik_pay
-            expect(response.location).to match(/quikpay.*?orderNumber=.*&orderType=Temple%20Library&amountDue=.*&redirectUrl=.*&redirectUrlParameters=transactionStatus%2CtransactionTotalAmount&timestamp=.*&hash=.*$/)
-          end
-        end
-
-        context "when quik pay sessionless callback is enabled" do
-          before { allow(Flipflop).to receive(:quik_pay_sessionless_callback?).and_return(true) }
-
-          it "redirects to users account paths" do
-            get :quik_pay
-            expect(response.location).to match(/quikpay.*?orderNumber=.*&orderType=Temple%20Library&amountDue=.*&redirectUrl=.*&redirectUrlParameters=transactionStatus%2CtransactionTotalAmount%2CorderNumber&timestamp=.*&hash=.*$/)
-          end
+        it "redirects to users account paths" do
+          get :quik_pay
+          expect(response.location).to match(/quikpay.*?orderNumber=.*&orderType=Temple%20Library&amountDue=.*&redirectUrl=.*&redirectUrlParameters=transactionStatus%2CtransactionTotalAmount%2CorderNumber&timestamp=.*&hash=.*$/)
         end
       end
 
@@ -251,22 +211,9 @@ RSpec.describe UsersController, type: "controller"  do
           session["total_fines"] = "25.11"
         end
 
-        context "when quik pay sessionless callback is disabled" do
-          before { allow(Flipflop).to receive(:quik_pay_sessionless_callback?).and_return(false) }
-
-          it "does not lose precision when converting total_fines to cents" do
-            get :quik_pay
-            expect(response.location).to match(/#{Rails.configuration.apis.dig(:quik_pay, :url)}.*orderNumber=.*&orderType=Temple%20Library&amountDue=2511.*&redirectUrl=.*&redirectUrlParameters=transactionStatus%2CtransactionTotalAmount&timestamp=.*&hash=.*$/)
-          end
-        end
-
-        context "when quik pay sessionless callback is enabled" do
-          before { allow(Flipflop).to receive(:quik_pay_sessionless_callback?).and_return(true) }
-
-          it "does not lose precision when converting total_fines to cents" do
-            get :quik_pay
-            expect(response.location).to match(/#{Rails.configuration.apis.dig(:quik_pay, :url)}.*orderNumber=.*&orderType=Temple%20Library&amountDue=2511.*&redirectUrl=.*&redirectUrlParameters=transactionStatus%2CtransactionTotalAmount%2CorderNumber&timestamp=.*&hash=.*$/)
-          end
+        it "does not lose precision when converting total_fines to cents" do
+          get :quik_pay
+          expect(response.location).to match(/#{Rails.configuration.apis.dig(:quik_pay, :url)}.*orderNumber=.*&orderType=Temple%20Library&amountDue=2511.*&redirectUrl=.*&redirectUrlParameters=transactionStatus%2CtransactionTotalAmount%2CorderNumber&timestamp=.*&hash=.*$/)
         end
       end
 


### PR DESCRIPTION
This is the QuikPay portion of BL-2015, which makes the sessionless callback permanent