### PR TITLE
BL-2066 Hide skip to search skip link from advanced search page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -227,7 +227,20 @@ module ApplicationHelper
   end
 
   def skip_links
+    return if advanced_search_page?
+
     link_to t("blacklight.skip_links.search_field"), "#q", class: "element-invisible element-focusable rounded-bottom py-2 px-3", data: { turbolinks: "false" }
+  end
+
+  def advanced_search_page?
+    controller_name.in?(
+      %w[
+        advanced
+        primo_advanced
+        databases_advanced
+        journals_advanced
+      ]
+    )
   end
 
   def creator_links(args)

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -137,4 +137,32 @@ RSpec.feature "Advanced Search" do
       expect(first(results_selector).text).not_to match(/Introduction to immunology/)
     end
   end
+
+  describe "skip links" do
+    advanced_search_paths = [
+      "/advanced",
+      "/articles/advanced",
+      "/databases/advanced",
+      "/journals/advanced"
+    ]
+
+    advanced_search_paths.each do |path|
+      scenario "hides Skip to search on #{path}" do
+        visit path
+
+        within("#skip-link", visible: :all) do
+          expect(page).to have_link(
+            "Skip to main content",
+            href: "#main-container",
+            visible: :all
+          )
+
+          expect(page).not_to have_link(
+            "Skip to search",
+            visible: :all
+          )
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hides the “Skip to search” skip link on all advanced search pages while retaining “Skip to main content.” Adds feature coverage for Catalog, Articles, Databases, and Journals advanced search pages.