### PR TITLE
Apply bot challenge to facet requests

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -28,7 +28,7 @@ class CatalogController < ApplicationController
     end
   end
 
-  bot_challenge only: :index, if: -> { bot_challenge? }
+  bot_challenge only: %i[index facet], if: -> { bot_challenge? }
 
   def bot_challenge?
     Flipflop.bot_challenge? &&

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2,7 +2,8 @@
 
 class CatalogController < ApplicationController
   # Run the challenge before Blacklight search-session tracking creates a Search record.
-  bot_challenge only: %i[index facet], if: -> { bot_challenge? }
+  bot_challenge only: :index, if: -> { bot_challenge? }
+  bot_challenge only: :facet, if: -> { facet_bot_challenge? }
 
   caches_page :show
 
@@ -32,8 +33,13 @@ class CatalogController < ApplicationController
   end
 
   def bot_challenge?
+    Flipflop.bot_challenge? &&
+      (current_user.nil? || current_user.guest?)
+  end
+
+  def facet_bot_challenge?
     request.headers["Sec-Fetch-Dest"] != "empty" &&
-      Flipflop.bot_challenge? &&
+      Flipflop.facet_bot_challenge? &&
       (current_user.nil? || current_user.guest?)
   end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -2,7 +2,7 @@
 
 class CatalogController < ApplicationController
   # Run the challenge before Blacklight search-session tracking creates a Search record.
-  bot_challenge only: :index, if: -> { bot_challenge? }
+  bot_challenge only: %i[index facet], if: -> { bot_challenge? }
 
   caches_page :show
 
@@ -32,10 +32,10 @@ class CatalogController < ApplicationController
   end
 
   def bot_challenge?
-    Flipflop.bot_challenge? &&
+    request.headers["Sec-Fetch-Dest"] != "empty" &&
+      Flipflop.bot_challenge? &&
       (current_user.nil? || current_user.guest?)
   end
-
 
   def override_solr_path
     single_word = params["q"]&.split&.count == 1

--- a/config/features.rb
+++ b/config/features.rb
@@ -16,5 +16,6 @@ Flipflop.configure do
 
   group :experimental do
     feature :bot_challenge, default: false
+    feature :facet_bot_challenge, default: false
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -445,32 +445,19 @@ RSpec.describe CatalogController, type: :controller do
     end
   end
 
-  describe "bot challenge" do
-    it "does not enable the bot challenge when the feature is disabled" do
-      allow(Flipflop).to receive(:bot_challenge?).and_return(false)
+  describe "facet bot challenge" do
+    it "does not invoke the bot challenge guard when the facet challenge is disabled" do
+      allow(Flipflop).to receive(:facet_bot_challenge?).and_return(false)
       allow(controller).to receive(:current_user).and_return(nil)
 
-      expect(controller.send(:bot_challenge?)).to be false
+      expect(BotChallengePage::BotChallengePageController)
+        .not_to receive(:bot_challenge_guard_action)
+
+      get :facet, params: { id: "creator_facet" }
     end
 
-    it "enables the bot challenge for a guest user" do
-      allow(Flipflop).to receive(:bot_challenge?).and_return(true)
-      allow(controller).to receive(:current_user).and_return(nil)
-
-      expect(controller.send(:bot_challenge?)).to be true
-    end
-
-    it "does not enable the bot challenge for an authenticated user" do
-      user = instance_double(User, guest?: false)
-
-      allow(Flipflop).to receive(:bot_challenge?).and_return(true)
-      allow(controller).to receive(:current_user).and_return(user)
-
-      expect(controller.send(:bot_challenge?)).to be false
-    end
-
-    it "invokes the bot challenge guard for a facet request" do
-      allow(Flipflop).to receive(:bot_challenge?).and_return(true)
+    it "invokes the bot challenge guard for an anonymous facet request" do
+      allow(Flipflop).to receive(:facet_bot_challenge?).and_return(true)
       allow(controller).to receive(:current_user).and_return(nil)
 
       expect(BotChallengePage::BotChallengePageController)
@@ -482,8 +469,20 @@ RSpec.describe CatalogController, type: :controller do
       get :facet, params: { id: "creator_facet" }
     end
 
+    it "does not invoke the bot challenge guard for an authenticated user" do
+      user = instance_double(User, guest?: false)
+
+      allow(Flipflop).to receive(:facet_bot_challenge?).and_return(true)
+      allow(controller).to receive(:current_user).and_return(user)
+
+      expect(BotChallengePage::BotChallengePageController)
+        .not_to receive(:bot_challenge_guard_action)
+
+      get :facet, params: { id: "creator_facet" }
+    end
+
     it "does not invoke the bot challenge guard for a facet fetch request" do
-      allow(Flipflop).to receive(:bot_challenge?).and_return(true)
+      allow(Flipflop).to receive(:facet_bot_challenge?).and_return(true)
       allow(controller).to receive(:current_user).and_return(nil)
 
       request.headers["Sec-Fetch-Dest"] = "empty"

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -481,5 +481,17 @@ RSpec.describe CatalogController, type: :controller do
 
       get :facet, params: { id: "creator_facet" }
     end
+
+    it "does not invoke the bot challenge guard for a facet fetch request" do
+      allow(Flipflop).to receive(:bot_challenge?).and_return(true)
+      allow(controller).to receive(:current_user).and_return(nil)
+
+      request.headers["Sec-Fetch-Dest"] = "empty"
+
+      expect(BotChallengePage::BotChallengePageController)
+        .not_to receive(:bot_challenge_guard_action)
+
+      get :facet, params: { id: "creator_facet" }
+    end
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -350,4 +350,42 @@ RSpec.describe CatalogController, type: :controller do
       end
     end
   end
+
+  describe "bot challenge" do
+    it "does not enable the bot challenge when the feature is disabled" do
+      allow(Flipflop).to receive(:bot_challenge?).and_return(false)
+      allow(controller).to receive(:current_user).and_return(nil)
+
+      expect(controller.send(:bot_challenge?)).to be false
+    end
+
+    it "enables the bot challenge for a guest user" do
+      allow(Flipflop).to receive(:bot_challenge?).and_return(true)
+      allow(controller).to receive(:current_user).and_return(nil)
+
+      expect(controller.send(:bot_challenge?)).to be true
+    end
+
+    it "does not enable the bot challenge for an authenticated user" do
+      user = instance_double(User, guest?: false)
+
+      allow(Flipflop).to receive(:bot_challenge?).and_return(true)
+      allow(controller).to receive(:current_user).and_return(user)
+
+      expect(controller.send(:bot_challenge?)).to be false
+    end
+
+    it "invokes the bot challenge guard for a facet request" do
+      allow(Flipflop).to receive(:bot_challenge?).and_return(true)
+      allow(controller).to receive(:current_user).and_return(nil)
+
+      expect(BotChallengePage::BotChallengePageController)
+        .to receive(:bot_challenge_guard_action)
+        .with(controller) do |challenged_controller|
+          challenged_controller.head :forbidden
+        end
+
+      get :facet, params: { id: "creator_facet" }
+    end
+  end
 end


### PR DESCRIPTION
Apply bot challenge to catalog facet requests

Note: to verify from a browser visit a local library search instance with the `/catalog/facet/creator_facet` path from an incognito browser and from a browser from which you've authenticated to Library Serach.  Incognito session should challenge while an authenticated session should take you to the facet page.