### PR TITLE
BL-2049 Remove obsolete digital_help_allowed? predicate

### DIFF
--- a/app/helpers/almaws_helper.rb
+++ b/app/helpers/almaws_helper.rb
@@ -63,7 +63,6 @@ module AlmawsHelper
       request_options.booking_allowed?,
       request_options.resource_sharing_broker_allowed? && books.present?,
       aeon_request_allowed(document),
-      document.digital_help_allowed?,
       document.open_shelves_allowed?,
       equipment.present?]
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -158,18 +158,6 @@ class SolrDocument
     @libkey_journals_url_thread.value&.fetch("browzineEnabled", nil) == true
   end
 
-  # Business logic methods moved from CatalogHelper
-  def digital_help_allowed?
-    fetch("availability_facet", [])
-      .include?("At the Library") &&
-    fetch("format", [])
-      .exclude?("Archival Material") &&
-    fetch("format", [])
-      .exclude?("Object") &&
-    !self["electronic_resource_display"] &&
-    !hathitrust_link_allowed?
-  end
-
   def open_shelves_allowed?
     {
       "MAIN"     => ["hirsh", "juvenile", "leisure", "stacks", "newbooks"],

--- a/spec/helpers/almaws_helper_spec.rb
+++ b/spec/helpers/almaws_helper_spec.rb
@@ -456,6 +456,33 @@ RSpec.describe AlmawsHelper, type: :helper do
       end
     end
 
+    context "only a booking is allowed" do
+      let(:books) {}
+      let(:equipment) {}
+      let(:document) { SolrDocument.new("items_json_display" =>
+        [{ "item_pid" => "23237957740003811",
+        "item_policy" => "5",
+        "permanent_library" => "AMBLER",
+        "permanent_location" => "media",
+        "current_library" => "AMBLER",
+        "current_location" => "media",
+        "call_number" => "DVD 13 A165",
+        "holding_id" => "22237957750003811" }]
+          ) }
+      let(:json) {
+        { request_option:
+          [{
+          "type" => { "value" => "BOOKING", "desc" => "Booking" },
+          "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+          }]
+        }.to_json
+      }
+
+      it "is true" do
+        expect(helper.only_one_option_allowed(request_options, books, document, equipment)).to be true
+      end
+    end
+
     context "only digitization is allowed" do
       let(:books) {}
       let(:equipment) {}

--- a/spec/helpers/almaws_helper_spec.rb
+++ b/spec/helpers/almaws_helper_spec.rb
@@ -456,30 +456,50 @@ RSpec.describe AlmawsHelper, type: :helper do
       end
     end
 
-    context "only a booking is allowed" do
+    context "only digitization is allowed" do
       let(:books) {}
       let(:equipment) {}
-      let(:document) { SolrDocument.new("items_json_display" =>
-        [{ "item_pid" => "23237957740003811",
-        "item_policy" => "5",
-        "permanent_library" => "AMBLER",
-        "permanent_location" => "media",
-        "current_library" => "AMBLER",
-        "current_location" => "media",
-        "call_number" => "DVD 13 A165",
-        "holding_id" => "22237957750003811" }]
-          ) }
-      let(:json) {
-        { request_option:
-          [{
-          "type" => { "value" => "BOOKING", "desc" => "Booking" },
-          "request_url" => "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
-          }]
+      let(:document) do
+        SolrDocument.new(
+          "items_json_display" => [
+            {
+              "item_pid" => "23237957740003811",
+              "item_policy" => "5",
+              "permanent_library" => "AMBLER",
+              "permanent_location" => "media",
+              "current_library" => "AMBLER",
+              "current_location" => "media",
+              "call_number" => "DVD 13 A165",
+              "holding_id" => "22237957750003811"
+            }
+          ]
+        )
+      end
+
+      let(:json) do
+        {
+          request_option: [
+            {
+              "type" => {
+                "value" => "DIGITIZATION",
+                "desc" => "Digitization"
+              },
+              "request_url" =>
+                "https://api-na.hosted.exlibrisgroup.com/almaws/v1/requests/"
+            }
+          ]
         }.to_json
-      }
+      end
 
       it "is true" do
-        expect(helper.only_one_option_allowed(request_options, books, document, equipment)).to be true
+        expect(
+          helper.only_one_option_allowed(
+            request_options,
+            books,
+            document,
+            equipment
+          )
+        ).to be true
       end
     end
 
@@ -536,7 +556,6 @@ RSpec.describe AlmawsHelper, type: :helper do
         expect(helper.only_one_option_allowed(request_options, books, document, equipment)).to be false
       end
     end
-
 
     context "both a hold and a booking are allowed" do
       let(:books) {}

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -648,57 +648,6 @@ RSpec.describe SolrDocument, type: :model do
     end
   end
 
-  # Business logic methods tests moved from CatalogHelper
-  describe "#digital_help_allowed?" do
-    context "is not a physical item" do
-      let(:document) { SolrDocument.new("availability_facet" => "Online") }
-      it "returns false" do
-        expect(document.digital_help_allowed?).to be false
-      end
-    end
-
-    context "is a physical item" do
-      let(:document) { SolrDocument.new("availability_facet" => "At the Library") }
-      it "returns true" do
-        expect(document.digital_help_allowed?).to be true
-      end
-    end
-
-    context "is a physical item with hathitrust access denied" do
-      let(:document) { SolrDocument.new(
-        "availability_facet" => "At the Library",
-        "hathi_trust_bib_key_display" => "foo"
-      ) }
-      it "returns true" do
-        expect(document.digital_help_allowed?).to be true
-      end
-    end
-
-    context "is an object" do
-      let(:document) { SolrDocument.new("format" => "Object") }
-      it "returns false" do
-        expect(document.digital_help_allowed?).to be false
-      end
-    end
-
-    context "has a hathitrust link" do
-      let(:document) { SolrDocument.new("hathi_trust_bib_key_display" => [{ "bib_key" => "000005117", "access" => "allow" }].first) }
-      it "returns false" do
-        expect(document.digital_help_allowed?).to be false
-      end
-    end
-
-    context "is a physical item and an online item" do
-      let(:document) { SolrDocument.new(
-        "availability_facet" => "At the Library",
-        "electronic_resource_display" => "foo"
-      ) }
-      it "returns false" do
-        expect(document.digital_help_allowed?).to be false
-      end
-    end
-  end
-
   describe "#open_shelves_allowed?" do
     context "is not in a relevant library" do
       let(:document) { SolrDocument.new("items_json_display" =>


### PR DESCRIPTION
Remove the obsolete `digital_help_allowed?` following the Digital Help request option removal.

The predicate's only remaining production use was in request-option counting for the request form. Removing it eliminates unused logic and keeps the request-option count aligned with the remaining visible request options.
