### PR TITLE
Relocate bot challenge active record

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CatalogController < ApplicationController
+  bot_challenge only: :index, if: -> { bot_challenge? }
+
   caches_page :show
 
   include FacetParamsDedupe
@@ -27,8 +29,6 @@ class CatalogController < ApplicationController
       redirect_to root_path
     end
   end
-
-  bot_challenge only: :index, if: -> { bot_challenge? }
 
   def bot_challenge?
     Flipflop.bot_challenge? &&

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class CatalogController < ApplicationController
+  # Run the challenge before Blacklight search-session tracking creates a Search record.
   bot_challenge only: :index, if: -> { bot_challenge? }
 
   caches_page :show

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -12,6 +12,99 @@ RSpec.describe CatalogController, type: :controller do
   let(:options) { { blacklight_config: controller.blacklight_config } }
   let(:document) { SolrDocument.new(doc, options) }
 
+  def capture_active_record_queries
+    queries = []
+
+    callback = lambda do |_name, started, finished, _unique_id, payload|
+      sql = payload[:sql]
+
+      next if payload[:name] == "SCHEMA"
+      next if payload[:cached]
+      next if sql.blank?
+      next if sql.match?(/\A\s*(?:BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)\b/i)
+
+      queries << {
+        name: payload[:name],
+        sql: sql,
+        duration_ms: ((finished - started) * 1000).round(2)
+      }
+    end
+
+    ActiveSupport::Notifications.subscribed(
+      callback,
+      "sql.active_record"
+    ) do
+      yield
+    end
+
+    queries
+  end
+
+  describe "anonymous bot challenge ActiveRecord usage" do
+    around do |example|
+      config =
+        BotChallengePage::BotChallengePageController.bot_challenge_config
+      original_enabled = config.enabled
+
+      config.enabled = true
+      example.run
+    ensure
+      config.enabled = original_enabled
+    end
+
+    before do
+      @active_record_strategy =
+        Flipflop::FeatureSet.current.strategies.find do |strategy|
+          strategy.is_a?(
+            Flipflop::Strategies::ActiveRecordStrategy
+          )
+        end
+
+      raise "Flipflop ActiveRecord strategy not configured" unless @active_record_strategy
+
+      Flipflop::FeatureSet.current.clear!(
+        :bot_challenge,
+        @active_record_strategy.key
+      )
+      Flipflop::FeatureSet.current.switch!(
+        :bot_challenge,
+        @active_record_strategy.key,
+        true
+      )
+      Flipflop::FeatureCache.current.disable!
+    end
+
+    after do
+      if @active_record_strategy
+        Flipflop::FeatureSet.current.clear!(
+          :bot_challenge,
+          @active_record_strategy.key
+        )
+      end
+
+      Flipflop::FeatureCache.current.disable!
+    end
+
+    it "executes search tracking and feature flag SQL before returning the bot challenge" do
+      queries = capture_active_record_queries do
+        get :index, params: { q: "bot challenge characterization" }
+      end
+
+      warn "\nCaptured SQL during challenged request:"
+      queries.each_with_index do |query, index|
+        warn(
+          "#{index + 1}. #{query[:name]} " \
+          "(#{query[:duration_ms]}ms): #{query[:sql]}"
+        )
+      end
+
+      expect(response).to have_http_status(:forbidden)
+      expect(queries.length).to eq(2)
+      expect(queries[0][:sql]).to include('INSERT INTO "searches"')
+      expect(queries[1][:sql]).to include('FROM "flipflop_features"')
+    end
+  end
+
   describe "show action" do
     it "gets the staff_view_path" do
       get :show, params: { id: doc_id }

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -85,7 +85,9 @@ RSpec.describe CatalogController, type: :controller do
       Flipflop::FeatureCache.current.disable!
     end
 
-    it "executes search tracking and feature flag SQL before returning the bot challenge" do
+    it "returns the bot challenge before search session tracking" do
+      expect(controller).not_to receive(:set_current_search_session)
+
       queries = capture_active_record_queries do
         get :index, params: { q: "bot challenge characterization" }
       end
@@ -99,9 +101,8 @@ RSpec.describe CatalogController, type: :controller do
       end
 
       expect(response).to have_http_status(:forbidden)
-      expect(queries.length).to eq(2)
-      expect(queries[0][:sql]).to include('INSERT INTO "searches"')
-      expect(queries[1][:sql]).to include('FROM "flipflop_features"')
+      expect(queries.length).to eq(1)
+      expect(queries[0][:sql]).to include('FROM "flipflop_features"')
     end
 
     context "with an authenticated user" do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -101,8 +101,9 @@ RSpec.describe CatalogController, type: :controller do
       end
 
       expect(response).to have_http_status(:forbidden)
