### PR TITLE
BL-2015 remove bento style updates flipflop

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -28,7 +28,7 @@ class SearchController < CatalogController
     respond_to do |format|
       format.html do
         store_preferred_view
-        template = Flipflop.style_updates? ? "search/index_new" : "search/index"
+        template = "search/index_new"
         render template
       end
       format.json do
@@ -42,7 +42,7 @@ class SearchController < CatalogController
   private
 
     def configure_bento_item_partials
-      item_partial = Flipflop.style_updates? ? "bento_search/std_item_new" : "bento_search/std_item"
+      item_partial = "bento_search/std_item_new"
       bento_engines = %w[blacklight journals databases library_website books_and_media articles cdm lib_guides]
 
       bento_engines.each do |engine_id|
@@ -60,7 +60,7 @@ class SearchController < CatalogController
     def apply_bento_item_partials(results)
       return results unless results.is_a?(Hash)
 
-      item_partial = Flipflop.style_updates? ? "bento_search/std_item_new" : "bento_search/std_item"
+      item_partial = "bento_search/std_item_new"
 
       results.each_value do |result|
         next unless result.respond_to?(:display_configuration)

--- a/app/helpers/bento_changes_helper.rb
+++ b/app/helpers/bento_changes_helper.rb
@@ -4,8 +4,4 @@ module BentoChangesHelper
   def aspace_integration_enabled?
     Flipflop.aspace_integration?
   end
-
-  def style_updates_enabled?
-    Flipflop.style_updates?
-  end
 end

--- a/app/search_engines/bento_search/archival_collections_engine.rb
+++ b/app/search_engines/bento_search/archival_collections_engine.rb
@@ -98,7 +98,7 @@ module BentoSearch
 
     def view_link(total = nil, helper)
       full_url = url(helper)
-      link_text = Flipflop.style_updates? ? "See all results" : "View all results"
+      link_text = "See all results"
       helper.link_to link_text, full_url, class: "bento-full-results bento_archival_collections_header", target: "_blank"
     end
 

--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -63,7 +63,7 @@ module BentoSearch
 
     def view_link(total = nil, helper)
       url = url(helper)
-      link_text = Flipflop.style_updates? ? "See all catalog results" : "View all catalog results"
+      link_text = "See all catalog results"
       helper.link_to link_text, url, class: "bento-full-results"
     end
   end

--- a/app/search_engines/bento_search/books_and_media_engine.rb
+++ b/app/search_engines/bento_search/books_and_media_engine.rb
@@ -27,7 +27,7 @@ module BentoSearch
 
     def view_link(total = nil, helper)
       url = url(helper)
-      link_text = Flipflop.style_updates? ? "See all #{total} results" : "View all #{total} results"
+      link_text = "See all #{total} results"
       helper.link_to link_text, url, class: "bento-full-results bento_books_and_media_header"
     end
   end

--- a/app/search_engines/bento_search/databases_engine.rb
+++ b/app/search_engines/bento_search/databases_engine.rb
@@ -15,7 +15,7 @@ module BentoSearch
 
     def view_link(total = nil, helper)
       url = url(helper)
-      link_text = Flipflop.style_updates? ? "See all #{total} results" : "View all #{total} results"
+      link_text = "See all #{total} results"
       helper.link_to link_text, url, class: "bento-full-results bento_databases_header"
     end
   end

--- a/app/search_engines/bento_search/journals_engine.rb
+++ b/app/search_engines/bento_search/journals_engine.rb
@@ -15,7 +15,7 @@ module BentoSearch
 
     def view_link(total = nil, helper)
       url = url(helper)
-      link_text = Flipflop.style_updates? ? "See all #{total} results" : "View all #{total} results"
+      link_text = "See all #{total} results"
       helper.link_to link_text, url, class: "bento-full-results bento_journals_header"
     end
   end

--- a/app/search_engines/bento_search/lib_guides_engine.rb
+++ b/app/search_engines/bento_search/lib_guides_engine.rb
@@ -45,7 +45,7 @@ module BentoSearch
 
     def view_link(total = nil, helper)
       url = url(helper)
-      link_text = Flipflop.style_updates? ? "See all results" : "View all results"
+      link_text = "See all results"
       helper.link_to link_text, url, class: "bento-full-results bento_lib_guides_header"
     end
   end

--- a/app/search_engines/bento_search/primo_engine.rb
+++ b/app/search_engines/bento_search/primo_engine.rb
@@ -37,7 +37,7 @@ module BentoSearch
 
     def view_link(total = nil, helper)
       url = url(helper)
-      link_text = Flipflop.style_updates? ? "See all #{total} results" : "View all #{total} results"
+      link_text = "See all #{total} results"
       helper.link_to link_text, url, class: "bento-full-results bento_articles_header"
     end
   end

--- a/app/search_engines/bento_search/web_content_engine.rb
+++ b/app/search_engines/bento_search/web_content_engine.rb
@@ -30,7 +30,7 @@ module BentoSearch
 
     def view_link(total = nil, helper)
       url = url(helper)
-      link_text = Flipflop.style_updates? ? "See all results" : "View all results"
+      link_text = "See all results"
       helper.link_to link_text, url, class: "bento-full-results bento_library_website_header"
     end
   end

--- a/config/features.rb
+++ b/config/features.rb
@@ -8,7 +8,6 @@ Flipflop.configure do
 
   group :bento_changes do
     feature :aspace_integration
-    feature :style_updates
   end
 
   group :citations do

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -56,21 +56,10 @@ RSpec.describe SearchController, type: :controller do
       allow(BentoSearch).to receive(:get_engine).and_return(engine_double)
     end
 
-    it "points to the new std_item template when style updates are enabled" do
-      allow(Flipflop).to receive(:style_updates?).and_return(true)
-
+    it "points to the new std_item template" do
       controller.send(:configure_bento_item_partials)
 
       expect(display_config[:item_partial]).to eq("bento_search/std_item_new")
-    end
-
-    it "points to the original std_item template when style updates are disabled" do
-      allow(Flipflop).to receive(:style_updates?).and_return(false)
-      display_config[:item_partial] = "custom_partial"
-
-      controller.send(:configure_bento_item_partials)
-
-      expect(display_config[:item_partial]).to eq("bento_search/std_item")
     end
   end
 end

--- a/spec/features/bento_availability_spec.rb
+++ b/spec/features/bento_availability_spec.rb
@@ -29,9 +29,6 @@ RSpec.feature "Bento Availability" do
         link_tag = find("a.bento-avail-btn")
         expect(link_tag[:href]).to match(electronic_resource_url)
       end
-      within first("div.bento-search-engine") do
-        expect(page).to have_css(".bento-full-results") unless Flipflop.style_updates?
-      end
 
     end
 

--- a/spec/features/bento_search_spec.rb
+++ b/spec/features/bento_search_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Bento Searches" do
         }
       end
       within first("div.bento-search-engine") do
-        expect(page).to have_css("a.bento-full-results") unless Flipflop.style_updates?
+        expect(page).to_not have_css("a.bento-full-results")
 
         within first("dl.document-metadata") do
           expect(page).not_to have_css("dt.index-label")
@@ -42,9 +42,7 @@ RSpec.feature "Bento Searches" do
       end
     end
 
-    scenario "Blacklight totals link appears in the header when style updates are enabled" do
-      allow(Flipflop).to receive(:style_updates?).and_return(true)
-
+    scenario "Blacklight totals link appears in the header" do
       visit "/bento"
       within("div.input-group") do
         fill_in "q", with: item["title"]


### PR DESCRIPTION
This is the Bento Style Update portion of BL-2015, which makes the Bento styles permanent