### PR TITLE
BL-2063-update-skip-link-for-skip-to-search

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -229,7 +229,15 @@ module ApplicationHelper
   def skip_links
     return if advanced_search_page?
 
-    link_to t("blacklight.skip_links.search_field"), "#q", class: "element-invisible element-focusable rounded-bottom py-2 px-3", data: { turbolinks: "false" }
+    links = [
+      link_to(t("blacklight.skip_links.search_field"), "#q", class: "element-invisible element-focusable rounded-bottom py-2 px-3", data: { turbolinks: "false" })
+    ]
+
+    unless controller_name == "search" && action_name == "index"
+      links << link_to(t("blacklight.skip_to_filters_link"), "#search_field", class: "element-invisible element-focusable rounded-bottom py-2 px-3", data: { turbolinks: "false" })
+    end
+
+    safe_join(links)
   end
 
   def advanced_search_page?

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -60,7 +60,6 @@
     <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links') %>">
        <%= skip_links %>
        <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
-       <%= content_for(:skip_links) %>
     </nav>
 
     <%= render :partial => "shared/header_navbar" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
     purchase_order_text_2: "Access is generally granted within 2 business days. You will receive an email notification when the title is available for use."
     purchase_order_extra_instructions: "You may add extra instructions in the message field below if desired."
   blacklight:
+    skip_to_filters_link: "Skip to search filters"
     application_name: "Library Search"
     section_heading_html: "<strong>Books & Media</strong> includes books, ebooks, DVDs, streaming video, music, and other items you can borrow or access online."
     scrc: "Special Collections Research Center"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -276,31 +276,49 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe "#skip_links" do
     let(:subject) { helper.skip_links }
+    let(:config) { CatalogController.blacklight_config }
+    let(:context) { Blacklight::Configuration::Context.new(config) }
 
     before do
       without_partial_double_verification do
         allow(helper).to receive(:blacklight_config) { config }
         allow(helper).to receive(:blacklight_configuration_context) { context }
       end
+      allow(helper).to receive(:controller_name).and_return(controller_name)
+      allow(helper).to receive(:action_name).and_return(action_name)
     end
 
-    context "only 1 search field" do
-      let(:config) { SearchController.blacklight_config }
-      let(:context) { Blacklight::Configuration::Context.new(config) }
-      let(:search_fields)  {  [["All Fields", "all_fields"]] }
+    context "on a standard page (catalog#show)" do
+      let(:controller_name) { "catalog" }
+      let(:action_name) { "show" }
 
-      it "should link to the search query input" do
+      it "renders both skip links" do
         expect(subject).to have_link("Skip to search", href: "#q")
+        expect(subject).to have_link("Skip to search filters", href: "#search_field")
       end
     end
 
-    context "multiple search fields" do
-      let(:config) { CatalogController.blacklight_config }
-      let(:context) { Blacklight::Configuration::Context.new(config) }
-      let(:search_fields)  {  [["All Fields", "all_fields"], ["Title", "title"], ["Author/creator/contributor", "creator_t"]] }
+    context "on the search#index action" do
+      let(:controller_name) { "search" }
+      let(:action_name) { "index" }
 
-      it "should link to the search query input" do
+      it "renders only the skip to search link" do
         expect(subject).to have_link("Skip to search", href: "#q")
+        expect(subject).not_to have_link("Skip to search filters", href: "#search_field")
+      end
+    end
+
+    context "on an advanced search page" do
+      let(:action_name) { "index" }
+
+      %w[advanced primo_advanced databases_advanced journals_advanced].each do |name|
+        context "(#{name})" do
+          let(:controller_name) { name }
+
+          it "renders no skip links" do
+            expect(subject).to be_nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
- This work adds a "Skip to search filters" accessibility link after the existing "Skip to search" link. 
- The filters link is suppressed on search#index (/bento and /everything). 
- Both skip to search links are still suppressed on the advanced search pages where we only skip to main content. 

Specs cover all three cases.