### PR TITLE
BL More normalization updates

### DIFF
--- a/app/models/citeproc_citation.rb
+++ b/app/models/citeproc_citation.rb
@@ -51,7 +51,10 @@ class CiteprocCitation
 
     def render_style(style_id, label)
       processor = CiteProc::Processor.new(style: load_style(style_id), format: "html")
-      processor.import([csl_item])
+      item = csl_item_for(style_id)
+      return "" if item.blank?
+
+      processor.import([item])
       bibliography = processor.bibliography
       result = Array(bibliography&.references).first.to_s
       return "" if result.blank?
@@ -70,6 +73,13 @@ class CiteprocCitation
 
     def csl_item
       @csl_item ||= Citeproc::ItemService.build(document)
+    end
+
+    def csl_item_for(style_id)
+      return csl_item unless style_id == "apa"
+
+      @style_items ||= {}
+      @style_items[style_id] ||= Citeproc::ItemService.build(document, style_id: style_id)
     end
 
     def null_citation

--- a/app/services/citeproc/item_service.rb
+++ b/app/services/citeproc/item_service.rb
@@ -5,6 +5,7 @@ module Citeproc
     ROLE_MAPPINGS = {
       "author" => "author",
       "aut" => "author",
+      "issuing body" => "author",
       "editor" => "editor",
       "edt" => "editor",
       "translator" => "translator",
@@ -13,15 +14,16 @@ module Citeproc
       "ill" => "illustrator"
     }.freeze
 
-    def self.build(document)
-      new(document).item
+    def self.build(document, style_id: nil)
+      new(document, style_id: style_id).item
     end
 
-    def initialize(document)
+    def initialize(document, style_id: nil)
       @document = document
+      @style_id = style_id
     end
 
-    attr_reader :document
+    attr_reader :document, :style_id
 
     def item
       return if normalized_title.blank?
@@ -132,15 +134,9 @@ module Citeproc
 
       def extract_contributor_names(target_role)
         Array(document["contributor_display"]).filter_map do |value|
-          role = extract_role(value, default_role: default_role_for_contributor_entries)
+          role = extract_role(value)
           extract_name(value) if role == target_role
         end.uniq
-      end
-
-      def default_role_for_contributor_entries
-        return unless Array(document["creator_display"]).blank?
-
-        "author"
       end
 
       def extract_name(value)
@@ -155,14 +151,24 @@ module Citeproc
 
         if personal_name?(normalized_value)
           family, given = normalized_value.split(",", 2).map(&:strip)
-          { family: strip_trailing_name_dates(family), given: strip_trailing_name_dates(given).presence }
+          build_personal_name(family, given)
         else
           { literal: normalized_value }
         end
       end
 
       def personal_name?(value)
-        value.count(",") == 1
+        comma_count_outside_parentheses(value) == 1
+      end
+
+      def comma_count_outside_parentheses(value)
+        depth = 0
+
+        value.to_s.each_char.count do |char|
+          depth += 1 if char == "("
+          depth -= 1 if char == ")" && depth.positive?
+          char == "," && depth.zero?
+        end
       end
 
       def extract_role(value, default_role: nil)
@@ -174,9 +180,53 @@ module Citeproc
         default_role
       end
 
+      def build_personal_name(family, given)
+        normalized_family = normalize_personal_name_part(family)
+        normalized_given = normalize_personal_name_part(given)
+
+        if apa_style? && parenthetical_qualifier(normalized_given).present?
+          { literal: apa_literal_name(normalized_family, normalized_given) }
+        else
+          { family: normalized_family, given: normalized_given.presence }
+        end
+      end
+
+      def normalize_personal_name_part(value)
+        normalized = strip_trailing_name_dates(value)
+        strip_trailing_punct(normalized).strip
+      end
+
+      def apa_literal_name(family, given)
+        primary_given = given.to_s.sub(/\s*\([^)]*\)\s*\z/, "").strip
+        qualifier = apa_parenthetical_qualifier(given)
+        "#{family}, #{initials(primary_given)} #{qualifier}".strip
+      end
+
+      def apa_parenthetical_qualifier(given)
+        qualifier = parenthetical_qualifier(given)
+        return "" if qualifier.blank?
+
+        inner = qualifier.delete_prefix("(").delete_suffix(")")
+        "(#{initials(inner)})"
+      end
+
+      def parenthetical_qualifier(value)
+        value.to_s[/\([^)]*\)\s*\z/].to_s.strip
+      end
+
+      def initials(value)
+        value.to_s.scan(/[[:alpha:]]+/).map { |part| "#{part[0].upcase}." }.join(" ")
+      end
+
+      def apa_style?
+        style_id == "apa"
+      end
+
       def relator_segments(value)
         parsed = parsed_indexed_value(value)
-        Array(parsed[:relators])
+        Array(parsed[:relators]).flat_map do |segment|
+          segment.to_s.split(/\s*,\s*/)
+        end
       end
 
       def normalize_relator(value)