-      expect(queries.length).to eq(1)
-      expect(queries[0][:sql]).to include('FROM "flipflop_features"')
+      expect(queries).not_to include(
+        a_hash_including(sql: include('"searches"'))
+      )
     end
 
     context "with an authenticated user" do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -12,35 +12,7 @@ RSpec.describe CatalogController, type: :controller do
   let(:options) { { blacklight_config: controller.blacklight_config } }
   let(:document) { SolrDocument.new(doc, options) }
 
-  def capture_active_record_queries
-    queries = []
-
-    callback = lambda do |_name, started, finished, _unique_id, payload|
-      sql = payload[:sql]
-
-      next if payload[:name] == "SCHEMA"
-      next if payload[:cached]
-      next if sql.blank?
-      next if sql.match?(/\A\s*(?:BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)\b/i)
-
-      queries << {
-        name: payload[:name],
-        sql: sql,
-        duration_ms: ((finished - started) * 1000).round(2)
-      }
-    end
-
-    ActiveSupport::Notifications.subscribed(
-      callback,
-      "sql.active_record"
-    ) do
-      yield
-    end
-
-    queries
-  end
-
-  describe "bot challenge behavior and ActiveRecord usage" do
+  describe "bot challenge behavior" do
     around do |example|
       config =
         BotChallengePage::BotChallengePageController.bot_challenge_config
@@ -53,57 +25,15 @@ RSpec.describe CatalogController, type: :controller do
     end
 
     before do
-      @active_record_strategy =
-        Flipflop::FeatureSet.current.strategies.find do |strategy|
-          strategy.is_a?(
-            Flipflop::Strategies::ActiveRecordStrategy
-          )
-        end
-
-      raise "Flipflop ActiveRecord strategy not configured" unless @active_record_strategy
-
-      Flipflop::FeatureSet.current.clear!(
-        :bot_challenge,
-        @active_record_strategy.key
-      )
-      Flipflop::FeatureSet.current.switch!(
-        :bot_challenge,
-        @active_record_strategy.key,
-        true
-      )
-      Flipflop::FeatureCache.current.disable!
-    end
-
-    after do
-      if @active_record_strategy
-        Flipflop::FeatureSet.current.clear!(
-          :bot_challenge,
-          @active_record_strategy.key
-        )
-      end
-
-      Flipflop::FeatureCache.current.disable!
+      allow(Flipflop).to receive(:bot_challenge?).and_return(true)
     end
 
     it "returns the bot challenge before search session tracking" do
       expect(controller).not_to receive(:set_current_search_session)
 
-      queries = capture_active_record_queries do
-        get :index, params: { q: "bot challenge characterization" }
-      end
-
-      warn "\nCaptured SQL during challenged request:"
-      queries.each_with_index do |query, index|
-        warn(
-          "#{index + 1}. #{query[:name]} " \
-          "(#{query[:duration_ms]}ms): #{query[:sql]}"
-        )
-      end
+      get :index, params: { q: "bot challenge characterization" }
 
       expect(response).to have_http_status(:forbidden)
-      expect(queries).not_to include(
-        a_hash_including(sql: include('"searches"'))
-      )
     end
 
     context "with an authenticated user" do
@@ -191,12 +121,7 @@ RSpec.describe CatalogController, type: :controller do
 
     context "when the Flipflop challenge flag is disabled" do
       before do
-        Flipflop::FeatureSet.current.switch!(
-          :bot_challenge,
-          @active_record_strategy.key,
-          false
-        )
-        Flipflop::FeatureCache.current.disable!
+        allow(Flipflop).to receive(:bot_challenge?).and_return(false)
       end
 
       it "preserves normal catalog access" do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CatalogController, type: :controller do
     queries
   end
 
-  describe "anonymous bot challenge ActiveRecord usage" do
+  describe "bot challenge behavior and ActiveRecord usage" do
     around do |example|
       config =
         BotChallengePage::BotChallengePageController.bot_challenge_config
@@ -102,6 +102,120 @@ RSpec.describe CatalogController, type: :controller do
       expect(queries.length).to eq(2)
       expect(queries[0][:sql]).to include('INSERT INTO "searches"')
       expect(queries[1][:sql]).to include('FROM "flipflop_features"')
