### PR TITLE
BL-2030 Update citeproc to fallback to 3 contributors if no creator

### DIFF
--- a/app/services/citeproc/item_service.rb
+++ b/app/services/citeproc/item_service.rb
@@ -2,6 +2,8 @@
 
 module Citeproc
   class ItemService
+    FALLBACK_AUTHOR_LIMIT = 3
+
     ROLE_MAPPINGS = {
       "author" => "author",
       "aut" => "author",
@@ -122,26 +124,34 @@ module Citeproc
       end
 
       def extract_names(target_role)
-        extract_main_entry_names(target_role) + extract_contributor_names(target_role)
+        names = extract_main_entry_names(target_role) + extract_contributor_names(target_role)
+        return names if names.present? || target_role != "author"
+
+        fallback_contributor_author_names
       end
 
       def extract_main_entry_names(target_role)
-        Array(document["creator_display"]).filter_map do |value|
-          role = extract_role(value, default_role: "author")
-          extract_name(value) if role == target_role
+        name_extractor.creator_entries.filter_map do |entry|
+          build_name(entry.name) if extract_role(entry.relators, default_role: "author") == target_role
         end.uniq
       end
 
       def extract_contributor_names(target_role)
-        Array(document["contributor_display"]).filter_map do |value|
-          role = extract_role(value)
-          extract_name(value) if role == target_role
+        name_extractor.contributor_entries.filter_map do |entry|
+          build_name(entry.name) if extract_role(entry.relators) == target_role
         end.uniq
       end
 
-      def extract_name(value)
-        name = parsed_indexed_value(value)[:name]
-        build_name(name)
+      def fallback_contributor_author_names
+        return [] if name_extractor.creator_entries.present?
+
+        name_extractor.fallback_contributor_entries.filter_map do |entry|
+          build_name(entry.name)
+        end.uniq.first(FALLBACK_AUTHOR_LIMIT)
+      end
+
+      def name_extractor
+        @name_extractor ||= Citeproc::NameExtractor.new(document)
       end
 
       def build_name(value)
@@ -171,8 +181,8 @@ module Citeproc
         end
       end
 
-      def extract_role(value, default_role: nil)
-        relator_segments(value).each do |segment|
+      def extract_role(relators, default_role: nil)
+        Array(relators).flat_map { |segment| segment.to_s.split(/\s*,\s*/) }.each do |segment|
           role = ROLE_MAPPINGS[normalize_relator(segment)]
           return role if role.present?
         end
@@ -222,45 +232,9 @@ module Citeproc
         style_id == "apa"
       end
 
-      def relator_segments(value)
-        parsed = parsed_indexed_value(value)
-        Array(parsed[:relators]).flat_map do |segment|
-          segment.to_s.split(/\s*,\s*/)
-        end
-      end
-
       def normalize_relator(value)
         normalized = strip_trailing_punct(value).downcase
         normalized.include?("relators/") ? normalized.split("/").last : normalized
-      end
-
-      def parsed_indexed_value(value)
-        return parse_json_indexed_value(value) if json_indexed_value?(value)
-
-        parse_pipe_indexed_value(value)
-      end
-
-      def json_indexed_value?(value)
-        string = value.to_s.strip
-        string.start_with?("{") && string.end_with?("}")
-      end
-
-      def parse_json_indexed_value(value)
-        parsed = JSON.parse(value.to_s)
-        {
-          name: parsed["name"].to_s.strip,
-          relators: [parsed["role"], parsed["relation"]].compact_blank
-        }
-      rescue JSON::ParserError
-        parse_pipe_indexed_value(value)
-      end
-
-      def parse_pipe_indexed_value(value)
-        segments = value.to_s.split("|").map(&:strip)
-        {
-          name: segments.first.to_s,
-          relators: segments.drop(1)
-        }
       end
 
       def strip_trailing_punct(value)

--- a/app/services/citeproc/name_extractor.rb
+++ b/app/services/citeproc/name_extractor.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module Citeproc
+  class NameExtractor
+    Entry = Struct.new(:name, :relators, keyword_init: true)
+
+    def initialize(document)
+      @document = document
+    end
+
+    attr_reader :document
+
+    def creator_entries
+      @creator_entries ||= entries_for("creator_display", "creator")
+    end
+
+    def contributor_entries
+      @contributor_entries ||= entries_for("contributor_display", "contributor")
+    end
+
+    def fallback_contributor_entries
+      entries = contributor_entries
+      return entries if entries.present?
+
+      marc_contributor_entries
+    end
+
+    private
+
+      def entries_for(*fields)
+        values_for(*fields).filter_map do |value|
+          build_entry(value)
+        end
+      end
+
+      def values_for(*fields)
+        fields.each do |field|
+          values = Array(document[field]).compact_blank
+          return values if values.present?
+        end
+
+        []
+      end
+
+      def build_entry(value)
+        parsed = parse_value(value)
+        return if parsed[:name].blank?
+
+        Entry.new(name: parsed[:name], relators: Array(parsed[:relators]).compact_blank)
+      end
+
+      def parse_value(value)
+        return parse_html_value(value) if html_value?(value)
+        return parse_json_value(value) if json_value?(value)
+
+        parse_pipe_value(value)
+      end
+
+      def html_value?(value)
+        value.to_s.include?("<")
+      end
+
+      def json_value?(value)
+        string = value.to_s.strip
+        string.start_with?("{") && string.end_with?("}")
+      end
+
+      def parse_html_value(value)
+        string = value.to_s
+        anchor_text = string[/>([^<]+)<\/a>/i, 1].to_s
+        trailing_text = string.split(%r{</a>}i, 2).last.to_s
+
+        {
+          name: sanitize_text(anchor_text),
+          relators: [sanitize_text(trailing_text)]
+        }
+      end
+
+      def parse_json_value(value)
+        parsed = JSON.parse(value.to_s)
+        {
+          name: parsed["name"].to_s.strip,
+          relators: [parsed["role"], parsed["relation"]]
+        }
+      rescue JSON::ParserError
+        parse_pipe_value(value)
+      end
+
+      def parse_pipe_value(value)
+        segments = value.to_s.split("|").map(&:strip)
+        {
+          name: segments.first.to_s,
+          relators: segments.drop(1)
+        }
+      end
+
+      def sanitize_text(value)
+        CGI.unescapeHTML(value.to_s.gsub(/<[^>]+>/, " ")).squish
+      end
+
+      def marc_contributor_entries
+        return [] unless document.respond_to?(:to_marc)
+
+        Array(document.to_marc&.fields).select do |field|
+          %w[700 710 711].include?(field.tag)
+        end.filter_map do |field|
+          build_entry(marc_name_value(field))
+        end
+      rescue StandardError
+        []
+      end
+
+      def marc_name_value(field)
+        return if field.blank?
+
+        subfields = field.subfields.select do |subfield|
+          %w[a b c d q].include?(subfield.code)
+        end
+        return if subfields.blank?
+
+        subfields.map(&:value).join(" ").squish
+      end
+  end
+end

--- a/app/services/citeproc/name_extractor.rb
+++ b/app/services/citeproc/name_extractor.rb
@@ -50,14 +50,14 @@ module Citeproc
       end
 
       def parse_value(value)
-        return parse_html_value(value) if html_value?(value)
         return parse_json_value(value) if json_value?(value)
+        return parse_html_value(value) if html_value?(value)
 
         parse_pipe_value(value)
       end
 
       def html_value?(value)
-        value.to_s.include?("<")
+        value.to_s.match?(%r{<a\b[^>]*>}i)
       end
 
       def json_value?(value)
@@ -106,7 +106,8 @@ module Citeproc
         end.filter_map do |field|
           build_entry(marc_name_value(field))
         end
-      rescue StandardError
+      rescue StandardError => e
+        Rails.logger.warn("Unable to extract MARC contributors for citation: #{e.message}")
         []
       end
 

--- a/spec/services/citeproc/item_service_spec.rb
+++ b/spec/services/citeproc/item_service_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Citeproc::ItemService do
     expect(citeproc_names(item.author)).to eq([{ "family" => "Example", "given" => "Avery" }])
   end
 
-  it "does not use contributor_display as author when there is no supported relator" do
+  it "uses contributor_display as a fallback author when there is no supported relator" do
     document["creator_display"] = []
     document["contributor_display"] = [
       "Norris, Denne Michele,"

--- a/spec/services/citeproc/item_service_spec.rb
+++ b/spec/services/citeproc/item_service_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "marc"
 
 RSpec.describe Citeproc::ItemService do
   subject(:item) { described_class.build(document) }
@@ -75,7 +76,7 @@ RSpec.describe Citeproc::ItemService do
       "Norris, Denne Michele,"
     ]
 
-    expect(item.author).to be_nil
+    expect(citeproc_names(item.author)).to eq([{ "family" => "Norris", "given" => "Denne Michele" }])
   end
 
   it "uses contributor_display as author when there is an author relator and no creator_display" do
@@ -214,5 +215,99 @@ RSpec.describe Citeproc::ItemService do
     expect(citeproc_names(item.author)).to eq([{ "family" => "Primary", "given" => "Pat" }])
     expect(item.editor).to be_nil
     expect(item.translator).to be_nil
+  end
+
+  it "uses the first three contributor_display entries as authors when no creator_display or supported contributor relators exist" do
+    document["creator_display"] = []
+    document["contributor_display"] = [
+      "Alpha, Ada|writer of supplementary textual content.",
+      "Beta, Ben.",
+      "Gamma, Gia|honouree.",
+      "Delta, Dom|former owner."
+    ]
+
+    expect(citeproc_names(item.author)).to eq([
+      { "family" => "Alpha", "given" => "Ada" },
+      { "family" => "Beta", "given" => "Ben" },
+      { "family" => "Gamma", "given" => "Gia" }
+    ])
+  end
+
+  it "uses semantic contributor values as the fallback author source when display fields are absent" do
+    document = SolrDocument.new(
+      "id" => "991012041239703811",
+      "title_statement_display" => ["Example title / Foo."],
+      "creator" => [],
+      "contributor" => [
+        "Alpha, Ada",
+        "Beta, Ben",
+        "Gamma, Gia",
+        "Delta, Dom"
+      ],
+      "format" => ["Book"]
+    )
+
+    item = described_class.build(document)
+
+    expect(citeproc_names(item.author)).to eq([
+      { "family" => "Alpha", "given" => "Ada" },
+      { "family" => "Beta", "given" => "Ben" },
+      { "family" => "Gamma", "given" => "Gia" }
+    ])
+  end
+
+  it "uses html-rendered contributor_display values as fallback authors when no creator_display exists" do
+    document["creator_display"] = []
+    document["contributor_display"] = [
+      '<a href="/catalog?f[creator_facet][]=Warner+Bros.+Pictures+%281969-+%29">Warner Bros. Pictures (1969- )</a>',
+      '<a href="/catalog?f[creator_facet][]=Heyday+Films">Heyday Films</a>',
+      '<a href="/catalog?f[creator_facet][]=Warner+Home+Video+%28Firm%29">Warner Home Video (Firm)</a>',
+      '<a href="/catalog?f[creator_facet][]=Yates%2C+David%2C+1963-">Yates, David, 1963-</a> director'
+    ]
+
+    expect(citeproc_names(item.author)).to eq([
+      { "literal" => "Warner Bros. Pictures" },
+      { "literal" => "Heyday Films" },
+      { "literal" => "Warner Home Video (Firm)" }
+    ])
+  end
+
+  it "uses marc 7xx entries as fallback authors when indexed contributor fields are absent" do
+    marc_record = MARC::Record.new
+    marc_record.append(MARC::DataField.new("700", "1", " ", ["a", "Alpha, Ada"], ["e", "former owner"]))
+    marc_record.append(MARC::DataField.new("710", "2", " ", ["a", "Beta Research Group"], ["e", "sponsor"]))
+    marc_record.append(MARC::DataField.new("711", "2", " ", ["a", "Gamma Symposium"], ["d", "(2024 : Philadelphia, Pa.)"]))
+    marc_record.append(MARC::DataField.new("700", "1", " ", ["a", "Delta, Dom"], ["e", "honouree"]))
+
+    document = double(
+      "document",
+      id: "991012041239703811",
+      to_marc: marc_record
+    )
+    allow(document).to receive(:[]).with("title_with_subtitle_display").and_return(nil)
+    allow(document).to receive(:[]).with("title_with_subtitle_truncated_display").and_return(nil)
+    allow(document).to receive(:[]).with("title_statement_display").and_return(["Example title / Foo."])
+    allow(document).to receive(:[]).with("format").and_return(["Book"])
+    allow(document).to receive(:[]).with("creator_display").and_return([])
+    allow(document).to receive(:[]).with("creator").and_return(nil)
+    allow(document).to receive(:[]).with("contributor_display").and_return([])
+    allow(document).to receive(:[]).with("contributor").and_return(nil)
+    allow(document).to receive(:[]).with("pub_date_display").and_return(nil)
+    allow(document).to receive(:[]).with("pub_date").and_return(nil)
+    allow(document).to receive(:[]).with("date_copyright_display").and_return(nil)
+    allow(document).to receive(:[]).with("imprint_display").and_return(nil)
+    allow(document).to receive(:[]).with("imprint_prod_display").and_return(nil)
+    allow(document).to receive(:[]).with("imprint_dist_display").and_return(nil)
+    allow(document).to receive(:[]).with("imprint_man_display").and_return(nil)
+    allow(document).to receive(:[]).with("isbn_display").and_return(nil)
+    allow(document).to receive(:[]).with("issn_display").and_return(nil)
+
+    item = described_class.build(document)
+
+    expect(citeproc_names(item.author)).to eq([
+      { "family" => "Alpha", "given" => "Ada" },
+      { "literal" => "Beta Research Group" },
+      { "literal" => "Gamma Symposium" }
+    ])
   end
 end

--- a/spec/services/citeproc/name_extractor_spec.rb
+++ b/spec/services/citeproc/name_extractor_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "marc"
+
+RSpec.describe Citeproc::NameExtractor do
+  subject(:extractor) { described_class.new(document) }
+
+  let(:document) do
+    SolrDocument.new(
+      "id" => "991012041239703811",
+      "title_statement_display" => ["Example title / Foo."],
+      "creator_display" => ["Chen, Bor-Sen|author."],
+      "contributor_display" => ["Li, Zhengwei|author."],
+      "format" => ["Book"]
+    )
+  end
+
+  def entry_hashes(entries)
+    entries.map { |entry| { name: entry.name, relators: entry.relators } }
+  end
+
+  it "extracts pipe-delimited creator and contributor values" do
+    expect(entry_hashes(extractor.creator_entries)).to eq([
+      { name: "Chen, Bor-Sen", relators: ["author."] }
+    ])
+    expect(entry_hashes(extractor.contributor_entries)).to eq([
+      { name: "Li, Zhengwei", relators: ["author."] }
+    ])
+  end
+
+  it "extracts json values" do
+    document["creator_display"] = []
+    document["contributor_display"] = [
+      '{"relation":"","name":"Example, Avery","role":"author"}'
+    ]
+
+    expect(entry_hashes(extractor.contributor_entries)).to eq([
+      { name: "Example, Avery", relators: ["author"] }
+    ])
+  end
+
+  it "extracts html-rendered contributor values" do
+    document["creator_display"] = []
+    document["contributor_display"] = [
+      '<a href="/catalog?f[creator_facet][]=Yates%2C+David%2C+1963-">Yates, David, 1963-</a> director'
+    ]
+
+    expect(entry_hashes(extractor.contributor_entries)).to eq([
+      { name: "Yates, David, 1963-", relators: ["director"] }
+    ])
+  end
+
+  it "falls back to semantic contributor values when display fields are absent" do
+    document = SolrDocument.new(
+      "id" => "991012041239703811",
+      "title_statement_display" => ["Example title / Foo."],
+      "creator" => [],
+      "contributor" => ["Alpha, Ada", "Beta, Ben"],
+      "format" => ["Book"]
+    )
+
+    extractor = described_class.new(document)
+
+    expect(entry_hashes(extractor.contributor_entries)).to eq([
+      { name: "Alpha, Ada", relators: [] },
+      { name: "Beta, Ben", relators: [] }
+    ])
+  end
+
+  it "falls back to marc 7xx values when indexed contributor fields are absent" do
+    marc_record = MARC::Record.new
+    marc_record.append(MARC::DataField.new("700", "1", " ", ["a", "Alpha, Ada"], ["e", "former owner"]))
+    marc_record.append(MARC::DataField.new("710", "2", " ", ["a", "Beta Research Group"], ["e", "sponsor"]))
+
+    document = double(
+      "document",
+      id: "991012041239703811",
+      to_marc: marc_record
+    )
+    allow(document).to receive(:[]).with("creator_display").and_return([])
+    allow(document).to receive(:[]).with("creator").and_return(nil)
+    allow(document).to receive(:[]).with("contributor_display").and_return([])
+    allow(document).to receive(:[]).with("contributor").and_return(nil)
+
+    extractor = described_class.new(document)
+
+    expect(entry_hashes(extractor.fallback_contributor_entries)).to eq([
+      { name: "Alpha, Ada", relators: [] },
+      { name: "Beta Research Group", relators: [] }
+    ])
+  end
+end


### PR DESCRIPTION
Refactor citeproc name extraction and add fallback author handling for records without 1xx creators. Normalize contributor inputs from raw indexed values, rendered HTML, semantic fields, and MARC 7xx data, then use the first three contributors as citation authors when no primary creator is present.