### PR TITLE
BL-2067 Improve account error handling

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,11 @@ class UsersController < ApplicationController
     if holds.success?
       render partial: "users/holds_details", layout: nil, locals: { holds: }
     else
-      render plain: "Problem!"
+      render(
+        partial: "users/account_data_error",
+        locals: { colspan: 4 },
+        status: :bad_gateway
+      )
     end
   end
 
@@ -37,7 +41,11 @@ class UsersController < ApplicationController
     if fines.success?
       render partial: "users/fines_details", layout: nil, locals: { fines: }
     else
-      render plain: "Problem!"
+      render(
+        partial: "users/account_data_error",
+        locals: { colspan: 4 },
+        status: :bad_gateway
+      )
     end
   end
 
@@ -46,7 +54,11 @@ class UsersController < ApplicationController
     if loans.success?
       render partial: "users/loans_details", layout: nil, locals: { loans: }
     else
-      render plain: "Problem!"
+      render(
+        partial: "users/account_data_error",
+        locals: { colspan: 7 },
+        status: :bad_gateway
+      )
     end
   end
 

--- a/app/views/users/_account_data_error.html.erb
+++ b/app/views/users/_account_data_error.html.erb
@@ -1,6 +1,6 @@
 <%# app/views/users/_account_data_error.html.erb %>
 <tr>
   <td colspan="<%= colspan %>">
-    We could not load your account information.
+    <%= t("account.data_error") %>
   </td>
 </tr>

--- a/app/views/users/_account_data_error.html.erb
+++ b/app/views/users/_account_data_error.html.erb
@@ -1,0 +1,6 @@
+<%# app/views/users/_account_data_error.html.erb %>
+<tr>
+  <td colspan="<%= colspan %>">
+    We could not load your account information.
+  </td>
+</tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -389,6 +389,7 @@ en:
     update_name_href: "https://tuportal.temple.edu"
     email_notice: "If you prefer not to receive email notices from us owing to privacy concerns, we offer an opt-out option. Please know that if you choose to opt out of receiving email notifications for due dates, late items, etc., you are still fully responsible for any and all related fines and other consequences resulting from late, long overdue or lost/missing items you have borrowed. If interested, please contact a staff member at the circulation desk."
     successful_payment_html: "<strong>Success!</strong> Your fees have been paid.<br /> Holds on student accounts will be removed in 24-48 hours. If you need <strong>a hold removed immediately,</strong> please call the One Stop Assistance Desk at 215-204-8212."
+    data_error: "We could not load your account information."
 
   lib_guides:
     librarian_no_results: "Need research help?"

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -25,10 +25,12 @@ RSpec.describe UsersController, type: :controller do
 
     context "User had transactions" do
       describe "GET #loans" do
+        render_views
+
         context "when the loans response is successful" do
           it "renders the loans details for a successful loans response" do
             user = FactoryBot.create(:user)
-            loans = double("Alma loans response", success?: true)
+            loans = double("Alma loans response", success?: true, all: [])
 
             sign_in user, scope: :user
             allow(controller).to receive(:current_user).and_return(user)
@@ -42,7 +44,7 @@ RSpec.describe UsersController, type: :controller do
         end
 
         context "when the loans response is unsuccessful" do
-          it "renders a plain-text fallback message" do
+          it "renders the account-data error response" do
             user = FactoryBot.create(:user)
             loans = double("Alma loans response", success?: false)
 
@@ -52,9 +54,16 @@ RSpec.describe UsersController, type: :controller do
 
             get :loans
 
-            expect(response).to have_http_status(:success)
-            expect(response.media_type).to eq("text/plain")
-            expect(response.body).to eq("Problem!")
+            expect(response).to have_http_status(:bad_gateway)
+            expect(response.media_type).to eq("text/html")
+            expect(response).to render_template(
+              partial: "users/_account_data_error"
+            )
+            expect(response.body).to include(
+              "We could not load your account information"
+            )
+            expect(response.body).to include('colspan="7"')
+            expect(response.body).not_to include("Problem!")
           end
         end
 
@@ -135,7 +144,7 @@ RSpec.describe UsersController, type: :controller do
         end
 
         context "when the holds response is unsuccessful" do
-          it "renders a plain-text fallback message" do
+          it "renders the account-data error response" do
             user = FactoryBot.create(:user)
             holds = double("Alma holds response", success?: false)
 
@@ -145,18 +154,32 @@ RSpec.describe UsersController, type: :controller do
 
             get :holds
 
-            expect(response).to have_http_status(:success)
-            expect(response.media_type).to eq("text/plain")
-            expect(response.body).to eq("Problem!")
+            expect(response).to have_http_status(:bad_gateway)
+            expect(response.media_type).to eq("text/html")
+            expect(response).to render_template(
+              partial: "users/_account_data_error"
+            )
+            expect(response.body).to include(
+              "We could not load your account information"
+            )
+            expect(response.body).to include('colspan="4"')
+            expect(response.body).not_to include("Problem!")
           end
         end
       end
 
       describe "GET #fines" do
+        render_views
+
         context "when the fines response is successful" do
           it "renders the fines details partial" do
             user = FactoryBot.create(:user)
-            fines = double("Alma fines response", success?: true)
+            fines = double(
+              "Alma fines response",
+              success?: true,
+              each_with_index: nil,
+              sum: 0
+            )
 
             sign_in user, scope: :user
             allow(controller).to receive(:current_user).and_return(user)
@@ -170,7 +193,7 @@ RSpec.describe UsersController, type: :controller do
         end
 
         context "when the fines response is unsuccessful" do
-          it "renders a plain-text fallback message" do
+          it "renders the account-data error response" do
             user = FactoryBot.create(:user)
             fines = double("Alma fines response", success?: false)
 
@@ -180,9 +203,16 @@ RSpec.describe UsersController, type: :controller do
 
             get :fines
 
-            expect(response).to have_http_status(:success)
-            expect(response.media_type).to eq("text/plain")
-            expect(response.body).to eq("Problem!")
+            expect(response).to have_http_status(:bad_gateway)
+            expect(response.media_type).to eq("text/html")
+            expect(response).to render_template(
+              partial: "users/_account_data_error"
+            )
+            expect(response.body).to include(
+              "We could not load your account information"
+            )
+            expect(response.body).to include('colspan="4"')
+            expect(response.body).not_to include("Problem!")
           end
         end
       end


### PR DESCRIPTION
Improves error handling for account loans, fines, and holds by displaying a user-facing error message when account data cannot be retrieved, adding controller test coverage for error paths, and internationalizing the displayed message.