+    end
+
+    context "with an authenticated user" do
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        sign_in user
+      end
+
+      it "preserves normal catalog access" do
+        get :index, params: { q: "authenticated user characterization" }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with a signed-in guest user" do
+      let(:guest_user) { FactoryBot.create(:user, guest: true) }
+
+      before do
+        sign_in guest_user
+      end
+
+      it "continues to require the bot challenge" do
+        get :index, params: { q: "guest user characterization" }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "with a valid bot challenge pass" do
+      before do
+        challenge_controller =
+          BotChallengePage::BotChallengePageController
+        config = challenge_controller.bot_challenge_config
+
+        session[config.session_passed_key] = {
+          challenge_controller::SESSION_DATETIME_KEY =>
+            Time.now.utc.iso8601,
+          challenge_controller::SESSION_FINGERPRINT_KEY =>
+            config.session_valid_fingerprint.call(request)
+        }
+      end
+
+      it "preserves normal catalog access without another challenge" do
+        get :index, params: { q: "passed challenge characterization" }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with a stale signed login marker" do
+      before do
+        cookies.signed[LoginCookie::LOGIN_COOKIE_NAME] = {
+          user_id: -1,
+          issued_at: 1.hour.ago.to_i
+        }
+      end
+
+      it "clears the marker and requires the bot challenge" do
+        get :index, params: { q: "stale login marker characterization" }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.headers["Set-Cookie"]).to match(
+          /#{LoginCookie::LOGIN_COOKIE_NAME}=;/
+        )
+      end
+    end
+
+    context "with an invalid unsigned login marker" do
+      before do
+        cookies[LoginCookie::LOGIN_COOKIE_NAME] = "forged"
+      end
+
+      it "clears the marker and requires the bot challenge" do
+        get :index, params: { q: "invalid login marker characterization" }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(cookies.signed[LoginCookie::LOGIN_COOKIE_NAME]).to be_nil
+        expect(response.headers["Set-Cookie"]).to match(
+          /#{LoginCookie::LOGIN_COOKIE_NAME}=;/
+        )
+      end
+    end
+
+    context "when the Flipflop challenge flag is disabled" do
+      before do
+        Flipflop::FeatureSet.current.switch!(
+          :bot_challenge,
+          @active_record_strategy.key,
+          false
+        )
+        Flipflop::FeatureCache.current.disable!
+      end
+
+      it "preserves normal catalog access" do
+        get :index, params: { q: "disabled challenge characterization" }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when the global bot challenge configuration is disabled" do
+      before do
+        BotChallengePage::BotChallengePageController
+          .bot_challenge_config
+          .enabled = false
+      end
+
+      it "preserves normal catalog access" do
+        get :index, params: { q: "globally disabled challenge characterization" }
+
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CatalogController, type: :controller do
     end
 
     before do
-      allow(Flipflop).to receive(:bot_challenge?).and_return(true)
+      allow(controller).to receive(:bot_challenge?).and_return(true)
     end
 
     it "returns the bot challenge before search session tracking" do
@@ -34,34 +34,6 @@ RSpec.describe CatalogController, type: :controller do
       get :index, params: { q: "bot challenge characterization" }
 
       expect(response).to have_http_status(:forbidden)
-    end
-
-    context "with an authenticated user" do
-      let(:user) { FactoryBot.create(:user) }
-
-      before do
-        sign_in user
-      end
-
-      it "preserves normal catalog access" do
-        get :index, params: { q: "authenticated user characterization" }
-
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
-    context "with a signed-in guest user" do
-      let(:guest_user) { FactoryBot.create(:user, guest: true) }
-
-      before do
-        sign_in guest_user
-      end
-
-      it "continues to require the bot challenge" do
-        get :index, params: { q: "guest user characterization" }
-
-        expect(response).to have_http_status(:forbidden)
-      end
     end
 
     context "with a valid bot challenge pass" do
@@ -116,18 +88,6 @@ RSpec.describe CatalogController, type: :controller do
         expect(response.headers["Set-Cookie"]).to match(
           /#{LoginCookie::LOGIN_COOKIE_NAME}=;/
         )
-      end
-    end
-
-    context "when the Flipflop challenge flag is disabled" do
-      before do
-        allow(Flipflop).to receive(:bot_challenge?).and_return(false)
-      end
-
-      it "preserves normal catalog access" do
-        get :index, params: { q: "disabled challenge characterization" }
-
-        expect(response).to have_http_status(:ok)
       end
     end
 

--- a/spec/controllers/primo_central_controller_spec.rb
+++ b/spec/controllers/primo_central_controller_spec.rb
@@ -93,8 +93,9 @@ RSpec.describe PrimoCentralController, type: :controller do
       Flipflop::FeatureCache.current.disable!
     end
 