--- a/spec/models/citeproc_citation_spec.rb
+++ b/spec/models/citeproc_citation_spec.rb
@@ -1,35 +1,19 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "citeproc"
 
-RSpec.describe CiteprocCitation, type: :model do
-  let(:document) do
-    SolrDocument.new(
-      "id" => "991012041239703811",
-      "title_statement_display" => ["Test Title"],
-      "creator_display" => ["Doe, Jane"],
-      "pub_date_display" => ["2020"],
+RSpec.describe CiteprocCitation do
+  it "renders parenthetical fuller forms correctly across styles" do
+    document = SolrDocument.new(
+      "id" => "991006438039703811",
+      "title_statement_display" => ["Example / Foo."],
+      "creator_display" => ["Slayton, William L. (William Larew), 1916-|author"],
       "format" => ["Book"]
     )
-  end
-
-  it "returns citations for the configured styles" do
-    allow_any_instance_of(described_class).to receive(:render_style) do |_instance, _style_id, label|
-      "<p class=\"citation_style_#{label}\">Citation</p>".html_safe
-    end
 
     citations = described_class.new(document).citations
 
-    expect(citations.keys).to contain_exactly(
-      "APA",
-      "CHICAGO-AUTHOR-DATE",
-      "CHICAGO-NOTES-BIBLIOGRAPHY",
-      "MLA"
-    )
-
-    citations.each do |format, citation|
-      expect(citation).to include("citation_style_#{format}")
-    end
+    expect(citations["APA"]).to include("Slayton, W. L. (W. L.).")
+    expect(citations["CHICAGO-AUTHOR-DATE"]).to include("Slayton, William L. (William Larew).")
   end
 end

--- a/spec/services/citeproc/item_service_spec.rb
+++ b/spec/services/citeproc/item_service_spec.rb
@@ -69,13 +69,40 @@ RSpec.describe Citeproc::ItemService do
     expect(citeproc_names(item.author)).to eq([{ "family" => "Example", "given" => "Avery" }])
   end
 
-  it "uses contributor_display as author when there is no creator_display" do
+  it "does not use contributor_display as author when there is no supported relator" do
     document["creator_display"] = []
     document["contributor_display"] = [
       "Norris, Denne Michele,"
     ]
 
+    expect(item.author).to be_nil
+  end
+
+  it "uses contributor_display as author when there is an author relator and no creator_display" do
+    document["creator_display"] = []
+    document["contributor_display"] = [
+      "Norris, Denne Michele,|author."
+    ]
+
     expect(citeproc_names(item.author)).to eq([{ "family" => "Norris", "given" => "Denne Michele" }])
+  end
+
+  it "maps issuing body contributors to author" do
+    document["creator_display"] = []
+    document["contributor_display"] = [
+      "World Health Organization.|issuing body."
+    ]
+
+    expect(citeproc_names(item.author)).to eq([{ "literal" => "World Health Organization" }])
+  end
+
+  it "maps issuing body to author when relators are combined in one segment" do
+    document["creator_display"] = []
+    document["contributor_display"] = [
+      "World Health Organization.|issuing body, publisher"
+    ]
+
+    expect(citeproc_names(item.author)).to eq([{ "literal" => "World Health Organization" }])
   end
 
   it "returns nil when indexed title data is missing" do
@@ -128,6 +155,13 @@ RSpec.describe Citeproc::ItemService do
     expect(citeproc_names(item.author)).to eq([{ "family" => "Example", "given" => "Avery" }])
   end
 
+  it "preserves parenthetical qualifiers in personal given names" do
+    document["creator_display"] = ["Slayton, William L. (William Larew), 1916-"]
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "family" => "Slayton", "given" => "William L. (William Larew)" }])
+  end
+
   it "strips trailing meeting metadata from literal names" do
     document["creator_display"] = ["International Society on Oxygen Transport to Tissue. Annual Meeting (36th : 2008 : Sapporo-shi, Japan)"]
     document["contributor_display"] = []
@@ -161,6 +195,13 @@ RSpec.describe Citeproc::ItemService do
     document["contributor_display"] = []
 
     expect(citeproc_names(item.author)).to eq([{ "literal" => "International Society on Oxygen Transport to Tissue. Annual Meeting, Sapporo-shi, Japan" }])
+  end
+
+  it "treats parenthetical qualifiers with internal commas as literal names" do
+    document["creator_display"] = ["Example Society (Philadelphia, Pa.)"]
+    document["contributor_display"] = []
+
+    expect(citeproc_names(item.author)).to eq([{ "literal" => "Example Society (Philadelphia, Pa.)" }])
   end
 
   it "ignores contributor_display entries without supported relators when creator_display is present" do


### PR DESCRIPTION
Refactored citeproc item building into a dedicated normalization service while preserving legacy citation metadata, and updated contributor handling to rely on supported relator mappings. The change also improves name normalization for citations, including meeting/corporate names, parenthetical personal-name qualifiers, and combined relator strings such as issuing body, publisher, with APA-specific handling for abbreviated parenthetical names.