-    it "executes search tracking and feature flag SQL before returning the article bot challenge" do
+    it "returns the article bot challenge before search tracking and recaptcha" do
       expect(controller).not_to receive(:recaptcha)
+      expect(controller).not_to receive(:set_current_search_session)
 
       queries = capture_active_record_queries do
         get :index, params: { q: "article bot challenge characterization" }
@@ -109,9 +110,8 @@ RSpec.describe PrimoCentralController, type: :controller do
       end
 
       expect(response).to have_http_status(:forbidden)
-      expect(queries.length).to eq(2)
-      expect(queries[0][:sql]).to include('INSERT INTO "searches"')
-      expect(queries[1][:sql]).to include('FROM "flipflop_features"')
+      expect(queries.length).to eq(1)
+      expect(queries[0][:sql]).to include('FROM "flipflop_features"')
     end
   end
 

--- a/spec/controllers/primo_central_controller_spec.rb
+++ b/spec/controllers/primo_central_controller_spec.rb
@@ -10,12 +10,109 @@ RSpec.describe PrimoCentralController, type: :controller do
   let(:mock_response) { instance_double(Blacklight::PrimoCentral::Response) }
   let(:search_service) { instance_double(Blacklight::SearchService) }
 
+  def capture_active_record_queries
+    queries = []
+
+    callback = lambda do |_name, started, finished, _unique_id, payload|
+      sql = payload[:sql]
+
+      next if payload[:name] == "SCHEMA"
+      next if payload[:cached]
+      next if sql.blank?
+      next if sql.match?(/\A\s*(?:BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)\b/i)
+
+      queries << {
+        name: payload[:name],
+        sql: sql,
+        duration_ms: ((finished - started) * 1000).round(2)
+      }
+    end
+
+    ActiveSupport::Notifications.subscribed(
+      callback,
+      "sql.active_record"
+    ) do
+      yield
+    end
+
+    queries
+  end
+
   before(:each) do
     allow(helpers).to receive(:base_path).and_return("/")
     allow(controller).to receive(:helpers).and_return(helpers)
     allow(controller).to receive(:search_service).and_return(search_service)
     allow(search_service).to receive(:fetch).and_return([mock_response, document])
     allow(search_service).to receive(:search_results).and_return([mock_response, document])
+  end
+
+  describe "anonymous bot challenge ActiveRecord usage" do
+    around do |example|
+      config =
+        BotChallengePage::BotChallengePageController.bot_challenge_config
+      original_enabled = config.enabled
+
+      config.enabled = true
+      example.run
+    ensure
+      config.enabled = original_enabled
+    end
+
+    before do
+      allow(helpers).to receive(:current_page?).and_return(false)
+
+      @active_record_strategy =
+        Flipflop::FeatureSet.current.strategies.find do |strategy|
+          strategy.is_a?(
+            Flipflop::Strategies::ActiveRecordStrategy
+          )
+        end
+
+      raise "Flipflop ActiveRecord strategy not configured" unless @active_record_strategy
+
+      Flipflop::FeatureSet.current.clear!(
+        :bot_challenge,
+        @active_record_strategy.key
+      )
+      Flipflop::FeatureSet.current.switch!(
+        :bot_challenge,
+        @active_record_strategy.key,
+        true
+      )
+      Flipflop::FeatureCache.current.disable!
+    end
+
+    after do
+      if @active_record_strategy
+        Flipflop::FeatureSet.current.clear!(
+          :bot_challenge,
+          @active_record_strategy.key
+        )
+      end
+
+      Flipflop::FeatureCache.current.disable!
+    end
+
+    it "executes search tracking and feature flag SQL before returning the article bot challenge" do
+      expect(controller).not_to receive(:recaptcha)
+
+      queries = capture_active_record_queries do
+        get :index, params: { q: "article bot challenge characterization" }
+      end
+
+      warn "\nCaptured SQL during challenged article request:"
+      queries.each_with_index do |query, index|
+        warn(
+          "#{index + 1}. #{query[:name]} " \
+          "(#{query[:duration_ms]}ms): #{query[:sql]}"
+        )
+      end
+
+      expect(response).to have_http_status(:forbidden)
+      expect(queries.length).to eq(2)
+      expect(queries[0][:sql]).to include('INSERT INTO "searches"')
+      expect(queries[1][:sql]).to include('FROM "flipflop_features"')
+    end
   end
 
   describe "show action" do

--- a/spec/controllers/primo_central_controller_spec.rb
+++ b/spec/controllers/primo_central_controller_spec.rb
@@ -110,8 +110,9 @@ RSpec.describe PrimoCentralController, type: :controller do
       end
 
       expect(response).to have_http_status(:forbidden)
-      expect(queries.length).to eq(1)
-      expect(queries[0][:sql]).to include('FROM "flipflop_features"')
+      expect(queries).not_to include(
+        a_hash_including(sql: include('"searches"'))
+      )
     end
   end
 

--- a/spec/controllers/primo_central_controller_spec.rb
+++ b/spec/controllers/primo_central_controller_spec.rb
@@ -10,34 +10,6 @@ RSpec.describe PrimoCentralController, type: :controller do
   let(:mock_response) { instance_double(Blacklight::PrimoCentral::Response) }
   let(:search_service) { instance_double(Blacklight::SearchService) }
 
-  def capture_active_record_queries
-    queries = []
-
-    callback = lambda do |_name, started, finished, _unique_id, payload|
-      sql = payload[:sql]
-
-      next if payload[:name] == "SCHEMA"
-      next if payload[:cached]
-      next if sql.blank?
-      next if sql.match?(/\A\s*(?:BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE)\b/i)
-
-      queries << {
-        name: payload[:name],
-        sql: sql,
-        duration_ms: ((finished - started) * 1000).round(2)
-      }
-    end
-
-    ActiveSupport::Notifications.subscribed(
-      callback,
-      "sql.active_record"
-    ) do
-      yield
-    end
-
-    queries
-  end
-
   before(:each) do
     allow(helpers).to receive(:base_path).and_return("/")
     allow(controller).to receive(:helpers).and_return(helpers)
@@ -46,7 +18,7 @@ RSpec.describe PrimoCentralController, type: :controller do
     allow(search_service).to receive(:search_results).and_return([mock_response, document])
   end
 
-  describe "anonymous bot challenge ActiveRecord usage" do
+  describe "anonymous bot challenge behavior" do
     around do |example|
       config =
         BotChallengePage::BotChallengePageController.bot_challenge_config
@@ -60,59 +32,16 @@ RSpec.describe PrimoCentralController, type: :controller do
 
     before do
       allow(helpers).to receive(:current_page?).and_return(false)
-
-      @active_record_strategy =
-        Flipflop::FeatureSet.current.strategies.find do |strategy|
-          strategy.is_a?(
-            Flipflop::Strategies::ActiveRecordStrategy
-          )
-        end
-
-      raise "Flipflop ActiveRecord strategy not configured" unless @active_record_strategy
-
-      Flipflop::FeatureSet.current.clear!(
-        :bot_challenge,
-        @active_record_strategy.key
-      )
-      Flipflop::FeatureSet.current.switch!(
-        :bot_challenge,
-        @active_record_strategy.key,
-        true
-      )
-      Flipflop::FeatureCache.current.disable!
-    end
-
-    after do
-      if @active_record_strategy
-        Flipflop::FeatureSet.current.clear!(
-          :bot_challenge,
-          @active_record_strategy.key
-        )
-      end
-
-      Flipflop::FeatureCache.current.disable!
+      allow(Flipflop).to receive(:bot_challenge?).and_return(true)
     end
 
     it "returns the article bot challenge before search tracking and recaptcha" do
       expect(controller).not_to receive(:recaptcha)
       expect(controller).not_to receive(:set_current_search_session)
 
-      queries = capture_active_record_queries do
-        get :index, params: { q: "article bot challenge characterization" }
-      end
-
-      warn "\nCaptured SQL during challenged article request:"
-      queries.each_with_index do |query, index|
-        warn(
-          "#{index + 1}. #{query[:name]} " \
-          "(#{query[:duration_ms]}ms): #{query[:sql]}"
-        )
-      end
+      get :index, params: { q: "article bot challenge characterization" }
 
       expect(response).to have_http_status(:forbidden)
-      expect(queries).not_to include(
-        a_hash_including(sql: include('"searches"'))
-      )
     end
   end
 

--- a/spec/controllers/primo_central_controller_spec.rb
+++ b/spec/controllers/primo_central_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PrimoCentralController, type: :controller do
 
     before do
       allow(helpers).to receive(:current_page?).and_return(false)
-      allow(Flipflop).to receive(:bot_challenge?).and_return(true)
+      allow(controller).to receive(:bot_challenge?).and_return(true)
     end
 
     it "returns the article bot challenge before search tracking and recaptcha" do


### PR DESCRIPTION
Do not merge.  Draft for Comments and discussion.

Refactor the bot challenge in the catalog_controller in order to reduce CPU load prior to issuing 403 to turnstyle.